### PR TITLE
Remove msg.sender from inclusion in the tokenHash generation

### DIFF
--- a/contracts/GenArt721CoreV2.sol
+++ b/contracts/GenArt721CoreV2.sol
@@ -119,7 +119,7 @@ contract GenArt721CoreV2 is CustomERC721Metadata {
 
         projects[_projectId].invocations = projects[_projectId].invocations.add(1);
 
-        bytes32 hash = keccak256(abi.encodePacked(projects[_projectId].invocations, block.number, blockhash(block.number - 1), msg.sender, randomizerContract.returnValue()));
+        bytes32 hash = keccak256(abi.encodePacked(projects[_projectId].invocations, block.number, blockhash(block.number - 1), randomizerContract.returnValue()));
         tokenIdToHash[tokenIdToBe]=hash;
         hashToTokenId[hash] = tokenIdToBe;
 

--- a/contracts/GenArt721CoreV2_PBAB.sol
+++ b/contracts/GenArt721CoreV2_PBAB.sol
@@ -118,7 +118,7 @@ contract GenArt721CoreV2_PBAB is CustomERC721Metadata {
 
         projects[_projectId].invocations = projects[_projectId].invocations.add(1);
 
-        bytes32 hash = keccak256(abi.encodePacked(projects[_projectId].invocations, block.number, blockhash(block.number - 1), msg.sender, randomizerContract.returnValue()));
+        bytes32 hash = keccak256(abi.encodePacked(projects[_projectId].invocations, block.number, blockhash(block.number - 1), randomizerContract.returnValue()));
         tokenIdToHash[tokenIdToBe]=hash;
         hashToTokenId[hash] = tokenIdToBe;
 

--- a/contracts/PBAB/doodle-labs/GenArt721CoreV2_DoodleLabs.sol
+++ b/contracts/PBAB/doodle-labs/GenArt721CoreV2_DoodleLabs.sol
@@ -118,7 +118,7 @@ contract GenArt721CoreV2_DoodleLabs is CustomERC721Metadata {
 
         projects[_projectId].invocations = projects[_projectId].invocations.add(1);
 
-        bytes32 hash = keccak256(abi.encodePacked(projects[_projectId].invocations, block.number, blockhash(block.number - 1), msg.sender, randomizerContract.returnValue()));
+        bytes32 hash = keccak256(abi.encodePacked(projects[_projectId].invocations, block.number, blockhash(block.number - 1), randomizerContract.returnValue()));
         tokenIdToHash[tokenIdToBe]=hash;
         hashToTokenId[hash] = tokenIdToBe;
 

--- a/contracts/PBAB/flutter/GenArt721CoreV2_Flutter.sol
+++ b/contracts/PBAB/flutter/GenArt721CoreV2_Flutter.sol
@@ -118,7 +118,7 @@ contract GenArt721CoreV2_Flutter is CustomERC721Metadata {
 
         projects[_projectId].invocations = projects[_projectId].invocations.add(1);
 
-        bytes32 hash = keccak256(abi.encodePacked(projects[_projectId].invocations, block.number, blockhash(block.number - 1), msg.sender, randomizerContract.returnValue()));
+        bytes32 hash = keccak256(abi.encodePacked(projects[_projectId].invocations, block.number, blockhash(block.number - 1), randomizerContract.returnValue()));
         tokenIdToHash[tokenIdToBe]=hash;
         hashToTokenId[hash] = tokenIdToBe;
 


### PR DESCRIPTION
This PR removes inclusion of `msg.sender` in the token hash generation from the 4 actively maintained/developed GenArt721Core contracts (PBAB template and working copy of AB contract, as well as the two to-be-mainnet-deployed PBAB contracts for Doodle Labs and Flutter).

This is important to reduce the number of "lines one can fish with" (per the Fishing Game in #30) and closes #29 (which elaborates on this issue in greater depth).