### PR TITLE
prefer reset auction details event over setting to zeros

### DIFF
--- a/contracts/minter-suite/MinterDAExpV0.sol
+++ b/contracts/minter-suite/MinterDAExpV0.sol
@@ -24,6 +24,9 @@ contract MinterDAExpV0 is ReentrancyGuard, IFilteredMinterV0 {
         uint256 _basePrice
     );
 
+    /// Auction details cleared for project `projectId`.
+    event ResetAuctionDetails(uint256 indexed projectId);
+
     /// Maximum and minimum allowed price decay half lifes updated.
     event AuctionHalfLifeRangeSecondsUpdated(
         uint256 _minimumPriceDecayHalfLifeSeconds,
@@ -267,7 +270,7 @@ contract MinterDAExpV0 is ReentrancyGuard, IFilteredMinterV0 {
         onlyCoreWhitelisted
     {
         delete projectAuctionParameters[_projectId];
-        emit SetAuctionDetails(_projectId, 0, 0, 0, 0);
+        emit ResetAuctionDetails(_projectId);
     }
 
     /**

--- a/contracts/minter-suite/MinterDALinV0.sol
+++ b/contracts/minter-suite/MinterDALinV0.sol
@@ -24,6 +24,9 @@ contract MinterDALinV0 is ReentrancyGuard, IFilteredMinterV0 {
         uint256 _basePrice
     );
 
+    /// Auction details cleared for project `projectId`.
+    event ResetAuctionDetails(uint256 indexed projectId);
+
     /// Minimum allowed auction length updated
     event MinimumAuctionLengthSecondsUpdated(
         uint256 _minimumAuctionLengthSeconds
@@ -246,7 +249,7 @@ contract MinterDALinV0 is ReentrancyGuard, IFilteredMinterV0 {
         onlyCoreWhitelisted
     {
         delete projectAuctionParameters[_projectId];
-        emit SetAuctionDetails(_projectId, 0, 0, 0, 0);
+        emit ResetAuctionDetails(_projectId);
     }
 
     /**

--- a/test/MinterDAExpV0.test.ts
+++ b/test/MinterDAExpV0.test.ts
@@ -370,8 +370,8 @@ describe("MinterDAExpV0", async function () {
           .connect(this.accounts.deployer)
           .resetAuctionDetails(projectOne)
       )
-        .to.emit(this.minter, "SetAuctionDetails")
-        .withArgs(projectOne, 0, 0, 0, 0);
+        .to.emit(this.minter, "ResetAuctionDetails")
+        .withArgs(projectOne);
     });
 
     it("disallows artist to reset auction details", async function () {

--- a/test/MinterDALinV0.test.ts
+++ b/test/MinterDALinV0.test.ts
@@ -379,8 +379,8 @@ describe("GenArt721MinterEthAuction", async function () {
           .connect(this.accounts.deployer)
           .resetAuctionDetails(projectOne)
       )
-        .to.emit(this.minter, "SetAuctionDetails")
-        .withArgs(projectOne, 0, 0, 0, 0);
+        .to.emit(this.minter, "ResetAuctionDetails")
+        .withArgs(projectOne);
     });
 
     it("disallows artist to reset auction details", async function () {


### PR DESCRIPTION
nit - prefer a reset auction details event - more straightforward when writing subgraph handlers instead of using logic such as `if args 1,2,3,4 == 0 then set to null`