### PR TITLE
add new bulk add-remove holders of projects functionality

### DIFF
--- a/contracts/minter-suite/MinterHolderV0.sol
+++ b/contracts/minter-suite/MinterHolderV0.sol
@@ -232,6 +232,11 @@ contract MinterHolderV0 is ReentrancyGuard, IFilteredMinterHolderV0 {
      * allowlisted.
      * @param _ownedNFTProjectIdsAdd Project IDs on `_ownedNFTAddressesAdd`
      * whose holders shall be allowlisted to mint project `_projectId`.
+     * @param _ownedNFTAddressesRemove NFT core addresses of projects to be
+     * removed from allowlist.
+     * @param _ownedNFTProjectIdsRemove Project IDs on
+     * `_ownedNFTAddressesRemove` whose holders will be removed from allowlist
+     * to mint project `_projectId`.
      * @dev if a project is included in both add and remove arrays, it will be
      * removed.
      */

--- a/contracts/minter-suite/MinterHolderV0.sol
+++ b/contracts/minter-suite/MinterHolderV0.sol
@@ -166,7 +166,7 @@ contract MinterHolderV0 is ReentrancyGuard, IFilteredMinterHolderV0 {
      * @param _ownedNFTProjectIds Project IDs on `_ownedNFTAddresses` whose
      * holders shall be allowlisted to mint project `_projectId`.
      */
-    function allowHoldersOfProject(
+    function allowHoldersOfProjects(
         uint256 _projectId,
         address[] memory _ownedNFTAddresses,
         uint256[] memory _ownedNFTProjectIds
@@ -258,7 +258,7 @@ contract MinterHolderV0 is ReentrancyGuard, IFilteredMinterHolderV0 {
         address[] memory _ownedNFTAddressesRemove,
         uint256[] memory _ownedNFTProjectIdsRemove
     ) external onlyArtist(_projectId) {
-        allowHoldersOfProject(
+        allowHoldersOfProjects(
             _projectId,
             _ownedNFTAddressesAdd,
             _ownedNFTProjectIdsAdd

--- a/contracts/minter-suite/MinterHolderV0.sol
+++ b/contracts/minter-suite/MinterHolderV0.sol
@@ -32,16 +32,6 @@ contract MinterHolderV0 is ReentrancyGuard, IFilteredMinterHolderV0 {
     event UnregisteredNFTAddress(address indexed _NFTAddress);
 
     /**
-     * @notice Allow holders of NFTs at address `_ownedNFTAddress`, project ID
-     * `_ownedNFTProjectId` to mint on project `_projectId`.
-     */
-    event AllowHoldersOfProject(
-        uint256 indexed _projectId,
-        address _ownedNFTAddress,
-        uint256 _ownedNFTProjectId
-    );
-
-    /**
      * @notice Allow holders of NFTs at addresses `_ownedNFTAddresses`, project
      * IDs `_ownedNFTProjectIds` to mint on project `_projectId`.
      */
@@ -49,16 +39,6 @@ contract MinterHolderV0 is ReentrancyGuard, IFilteredMinterHolderV0 {
         uint256 indexed _projectId,
         address[] _ownedNFTAddresses,
         uint256[] _ownedNFTProjectIds
-    );
-
-    /**
-     * @notice Remove holders of NFTs at address `_ownedNFTAddress`, project ID
-     * `_ownedNFTProjectId` to mint on project `_projectId`.
-     */
-    event RemovedHoldersOfProject(
-        uint256 indexed _projectId,
-        address _ownedNFTAddress,
-        uint256 _ownedNFTProjectId
     );
 
     /**
@@ -198,10 +178,15 @@ contract MinterHolderV0 is ReentrancyGuard, IFilteredMinterHolderV0 {
         allowedProjectHolders[_projectId][_ownedNFTAddress][
             _ownedNFTProjectId
         ] = true;
-        emit AllowHoldersOfProject(
+        // convert to arrays and emit event
+        address[] memory _ownedNFTAddresses = new address[](1);
+        _ownedNFTAddresses[0] = _ownedNFTAddress;
+        uint256[] memory _ownedNFTProjectIds = new uint256[](1);
+        _ownedNFTProjectIds[0] = _ownedNFTProjectId;
+        emit AllowHoldersOfProjects(
             _projectId,
-            _ownedNFTAddress,
-            _ownedNFTProjectId
+            _ownedNFTAddresses,
+            _ownedNFTProjectIds
         );
     }
 
@@ -294,10 +279,15 @@ contract MinterHolderV0 is ReentrancyGuard, IFilteredMinterHolderV0 {
         allowedProjectHolders[_projectId][_ownedNFTAddress][
             _ownedNFTProjectId
         ] = false;
-        emit RemovedHoldersOfProject(
+        // convert to arrays and emit event
+        address[] memory _ownedNFTAddresses = new address[](1);
+        _ownedNFTAddresses[0] = _ownedNFTAddress;
+        uint256[] memory _ownedNFTProjectIds = new uint256[](1);
+        _ownedNFTProjectIds[0] = _ownedNFTProjectId;
+        emit RemovedHoldersOfProjects(
             _projectId,
-            _ownedNFTAddress,
-            _ownedNFTProjectId
+            _ownedNFTAddresses,
+            _ownedNFTProjectIds
         );
     }
 

--- a/contracts/minter-suite/MinterHolderV0.sol
+++ b/contracts/minter-suite/MinterHolderV0.sol
@@ -20,13 +20,13 @@ pragma solidity 0.8.9;
  */
 contract MinterHolderV0 is ReentrancyGuard, IFilteredMinterHolderV0 {
     /**
-     * @notice Allowlisted holders of NFTs at address `_NFTAddress` to be
+     * @notice Registered holders of NFTs at address `_NFTAddress` to be
      * considered for minting.
      */
     event RegisteredNFTAddress(address indexed _NFTAddress);
 
     /**
-     * @notice Removed holders of NFTs at address `_NFTAddress` to be
+     * @notice Unregistered holders of NFTs at address `_NFTAddress` to be
      * considered for minting.
      */
     event UnregisteredNFTAddress(address indexed _NFTAddress);
@@ -34,6 +34,9 @@ contract MinterHolderV0 is ReentrancyGuard, IFilteredMinterHolderV0 {
     /**
      * @notice Allow holders of NFTs at addresses `_ownedNFTAddresses`, project
      * IDs `_ownedNFTProjectIds` to mint on project `_projectId`.
+     * `_ownedNFTAddresses` assumed to be aligned with `_ownedNFTProjectIds`.
+     * e.g. Allows holders of project `_ownedNFTProjectIds[0]` on token
+     * contract `_ownedNFTAddresses[0]` to mint.
      */
     event AllowedHoldersOfProjects(
         uint256 indexed _projectId,
@@ -44,6 +47,9 @@ contract MinterHolderV0 is ReentrancyGuard, IFilteredMinterHolderV0 {
     /**
      * @notice Remove holders of NFTs at addresses `_ownedNFTAddresses`,
      * project IDs `_ownedNFTProjectIds` to mint on project `_projectId`.
+     * `_ownedNFTAddresses` assumed to be aligned with `_ownedNFTProjectIds`.
+     * e.g. Removes holders of project `_ownedNFTProjectIds[0]` on token
+     * contract `_ownedNFTAddresses[0]` from mint allowlist.
      */
     event RemovedHoldersOfProjects(
         uint256 indexed _projectId,
@@ -160,11 +166,15 @@ contract MinterHolderV0 is ReentrancyGuard, IFilteredMinterHolderV0 {
     /**
      * @notice Allows holders of NFTs at addresses `_ownedNFTAddresses`,
      * project IDs `_ownedNFTProjectIds` to mint on project `_projectId`.
+     * `_ownedNFTAddresses` assumed to be aligned with `_ownedNFTProjectIds`.
+     * e.g. Allows holders of project `_ownedNFTProjectIds[0]` on token
+     * contract `_ownedNFTAddresses[0]` to mint `_projectId`.
      * @param _projectId Project ID to enable minting on.
      * @param _ownedNFTAddresses NFT core addresses of projects to be
-     * allowlisted.
+     * allowlisted. Indexes must align with `_ownedNFTProjectIds`.
      * @param _ownedNFTProjectIds Project IDs on `_ownedNFTAddresses` whose
-     * holders shall be allowlisted to mint project `_projectId`.
+     * holders shall be allowlisted to mint project `_projectId`. Indexes must
+     * align with `_ownedNFTAddresses`.
      */
     function allowHoldersOfProjects(
         uint256 _projectId,
@@ -201,11 +211,15 @@ contract MinterHolderV0 is ReentrancyGuard, IFilteredMinterHolderV0 {
      * project IDs `_ownedNFTProjectIds` to mint on project `_projectId`. If
      * other projects owned by a holder are still allowed to mint, holder will
      * maintain ability to purchase.
+     * `_ownedNFTAddresses` assumed to be aligned with `_ownedNFTProjectIds`.
+     * e.g. Removes holders of project `_ownedNFTProjectIds[0]` on token
+     * contract `_ownedNFTAddresses[0]` from mint allowlist of `_projectId`.
      * @param _projectId Project ID to enable minting on.
      * @param _ownedNFTAddresses NFT core addresses of projects to be removed
-     * from allowlist.
-     * @param _ownedNFTProjectIds Project IDs on `_ownedNFTAddresses` whose holders
-     * will be removed from allowlist to mint project `_projectId`.
+     * from allowlist. Indexes must align with `_ownedNFTProjectIds`.
+     * @param _ownedNFTProjectIds Project IDs on `_ownedNFTAddresses` whose
+     * holders will be removed from allowlist to mint project `_projectId`.
+     * Indexes must align with `_ownedNFTAddresses`.
      */
     function removeHoldersOfProjects(
         uint256 _projectId,
@@ -238,16 +252,25 @@ contract MinterHolderV0 is ReentrancyGuard, IFilteredMinterHolderV0 {
      * Also removes holders of NFTs at addresses `_ownedNFTAddressesRemove`,
      * project IDs `_ownedNFTProjectIdsRemove` from minting on project
      * `_projectId`.
+     * `_ownedNFTAddressesAdd` assumed to be aligned with
+     * `_ownedNFTProjectIdsAdd`.
+     * e.g. Allows holders of project `_ownedNFTProjectIdsAdd[0]` on token
+     * contract `_ownedNFTAddressesAdd[0]` to mint `_projectId`.
+     * `_ownedNFTAddressesRemove` also assumed to be aligned with
+     * `_ownedNFTProjectIdsRemove`.
      * @param _projectId Project ID to enable minting on.
      * @param _ownedNFTAddressesAdd NFT core addresses of projects to be
-     * allowlisted.
+     * allowlisted. Indexes must align with `_ownedNFTProjectIdsAdd`.
      * @param _ownedNFTProjectIdsAdd Project IDs on `_ownedNFTAddressesAdd`
-     * whose holders shall be allowlisted to mint project `_projectId`.
+     * whose holders shall be allowlisted to mint project `_projectId`. Indexes
+     * must align with `_ownedNFTAddressesAdd`.
      * @param _ownedNFTAddressesRemove NFT core addresses of projects to be
-     * removed from allowlist.
+     * removed from allowlist. Indexes must align with
+     * `_ownedNFTProjectIdsRemove`.
      * @param _ownedNFTProjectIdsRemove Project IDs on
      * `_ownedNFTAddressesRemove` whose holders will be removed from allowlist
-     * to mint project `_projectId`.
+     * to mint project `_projectId`. Indexes must align with
+     * `_ownedNFTAddressesRemove`.
      * @dev if a project is included in both add and remove arrays, it will be
      * removed.
      */

--- a/contracts/minter-suite/MinterHolderV0.sol
+++ b/contracts/minter-suite/MinterHolderV0.sol
@@ -191,6 +191,37 @@ contract MinterHolderV0 is ReentrancyGuard, IFilteredMinterHolderV0 {
     }
 
     /**
+     * @notice Removes holders of NFTs at address `_ownedNFTAddress`, project
+     * ID `_ownedNFTProjectId` to mint on project `_projectId`. If other
+     * projects owned by a holder are still allowed to mint, holder will
+     * maintain ability to purchase.
+     * @param _projectId Project ID to enable minting on.
+     * @param _ownedNFTAddress NFT core address of project to be removed from
+     * allowlist.
+     * @param _ownedNFTProjectId Project ID on `_ownedNFTAddress` whose holders
+     * will be removed from allowlist to mint project `_projectId`.
+     */
+    function removeHoldersOfProject(
+        uint256 _projectId,
+        address _ownedNFTAddress,
+        uint256 _ownedNFTProjectId
+    ) external onlyArtist(_projectId) {
+        allowedProjectHolders[_projectId][_ownedNFTAddress][
+            _ownedNFTProjectId
+        ] = false;
+        // convert to arrays and emit event
+        address[] memory _ownedNFTAddresses = new address[](1);
+        _ownedNFTAddresses[0] = _ownedNFTAddress;
+        uint256[] memory _ownedNFTProjectIds = new uint256[](1);
+        _ownedNFTProjectIds[0] = _ownedNFTProjectId;
+        emit RemovedHoldersOfProjects(
+            _projectId,
+            _ownedNFTAddresses,
+            _ownedNFTProjectIds
+        );
+    }
+
+    /**
      * @notice Allows holders of NFTs at addresses `_ownedNFTAddressesAdd`,
      * project IDs `_ownedNFTProjectIdsAdd` to mint on project `_projectId`.
      * Also removes holders of NFTs at addresses `_ownedNFTAddressesRemove`,
@@ -258,37 +289,6 @@ contract MinterHolderV0 is ReentrancyGuard, IFilteredMinterHolderV0 {
                 _ownedNFTProjectIdsRemove
             );
         }
-    }
-
-    /**
-     * @notice Removes holders of NFTs at address `_ownedNFTAddress`, project
-     * ID `_ownedNFTProjectId` to mint on project `_projectId`. If other
-     * projects owned by a holder are still allowed to mint, holder will
-     * maintain ability to purchase.
-     * @param _projectId Project ID to enable minting on.
-     * @param _ownedNFTAddress NFT core address of project to be removed from
-     * allowlist.
-     * @param _ownedNFTProjectId Project ID on `_ownedNFTAddress` whose holders
-     * will be removed from allowlist to mint project `_projectId`.
-     */
-    function removeHoldersOfProject(
-        uint256 _projectId,
-        address _ownedNFTAddress,
-        uint256 _ownedNFTProjectId
-    ) external onlyArtist(_projectId) {
-        allowedProjectHolders[_projectId][_ownedNFTAddress][
-            _ownedNFTProjectId
-        ] = false;
-        // convert to arrays and emit event
-        address[] memory _ownedNFTAddresses = new address[](1);
-        _ownedNFTAddresses[0] = _ownedNFTAddress;
-        uint256[] memory _ownedNFTProjectIds = new uint256[](1);
-        _ownedNFTProjectIds[0] = _ownedNFTProjectId;
-        emit RemovedHoldersOfProjects(
-            _projectId,
-            _ownedNFTAddresses,
-            _ownedNFTProjectIds
-        );
     }
 
     /**

--- a/test/MinterHolderV0.test.ts
+++ b/test/MinterHolderV0.test.ts
@@ -7,12 +7,17 @@ import {
   ether,
 } from "@openzeppelin/test-helpers";
 import { expect } from "chai";
-import { BigNumber } from "ethers";
+import { BigNumber, Contract } from "ethers";
 import { ethers } from "hardhat";
 import EthersAdapter from "@gnosis.pm/safe-ethers-lib";
 import Safe from "@gnosis.pm/safe-core-sdk";
 import { SafeTransactionDataPartial } from "@gnosis.pm/safe-core-sdk-types";
 import { getGnosisSafe } from "./util/GnosisSafeNetwork";
+
+type T_PBAB = {
+  pbabToken: Contract;
+  pbabMinter: Contract;
+};
 
 /**
  * These tests intended to ensure Filtered Minter integrates properly with V1
@@ -42,6 +47,35 @@ describe("MinterHolderV0", async function () {
   let merkleTreeZero;
   let merkleTreeOne;
   let merkleTreeTwo;
+
+  async function deployAndGetPBAB(): Promise<T_PBAB> {
+    const PBABFactory = await ethers.getContractFactory("GenArt721CoreV2_PBAB");
+    const pbabToken = await PBABFactory.connect(this.accounts.deployer).deploy(
+      name,
+      symbol,
+      this.randomizer.address
+    );
+    const minterFactory = await ethers.getContractFactory(
+      "GenArt721Minter_PBAB"
+    );
+    const pbabMinter = await minterFactory.deploy(pbabToken.address);
+    await pbabToken
+      .connect(this.accounts.deployer)
+      .addProject(
+        "project0_PBAB",
+        this.accounts.artist.address,
+        pricePerTokenInWei
+      );
+    await pbabToken.connect(this.accounts.deployer).toggleProjectIsActive(0);
+    await pbabToken
+      .connect(this.accounts.deployer)
+      .addMintWhitelisted(pbabMinter.address);
+    await pbabToken
+      .connect(this.accounts.artist)
+      .updateProjectMaxInvocations(0, projectMaxInvocations);
+    await pbabToken.connect(this.accounts.artist).toggleProjectIsPaused(0);
+    return { pbabToken, pbabMinter };
+  }
 
   beforeEach(async function () {
     const [owner, newOwner, artist, additional, deployer] =
@@ -334,6 +368,32 @@ describe("MinterHolderV0", async function () {
           [this.token.address, this.token.address],
           [projectOne, projectTwo]
         );
+    });
+
+    it("does not allow allowlisting a project on an unregistered contract", async function () {
+      // deploy different contract (for this case, use PBAB contract)
+      const { pbabToken, pbabMinter } = await deployAndGetPBAB.bind(this)();
+      await pbabMinter
+        .connect(this.accounts.artist)
+        .purchaseTo(this.accounts.additional.address, 0, {
+          value: pricePerTokenInWei,
+        });
+
+      // set token price for projects zero and one on our minter
+      await this.token
+        .connect(this.accounts.artist)
+        .updateProjectPricePerTokenInWei(projectZero, pricePerTokenInWei);
+      // allow holders of PBAB project 0 to purchase tokens on projectTwo
+      await expectRevert(
+        this.minter
+          .connect(this.accounts.artist)
+          .allowHoldersOfProjects(
+            projectTwo,
+            [pbabToken.address],
+            [projectZero]
+          ),
+        "Only Registered NFT Addresses"
+      );
     });
   });
 
@@ -739,6 +799,80 @@ describe("MinterHolderV0", async function () {
           "Only owner of NFT"
         );
       });
+
+      it("does not allow purchase when using token of an unallowed project on a different contract", async function () {
+        const { pbabToken, pbabMinter } = await deployAndGetPBAB.bind(this)();
+        await pbabMinter
+          .connect(this.accounts.artist)
+          .purchaseTo(this.accounts.additional.address, 0, {
+            value: pricePerTokenInWei,
+          });
+
+        // set token price for projects zero and one on our minter
+        await this.token
+          .connect(this.accounts.artist)
+          .updateProjectPricePerTokenInWei(projectZero, pricePerTokenInWei);
+        // register the PBAB token on our minter
+        await this.minter
+          .connect(this.accounts.deployer)
+          .registerNFTAddress(pbabToken.address);
+        // configure price per token to be zero
+        await this.minter
+          .connect(this.accounts.artist)
+          .updatePricePerTokenInWei(projectTwo, 0);
+        // expect failure when using PBAB token because it is not allowlisted for projectTwo
+        await expectRevert(
+          this.minter
+            .connect(this.accounts.additional)
+            ["purchase(uint256,address,uint256)"](
+              projectTwo,
+              pbabToken.address,
+              0,
+              {
+                value: pricePerTokenInWei,
+              }
+            ),
+          "Only allowlisted NFTs"
+        );
+      });
+
+      it("does allow purchase when using token of allowed project on a different contract", async function () {
+        // deploy different contract (for this case, use PBAB contract)
+        const { pbabToken, pbabMinter } = await deployAndGetPBAB.bind(this)();
+        await pbabMinter
+          .connect(this.accounts.artist)
+          .purchaseTo(this.accounts.additional.address, 0, {
+            value: pricePerTokenInWei,
+          });
+
+        // set token price for projects zero and one on our minter
+        await this.token
+          .connect(this.accounts.artist)
+          .updateProjectPricePerTokenInWei(projectZero, pricePerTokenInWei);
+        // register the PBAB token on our minter
+        await this.minter
+          .connect(this.accounts.deployer)
+          .registerNFTAddress(pbabToken.address);
+        // allow holders of PBAB project 0 to purchase tokens on projectTwo
+        await this.minter
+          .connect(this.accounts.artist)
+          .allowHoldersOfProjects(projectTwo, [pbabToken.address], [0]);
+        // configure price per token to be zero
+        await this.minter
+          .connect(this.accounts.artist)
+          .updatePricePerTokenInWei(projectTwo, 0);
+        // does allow purchase when holder of token in PBAB projectZero is used as pass
+        await this.minter
+          .connect(this.accounts.additional)
+          ["purchase(uint256,address,uint256)"](
+            projectTwo,
+            pbabToken.address,
+            0,
+            {
+              value: pricePerTokenInWei,
+            }
+          );
+      });
     });
 
     it("does allow purchase with a price of zero when intentionally configured", async function () {
@@ -977,7 +1111,7 @@ describe("MinterHolderV0", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0319919"));
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0319931"));
     });
   });
 

--- a/test/MinterHolderV0.test.ts
+++ b/test/MinterHolderV0.test.ts
@@ -977,7 +977,7 @@ describe("MinterHolderV0", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0319931"));
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0319919"));
     });
   });
 

--- a/test/MinterHolderV0.test.ts
+++ b/test/MinterHolderV0.test.ts
@@ -168,7 +168,7 @@ describe("MinterHolderV0", async function () {
       .registerNFTAddress(this.token.address);
     await this.minter
       .connect(this.accounts.artist)
-      .allowHoldersOfProject(projectZero, this.token.address, projectZero);
+      .allowHoldersOfProjects(projectZero, [this.token.address], [projectZero]);
   });
 
   describe("constructor", async function () {
@@ -270,36 +270,52 @@ describe("MinterHolderV0", async function () {
     });
   });
 
-  describe("allowHoldersOfProject", async function () {
+  describe("allowHoldersOfProjects", async function () {
     it("only allows artist to update allowed holders", async function () {
       // owner not allowed
       await expectRevert(
         this.minter
           .connect(this.accounts.owner)
-          .allowHoldersOfProject(projectZero, this.token.address, projectOne),
+          .allowHoldersOfProjects(
+            projectZero,
+            [this.token.address],
+            [projectOne]
+          ),
         "Only Artist"
       );
       // additional not allowed
       await expectRevert(
         this.minter
           .connect(this.accounts.additional)
-          .allowHoldersOfProject(projectZero, this.token.address, projectOne),
+          .allowHoldersOfProjects(
+            projectZero,
+            [this.token.address],
+            [projectOne]
+          ),
         "Only Artist"
       );
       // artist allowed
       await this.minter
         .connect(this.accounts.artist)
-        .allowHoldersOfProject(projectZero, this.token.address, projectOne);
+        .allowHoldersOfProjects(
+          projectZero,
+          [this.token.address],
+          [projectOne]
+        );
     });
 
     it("emits event when update allowed holders", async function () {
       await expect(
         this.minter
           .connect(this.accounts.artist)
-          .allowHoldersOfProject(projectZero, this.token.address, projectOne)
+          .allowHoldersOfProjects(
+            projectZero,
+            [this.token.address],
+            [projectOne]
+          )
       )
-        .to.emit(this.minter, "AllowHoldersOfProject")
-        .withArgs(projectZero, this.token.address, projectOne);
+        .to.emit(this.minter, "AllowedHoldersOfProjects")
+        .withArgs(projectZero, [this.token.address], [projectOne]);
     });
   });
 
@@ -309,30 +325,46 @@ describe("MinterHolderV0", async function () {
       await expectRevert(
         this.minter
           .connect(this.accounts.owner)
-          .removeHoldersOfProject(projectZero, this.token.address, projectOne),
+          .removeHoldersOfProjects(
+            projectZero,
+            [this.token.address],
+            [projectOne]
+          ),
         "Only Artist"
       );
       // additional not allowed
       await expectRevert(
         this.minter
           .connect(this.accounts.additional)
-          .removeHoldersOfProject(projectZero, this.token.address, projectOne),
+          .removeHoldersOfProjects(
+            projectZero,
+            [this.token.address],
+            [projectOne]
+          ),
         "Only Artist"
       );
       // artist allowed
       await this.minter
         .connect(this.accounts.artist)
-        .removeHoldersOfProject(projectZero, this.token.address, projectOne);
+        .removeHoldersOfProjects(
+          projectZero,
+          [this.token.address],
+          [projectOne]
+        );
     });
 
     it("emits event when removing allowed holders", async function () {
       await expect(
         this.minter
           .connect(this.accounts.artist)
-          .removeHoldersOfProject(projectZero, this.token.address, projectOne)
+          .removeHoldersOfProjects(
+            projectZero,
+            [this.token.address],
+            [projectOne]
+          )
       )
-        .to.emit(this.minter, "RemovedHoldersOfProject")
-        .withArgs(projectZero, this.token.address, projectOne);
+        .to.emit(this.minter, "RemovedHoldersOfProjects")
+        .withArgs(projectZero, [this.token.address], [projectOne]);
     });
   });
 
@@ -421,7 +453,7 @@ describe("MinterHolderV0", async function () {
       // allow holders of projectOne to purchase tokens on projectTwo
       await this.minter
         .connect(this.accounts.artist)
-        .allowHoldersOfProject(projectTwo, this.token.address, projectOne);
+        .allowHoldersOfProjects(projectTwo, [this.token.address], [projectOne]);
       // configure price per token to be zero
       await this.minter
         .connect(this.accounts.artist)
@@ -447,7 +479,11 @@ describe("MinterHolderV0", async function () {
       // allow holders of projectZero to purchase tokens on projectTwo
       await this.minter
         .connect(this.accounts.artist)
-        .allowHoldersOfProject(projectTwo, this.token.address, projectZero);
+        .allowHoldersOfProjects(
+          projectTwo,
+          [this.token.address],
+          [projectZero]
+        );
       // configure price per token to be zero
       await this.minter
         .connect(this.accounts.artist)
@@ -469,7 +505,11 @@ describe("MinterHolderV0", async function () {
       // allow holders of project zero to mint on project one
       await this.minter
         .connect(this.accounts.artist)
-        .allowHoldersOfProject(projectOne, this.token.address, projectZero);
+        .allowHoldersOfProjects(
+          projectOne,
+          [this.token.address],
+          [projectZero]
+        );
       for (let i = 0; i < projectMaxInvocations; i++) {
         await this.minter
           .connect(this.accounts.artist)
@@ -595,7 +635,11 @@ describe("MinterHolderV0", async function () {
       // Try with setProjectMaxInvocations, store gas cost
       await this.minter
         .connect(this.accounts.artist)
-        .allowHoldersOfProject(projectOne, this.token.address, projectZero);
+        .allowHoldersOfProjects(
+          projectOne,
+          [this.token.address],
+          [projectZero]
+        );
       await this.minter
         .connect(this.accounts.deployer)
         .setProjectMaxInvocations(projectOne);
@@ -667,7 +711,7 @@ describe("MinterHolderV0", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0319931"));
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0319919"));
     });
   });
 


### PR DESCRIPTION
## Change Summary
Update MinterHolderV0 functions/events to enable bulk add/remove of projects whose owners may purchase a given project.

updated/added tests for new functionality.

## Motivation
Enabling bulk add/remove of projects will enable a better artist UX. This update will allow an artist to configure which project token holders may mint their project in a single transaction instead of requiring a transaction for every project added/removed.

## other required changes
The Approved/Removed project events have been changed to use arrays for improved gas efficiency. A minor update to our subgraph will be a follow-on to this. No changes will be required to our subgraph schema - only the event handlers will require updating.

## alternatives considered
Opted to always use approve/remove arrays of projects in events and function inputs to eliminate redundant code in the smart contract. Functions that add/remove a single project are a subset of the new functions allowing one or more projects, and defining arrays when calling functions on etherscan is easy to do.