### PR TITLE
Update minter math to multiply-before-dividing

### DIFF
--- a/contracts/PBAB/GenArt721Minter_PBAB.sol
+++ b/contracts/PBAB/GenArt721Minter_PBAB.sol
@@ -313,8 +313,8 @@ contract GenArt721Minter_PBAB is ReentrancyGuard {
                 (bool success_, ) = msg.sender.call{value: refund}("");
                 require(success_, "Refund failed");
             }
-            uint256 renderProviderAmount = (pricePerTokenInWei / 100) *
-                genArtCoreContract.renderProviderPercentage();
+            uint256 renderProviderAmount = (pricePerTokenInWei *
+                genArtCoreContract.renderProviderPercentage()) / 100;
             if (renderProviderAmount > 0) {
                 (bool success_, ) = genArtCoreContract
                     .renderProviderAddress()
@@ -324,7 +324,7 @@ contract GenArt721Minter_PBAB is ReentrancyGuard {
 
             uint256 remainingFunds = pricePerTokenInWei - renderProviderAmount;
 
-            uint256 ownerFunds = (remainingFunds / 100) * ownerPercentage;
+            uint256 ownerFunds = (remainingFunds * ownerPercentage) / 100;
             if (ownerFunds > 0) {
                 (bool success_, ) = ownerAddress.call{value: ownerFunds}("");
                 require(success_, "Owner payment failed");
@@ -340,10 +340,11 @@ contract GenArt721Minter_PBAB is ReentrancyGuard {
                 ) > 0
             ) {
                 additionalPayeeAmount =
-                    (projectFunds / 100) *
-                    genArtCoreContract.projectIdToAdditionalPayeePercentage(
-                        _projectId
-                    );
+                    (projectFunds *
+                        genArtCoreContract.projectIdToAdditionalPayeePercentage(
+                            _projectId
+                        )) /
+                    100;
                 if (additionalPayeeAmount > 0) {
                     (bool success_, ) = genArtCoreContract
                         .projectIdToAdditionalPayee(_projectId)
@@ -369,8 +370,8 @@ contract GenArt721Minter_PBAB is ReentrancyGuard {
     function _splitFundsERC20(uint256 _projectId) internal {
         uint256 pricePerTokenInWei = genArtCoreContract
             .projectIdToPricePerTokenInWei(_projectId);
-        uint256 renderProviderAmount = (pricePerTokenInWei / 100) *
-            genArtCoreContract.renderProviderPercentage();
+        uint256 renderProviderAmount = (pricePerTokenInWei *
+            genArtCoreContract.renderProviderPercentage()) / 100;
         if (renderProviderAmount > 0) {
             IERC20(genArtCoreContract.projectIdToCurrencyAddress(_projectId))
                 .transferFrom(
@@ -381,7 +382,7 @@ contract GenArt721Minter_PBAB is ReentrancyGuard {
         }
         uint256 remainingFunds = pricePerTokenInWei - renderProviderAmount;
 
-        uint256 ownerFunds = (remainingFunds / 100) * ownerPercentage;
+        uint256 ownerFunds = (remainingFunds * ownerPercentage) / 100;
         if (ownerFunds > 0) {
             IERC20(genArtCoreContract.projectIdToCurrencyAddress(_projectId))
                 .transferFrom(msg.sender, ownerAddress, ownerFunds);
@@ -397,10 +398,11 @@ contract GenArt721Minter_PBAB is ReentrancyGuard {
             ) > 0
         ) {
             additionalPayeeAmount =
-                (projectFunds / 100) *
-                genArtCoreContract.projectIdToAdditionalPayeePercentage(
-                    _projectId
-                );
+                (projectFunds *
+                    genArtCoreContract.projectIdToAdditionalPayeePercentage(
+                        _projectId
+                    )) /
+                100;
             if (additionalPayeeAmount > 0) {
                 IERC20(
                     genArtCoreContract.projectIdToCurrencyAddress(_projectId)

--- a/contracts/minter-suite/MinterDAExpV0.sol
+++ b/contracts/minter-suite/MinterDAExpV0.sol
@@ -373,8 +373,8 @@ contract MinterDAExpV0 is ReentrancyGuard, IFilteredMinterV0 {
                 (bool success_, ) = msg.sender.call{value: refund}("");
                 require(success_, "Refund failed");
             }
-            uint256 foundationAmount = (_currentPriceInWei / 100) *
-                genArtCoreContract.artblocksPercentage();
+            uint256 foundationAmount = (_currentPriceInWei *
+                genArtCoreContract.artblocksPercentage()) / 100;
             if (foundationAmount > 0) {
                 (bool success_, ) = genArtCoreContract.artblocksAddress().call{
                     value: foundationAmount
@@ -389,10 +389,11 @@ contract MinterDAExpV0 is ReentrancyGuard, IFilteredMinterV0 {
                 ) > 0
             ) {
                 additionalPayeeAmount =
-                    (projectFunds / 100) *
-                    genArtCoreContract.projectIdToAdditionalPayeePercentage(
-                        _projectId
-                    );
+                    (projectFunds *
+                        genArtCoreContract.projectIdToAdditionalPayeePercentage(
+                            _projectId
+                        )) /
+                    100;
                 if (additionalPayeeAmount > 0) {
                     (bool success_, ) = genArtCoreContract
                         .projectIdToAdditionalPayee(_projectId)

--- a/contracts/minter-suite/MinterDALinV0.sol
+++ b/contracts/minter-suite/MinterDALinV0.sol
@@ -353,8 +353,8 @@ contract MinterDALinV0 is ReentrancyGuard, IFilteredMinterV0 {
                 (bool success_, ) = msg.sender.call{value: refund}("");
                 require(success_, "Refund failed");
             }
-            uint256 foundationAmount = (_currentPriceInWei / 100) *
-                genArtCoreContract.artblocksPercentage();
+            uint256 foundationAmount = (_currentPriceInWei *
+                genArtCoreContract.artblocksPercentage()) / 100;
             if (foundationAmount > 0) {
                 (bool success_, ) = genArtCoreContract.artblocksAddress().call{
                     value: foundationAmount
@@ -369,10 +369,11 @@ contract MinterDALinV0 is ReentrancyGuard, IFilteredMinterV0 {
                 ) > 0
             ) {
                 additionalPayeeAmount =
-                    (projectFunds / 100) *
-                    genArtCoreContract.projectIdToAdditionalPayeePercentage(
-                        _projectId
-                    );
+                    (projectFunds *
+                        genArtCoreContract.projectIdToAdditionalPayeePercentage(
+                            _projectId
+                        )) /
+                    100;
                 if (additionalPayeeAmount > 0) {
                     (bool success_, ) = genArtCoreContract
                         .projectIdToAdditionalPayee(_projectId)

--- a/contracts/minter-suite/MinterSetPriceERC20V0.sol
+++ b/contracts/minter-suite/MinterSetPriceERC20V0.sol
@@ -349,8 +349,8 @@ contract MinterSetPriceERC20V0 is ReentrancyGuard, IFilteredMinterV0 {
                 (bool success_, ) = msg.sender.call{value: refund}("");
                 require(success_, "Refund failed");
             }
-            uint256 foundationAmount = (pricePerTokenInWei / 100) *
-                genArtCoreContract.artblocksPercentage();
+            uint256 foundationAmount = (pricePerTokenInWei *
+                genArtCoreContract.artblocksPercentage()) / 100;
             if (foundationAmount > 0) {
                 (bool success_, ) = genArtCoreContract.artblocksAddress().call{
                     value: foundationAmount
@@ -365,10 +365,11 @@ contract MinterSetPriceERC20V0 is ReentrancyGuard, IFilteredMinterV0 {
                 ) > 0
             ) {
                 additionalPayeeAmount =
-                    (projectFunds / 100) *
-                    genArtCoreContract.projectIdToAdditionalPayeePercentage(
-                        _projectId
-                    );
+                    (projectFunds *
+                        genArtCoreContract.projectIdToAdditionalPayeePercentage(
+                            _projectId
+                        )) /
+                    100;
                 if (additionalPayeeAmount > 0) {
                     (bool success_, ) = genArtCoreContract
                         .projectIdToAdditionalPayee(_projectId)
@@ -392,8 +393,8 @@ contract MinterSetPriceERC20V0 is ReentrancyGuard, IFilteredMinterV0 {
      */
     function _splitFundsERC20(uint256 _projectId) internal {
         uint256 pricePerTokenInWei = projectIdToPricePerTokenInWei[_projectId];
-        uint256 foundationAmount = (pricePerTokenInWei / 100) *
-            genArtCoreContract.artblocksPercentage();
+        uint256 foundationAmount = (pricePerTokenInWei *
+            genArtCoreContract.artblocksPercentage()) / 100;
         if (foundationAmount > 0) {
             IERC20(projectIdToCurrencyAddress[_projectId]).transferFrom(
                 msg.sender,
@@ -409,10 +410,11 @@ contract MinterSetPriceERC20V0 is ReentrancyGuard, IFilteredMinterV0 {
             ) > 0
         ) {
             additionalPayeeAmount =
-                (projectFunds / 100) *
-                genArtCoreContract.projectIdToAdditionalPayeePercentage(
-                    _projectId
-                );
+                (projectFunds *
+                    genArtCoreContract.projectIdToAdditionalPayeePercentage(
+                        _projectId
+                    )) /
+                100;
             if (additionalPayeeAmount > 0) {
                 IERC20(projectIdToCurrencyAddress[_projectId]).transferFrom(
                     msg.sender,

--- a/contracts/minter-suite/MinterSetPriceV0.sol
+++ b/contracts/minter-suite/MinterSetPriceV0.sol
@@ -259,8 +259,8 @@ contract MinterSetPriceV0 is ReentrancyGuard, IFilteredMinterV0 {
                 (bool success_, ) = msg.sender.call{value: refund}("");
                 require(success_, "Refund failed");
             }
-            uint256 foundationAmount = (pricePerTokenInWei / 100) *
-                genArtCoreContract.artblocksPercentage();
+            uint256 foundationAmount = (pricePerTokenInWei *
+                genArtCoreContract.artblocksPercentage()) / 100;
             if (foundationAmount > 0) {
                 (bool success_, ) = genArtCoreContract.artblocksAddress().call{
                     value: foundationAmount
@@ -275,10 +275,11 @@ contract MinterSetPriceV0 is ReentrancyGuard, IFilteredMinterV0 {
                 ) > 0
             ) {
                 additionalPayeeAmount =
-                    (projectFunds / 100) *
-                    genArtCoreContract.projectIdToAdditionalPayeePercentage(
-                        _projectId
-                    );
+                    (projectFunds *
+                        genArtCoreContract.projectIdToAdditionalPayeePercentage(
+                            _projectId
+                        )) /
+                    100;
                 if (additionalPayeeAmount > 0) {
                     (bool success_, ) = genArtCoreContract
                         .projectIdToAdditionalPayee(_projectId)


### PR DESCRIPTION
Always do multiplication before division for precision in the minter math. Addresses feedback in: https://app.asana.com/0/1201568815538912/1201752545292263/f 

cc @ryley-o @lyaunzbe @Jbern16 