### PR TITLE
Smol performance improvements to `mint` in V3 working draft

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -138,24 +138,24 @@ contract GenArt721CoreV3 is ERC721Enumerable, IGenArt721CoreContractV3 {
             "Must mint from the allowed minter contract."
         );
         require(
-            projects[_projectId].invocations + 1 <=
+            projects[_projectId].invocations <
                 projects[_projectId].maxInvocations,
             "Must not exceed max invocations"
         );
-        require(
-            projects[_projectId].active ||
-                _by == projectIdToArtistAddress[_projectId],
-            "Project must exist and be active"
-        );
-        require(
-            !projects[_projectId].paused ||
-                _by == projectIdToArtistAddress[_projectId],
-            "Purchases are paused."
-        );
+        // Only perform active + paused checks if minting from
+        // a wallet that **is not** the artist.
+        if (_by != projectIdToArtistAddress[_projectId]) {
+            require(
+                projects[_projectId].active,
+                "Project must exist and be active"
+            );
+            require(
+                !projects[_projectId].paused,
+                "Purchases are paused."
+            );         
+        }
 
-        uint256 tokenId = _mintToken(_to, _projectId);
-
-        return tokenId;
+        return _mintToken(_to, _projectId);
     }
 
     function _mintToken(address _to, uint256 _projectId)

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -142,15 +142,16 @@ contract GenArt721CoreV3 is ERC721Enumerable, IGenArt721CoreContractV3 {
                 projects[_projectId].maxInvocations,
             "Must not exceed max invocations"
         );
-        // Only perform active + paused checks if minting from
-        // a wallet that **is not** the artist.
-        if (_by != projectIdToArtistAddress[_projectId]) {
-            require(
-                projects[_projectId].active,
-                "Project must exist and be active"
-            );
-            require(!projects[_projectId].paused, "Purchases are paused.");
-        }
+        require(
+            projects[_projectId].active ||
+                _by == projectIdToArtistAddress[_projectId],
+            "Project must exist and be active"
+        );
+        require(
+            !projects[_projectId].paused ||
+                _by == projectIdToArtistAddress[_projectId],
+            "Purchases are paused."
+        );
 
         return _mintToken(_to, _projectId);
     }

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -149,10 +149,7 @@ contract GenArt721CoreV3 is ERC721Enumerable, IGenArt721CoreContractV3 {
                 projects[_projectId].active,
                 "Project must exist and be active"
             );
-            require(
-                !projects[_projectId].paused,
-                "Purchases are paused."
-            );         
+            require(!projects[_projectId].paused, "Purchases are paused.");
         }
 
         return _mintToken(_to, _projectId);


### PR DESCRIPTION
A couple minor logic optimizations we can make with `mint` for the V3 working draft, that I noticed while poking around at V1.