### PR TITLE
add documentation for royalty overrides in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,18 +41,27 @@ Documenation for contracts may be generated via `yarn docgen`. Some Art Blocks c
 ## Royalty Registry Overrides
 Art Blocks supports lookups of all mainnet flagship and PBAB tokens on the [Royalty Registry](https://royaltyregistry.xyz/lookup).[^1]
 
-Two royalty override contracts are [to be[^1]] deployed for all flagship and PBAB GenArt721Core contracts.
-These contracts delegate all permissions to the core contracts, but require some configuring for newly deployed token contracts.
+The following Royalty Registry override contracts are [to be[^1]] deployed:
 
-### Configuring PBAB Royalty Override 
+- **mainnet:**
+  - PBAB royalty override: <0xTBD [^1]>
+  - AB Flagship royalty override: <0xTBD [^1]>
+- **ropsten:**
+  - PBAB royalty override: <0xTBD [^1]>
+  - AB Flagship royalty override: <0xTBD [^1]>
+
+
+These contracts delegate all permissions to the core contracts.
+
+### Configuring PBAB Royalty Override (REQUIRED)
 Upon deploying a PBAB contract, the following steps must be taken:
 >Tasks denoted by (scripted) are included in `scripts/1_reference_pbab_suite_deployer.ts`[^1]
 
-- **(scripted), Required** Set the royalty lookup address on the royalty registry for the newly deployed contract
+- **(scripted), REQUIRED** Set the royalty lookup address on the royalty registry for the newly deployed contract
   - Go to the [Royalty Registry](https://royaltyregistry.xyz/lookup) and call the following function on the Royalty Registry smart contract:
     - `setRoyaltyLookupAddress(<new_PBAB_coreAddr>, <PBAB_royaltyOverrideContract>)`
     >note: `PBAB_royaltyOverrideContract` will be known after [^1]
-- **(scripted), Required** Set Platform royalty payment address for the new core contract in PBAB royalty override contract
+- **(scripted), REQUIRED** Set Platform royalty payment address for the new core contract in PBAB royalty override contract
     >note: This step is optional in the PBAB deployer script in case platform royalty payment address is not known at time of deployment, but must be completed before royalty lookups will work
   - `admin` of the PBAB core contract must call the following function on the PBAB royalty override contract:
     - `updatePlatformRoyaltyAddressForContract(<new_PBAB_coreAddr>, <platformRoyaltyPaymentAddress>)`
@@ -65,14 +74,14 @@ Additionally, the following settings may be configured/changed by a PBAB core co
 - **Change Render Provider Royalty Payment Address**
     - The address to receive render provider royalty payments is delegated to the token core contract, and defined as the public variable `renderProviderAddress`.
 
-### Configuring Art Blocks Flagship Royalty Override
-Upon deploying a new Art Blocks flagship core contract, the following steps must be taken (not scripted/automated):
+### Configuring Art Blocks Flagship Royalty Override  (REQUIRED)
+Upon deploying a new Art Blocks flagship core contract, the following steps must be taken (NOT scripted):
 
-- **Required** Set the royalty lookup address on the royalty registry for the newly deployed contract
+- **REQUIRED** Set the royalty lookup address on the royalty registry for the newly deployed contract
   - Go to the [Royalty Registry](https://royaltyregistry.xyz/lookup) to call the following function on the Royalty Registry smart contract:
     - `setRoyaltyLookupAddress(<new_coreAddr>, <ArtBlocks_royaltyOverrideContract>)`
     >note: `ArtBlocks_royaltyOverrideContract` will be known after [^1]
-- **Required** Set Art Blocks royalty payment address for the new core contract in the royalty override contract
+- **REQUIRED** Set Art Blocks royalty payment address for the new core contract in the royalty override contract
   - `admin` of core contract must call:
     - `updateArtblocksRoyaltyAddressForContract(<new_coreAddr>, <ArtBlocksRoyaltyPaymentAddress>)`
 


### PR DESCRIPTION
closes #92 

I added to readme - let me know if you want to break-off into a separate md file. 

Some of this will read simpler once Manifold accepts our PR and we have the addresses of the override contracts.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201602847059704