### PR TITLE
Tune `_mintToken` method

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -638,8 +638,8 @@ contract GenArt721CoreV3 is ERC721Enumerable, IGenArt721CoreContractV3 {
      * @notice Gets the project ID for a given `_tokenId`.
      */
     function tokenIdToProjectId(uint256 _tokenId)
-        public
-        view
+        external
+        pure
         returns (uint256 _projectId)
     {
         return _tokenId / ONE_MILLION;

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -635,6 +635,17 @@ contract GenArt721CoreV3 is ERC721Enumerable, IGenArt721CoreContractV3 {
         ];
         royaltyFeeByID = projectIdToSecondaryMarketRoyaltyPercentage[projectId];
     }
+    
+    /**
+     * @notice Gets the project ID for a given `_tokenId`.
+     */
+    function tokenIdToProjectId(uint256 _tokenId) 
+        public
+        view
+        returns (uint256 _projectId)
+    {
+        return _tokenId / ONE_MILLION
+    }
 
     /**
      * @notice Gets token URI for token ID `_tokenId`.

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -630,25 +630,13 @@ contract GenArt721CoreV3 is ERC721Enumerable, IGenArt721CoreContractV3 {
             uint256 royaltyFeeByID
         )
     {
-        uint256 projectId = tokenIdToProjectId(_tokenId);
+        uint256 projectId = _tokenId / ONE_MILLION;
         artistAddress = projectIdToArtistAddress[projectId];
         additionalPayee = projectIdToAdditionalPayee[projectId];
         additionalPayeePercentage = projectIdToAdditionalPayeePercentage[
             projectId
         ];
         royaltyFeeByID = projectIdToSecondaryMarketRoyaltyPercentage[projectId];
-    }
-
-    /**
-     * @notice Derives the `projectId` for a given `_tokenId`, for convenience
-     * purposes.
-     */
-    function tokenIdToProjectId(uint256 _tokenId)
-        public
-        view
-        returns (uint256 _projectId)
-    {
-        return _tokenId - (_tokenId % ONE_MILLION);
     }
 
     /**
@@ -664,7 +652,7 @@ contract GenArt721CoreV3 is ERC721Enumerable, IGenArt721CoreContractV3 {
         return
             string(
                 abi.encodePacked(
-                    projects[tokenIdToProjectId(_tokenId)].projectBaseURI,
+                    projects[_tokenId / ONE_MILLION].projectBaseURI,
                     Strings.toString(_tokenId)
                 )
             );

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -163,7 +163,7 @@ contract GenArt721CoreV3 is ERC721Enumerable, IGenArt721CoreContractV3 {
         uint256 nextTokenId = (_projectId * ONE_MILLION) +
             projects[_projectId].invocations;
 
-        projects[_projectId].invocations = projects[_projectId].invocations + 1;
+        projects[_projectId].invocations++;
 
         bytes32 tokenHash = keccak256(
             abi.encodePacked(

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -176,7 +176,7 @@ contract GenArt721CoreV3 is ERC721Enumerable, IGenArt721CoreContractV3 {
 
         // Do not need to also log `projectId` in event, as the `projectId` for
         // a given token can be derived from the `tokenId` with:
-        //   projectId = tokenId - (tokenId % 1_000_000)
+        //   projectId = tokenId / 1_000_000
         emit Mint(_to, nextTokenId);
 
         return nextTokenId;

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -179,7 +179,7 @@ contract GenArt721CoreV3 is ERC721Enumerable, IGenArt721CoreContractV3 {
         // Do not need to also log `projectId` in event, as the `projectId` for
         // a given token can be derived from the `tokenId` with:
         //   projectId = tokenId - (tokenId % 1_000_000)
-        emit MintToken(_to, nextTokenId);
+        emit Mint(_to, nextTokenId);
 
         return nextTokenId;
     }

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -633,16 +633,16 @@ contract GenArt721CoreV3 is ERC721Enumerable, IGenArt721CoreContractV3 {
         ];
         royaltyFeeByID = projectIdToSecondaryMarketRoyaltyPercentage[projectId];
     }
-    
+
     /**
      * @notice Gets the project ID for a given `_tokenId`.
      */
-    function tokenIdToProjectId(uint256 _tokenId) 
+    function tokenIdToProjectId(uint256 _tokenId)
         public
         view
         returns (uint256 _projectId)
     {
-        return _tokenId / ONE_MILLION
+        return _tokenId / ONE_MILLION;
     }
 
     /**

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -51,7 +51,6 @@ contract GenArt721CoreV3 is ERC721Enumerable, IGenArt721CoreContractV3 {
     uint256 public artblocksPercentage = 10;
 
     mapping(uint256 => bytes32) public tokenIdToHash;
-    mapping(bytes32 => uint256) public hashToTokenId;
 
     /// admin for contract
     address public admin;
@@ -168,14 +167,12 @@ contract GenArt721CoreV3 is ERC721Enumerable, IGenArt721CoreContractV3 {
         bytes32 tokenHash = keccak256(
             abi.encodePacked(
                 projects[_projectId].invocations,
-                block.number,
                 blockhash(block.number - 1),
                 randomizerContract.returnValue()
             )
         );
 
         tokenIdToHash[nextTokenId] = tokenHash;
-        hashToTokenId[tokenHash] = nextTokenId;
 
         _mint(_to, nextTokenId);
 

--- a/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
+++ b/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
@@ -5,13 +5,9 @@ pragma solidity ^0.8.0;
 
 interface IGenArt721CoreContractV3 {
     /**
-     * @notice Token ID `_tokenId` minted on project ID `_projectId` to `_to`.
+     * @notice Token ID `_tokenId` minted to `_to`.
      */
-    event Mint(
-        address indexed _to,
-        uint256 indexed _tokenId,
-        uint256 indexed _projectId
-    );
+    event MintToken(address indexed _to, uint256 indexed _tokenId);
 
     /**
      * @notice currentMinter updated to `_currentMinter`.

--- a/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
+++ b/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
@@ -7,7 +7,7 @@ interface IGenArt721CoreContractV3 {
     /**
      * @notice Token ID `_tokenId` minted to `_to`.
      */
-    event MintToken(address indexed _to, uint256 indexed _tokenId);
+    event Mint(address indexed _to, uint256 indexed _tokenId);
 
     /**
      * @notice currentMinter updated to `_currentMinter`.


### PR DESCRIPTION
Follow up from #194, this tunes `_mintToken` further, including removing the `tokenIdToProjectId` mapping entirely.