### PR TITLE
Update Merkle library to reduce gas

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -4,9 +4,9 @@
 import "./interfaces/0.8.x/IRandomizer.sol";
 import "./interfaces/0.8.x/IGenArt721CoreContractV3.sol";
 
-import "@openzeppelin/contracts/utils/Strings.sol";
+import "@openzeppelin-4.5/contracts/utils/Strings.sol";
 
-import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+import "@openzeppelin-4.5/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 
 pragma solidity 0.8.9;
 

--- a/contracts/PBAB+Collabs/GenArt721CoreV2_PBAB.sol
+++ b/contracts/PBAB+Collabs/GenArt721CoreV2_PBAB.sol
@@ -4,9 +4,9 @@
 import "../interfaces/0.8.x/IRandomizer.sol";
 import "../interfaces/0.8.x/IGenArt721CoreV2_PBAB.sol";
 
-import "@openzeppelin/contracts/utils/Strings.sol";
+import "@openzeppelin-4.5/contracts/utils/Strings.sol";
 
-import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+import "@openzeppelin-4.5/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 
 pragma solidity 0.8.9;
 

--- a/contracts/PBAB+Collabs/GenArt721CoreV2_PRTNR.sol
+++ b/contracts/PBAB+Collabs/GenArt721CoreV2_PRTNR.sol
@@ -5,9 +5,9 @@ import "../interfaces/0.8.x/IRandomizer.sol";
 import "../interfaces/0.8.x/IGenArt721CoreV2_PBAB.sol";
 import "../interfaces/0.8.x/IGenArt721CoreContractV1.sol";
 
-import "@openzeppelin/contracts/utils/Strings.sol";
+import "@openzeppelin-4.5/contracts/utils/Strings.sol";
 
-import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+import "@openzeppelin-4.5/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 
 pragma solidity 0.8.9;
 

--- a/contracts/PBAB+Collabs/GenArt721MinterBurner_PBAB.sol
+++ b/contracts/PBAB+Collabs/GenArt721MinterBurner_PBAB.sol
@@ -4,9 +4,9 @@
 import "../interfaces/0.8.x/IGenArt721CoreV2_PBAB.sol";
 import "../interfaces/0.8.x/IBonusContract.sol";
 
-import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
-import "@openzeppelin/contracts/utils/Strings.sol";
-import "@openzeppelin/contracts/interfaces/IERC20.sol";
+import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin-4.5/contracts/utils/Strings.sol";
+import "@openzeppelin-4.5/contracts/interfaces/IERC20.sol";
 
 pragma solidity 0.8.9;
 

--- a/contracts/PBAB+Collabs/GenArt721Minter_PBAB.sol
+++ b/contracts/PBAB+Collabs/GenArt721Minter_PBAB.sol
@@ -4,9 +4,9 @@
 import "../interfaces/0.8.x/IGenArt721CoreV2_PBAB.sol";
 import "../interfaces/0.8.x/IBonusContract.sol";
 
-import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
-import "@openzeppelin/contracts/utils/Strings.sol";
-import "@openzeppelin/contracts/interfaces/IERC20.sol";
+import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin-4.5/contracts/utils/Strings.sol";
+import "@openzeppelin-4.5/contracts/interfaces/IERC20.sol";
 
 pragma solidity 0.8.9;
 

--- a/contracts/PBAB+Collabs/art-blocks-x-pace/GenArt721CoreV2_ArtBlocksXPace.sol
+++ b/contracts/PBAB+Collabs/art-blocks-x-pace/GenArt721CoreV2_ArtBlocksXPace.sol
@@ -5,9 +5,9 @@ import "../../interfaces/0.8.x/IRandomizer.sol";
 import "../../interfaces/0.8.x/IGenArt721CoreV2_PBAB.sol";
 import "../../interfaces/0.8.x/IGenArt721CoreContractV1.sol";
 
-import "@openzeppelin/contracts/utils/Strings.sol";
+import "@openzeppelin-4.5/contracts/utils/Strings.sol";
 
-import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+import "@openzeppelin-4.5/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 
 pragma solidity 0.8.9;
 

--- a/contracts/PBAB+Collabs/colors-and-shapes/GenArt721CoreV2_ColorsAndShapes.sol
+++ b/contracts/PBAB+Collabs/colors-and-shapes/GenArt721CoreV2_ColorsAndShapes.sol
@@ -4,9 +4,9 @@
 import "../../interfaces/0.8.x/IRandomizer.sol";
 import "../../interfaces/0.8.x/IGenArt721CoreV2_PBAB.sol";
 
-import "@openzeppelin/contracts/utils/Strings.sol";
+import "@openzeppelin-4.5/contracts/utils/Strings.sol";
 
-import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+import "@openzeppelin-4.5/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 
 pragma solidity 0.8.9;
 

--- a/contracts/PBAB+Collabs/colors-and-shapes/GenArt721Minter_ColorsAndShapes.sol
+++ b/contracts/PBAB+Collabs/colors-and-shapes/GenArt721Minter_ColorsAndShapes.sol
@@ -4,9 +4,9 @@
 import "../../interfaces/0.8.x/IGenArt721CoreV2_PBAB.sol";
 import "../../interfaces/0.8.x/IBonusContract.sol";
 
-import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
-import "@openzeppelin/contracts/utils/Strings.sol";
-import "@openzeppelin/contracts/interfaces/IERC20.sol";
+import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin-4.5/contracts/utils/Strings.sol";
+import "@openzeppelin-4.5/contracts/interfaces/IERC20.sol";
 
 pragma solidity 0.8.9;
 

--- a/contracts/PBAB+Collabs/fireworks/GenArt721CoreV2_Fireworks.sol
+++ b/contracts/PBAB+Collabs/fireworks/GenArt721CoreV2_Fireworks.sol
@@ -4,9 +4,9 @@
 import "../../interfaces/0.8.x/IRandomizer.sol";
 import "../../interfaces/0.8.x/IGenArt721CoreV2_PBAB.sol";
 
-import "@openzeppelin/contracts/utils/Strings.sol";
+import "@openzeppelin-4.5/contracts/utils/Strings.sol";
 
-import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+import "@openzeppelin-4.5/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 
 pragma solidity 0.8.9;
 

--- a/contracts/PBAB+Collabs/fireworks/GenArt721Minter_Fireworks.sol
+++ b/contracts/PBAB+Collabs/fireworks/GenArt721Minter_Fireworks.sol
@@ -4,9 +4,9 @@
 import "../../interfaces/0.8.x/IGenArt721CoreV2_PBAB.sol";
 import "../../interfaces/0.8.x/IBonusContract.sol";
 
-import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
-import "@openzeppelin/contracts/utils/Strings.sol";
-import "@openzeppelin/contracts/interfaces/IERC20.sol";
+import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin-4.5/contracts/utils/Strings.sol";
+import "@openzeppelin-4.5/contracts/interfaces/IERC20.sol";
 
 pragma solidity 0.8.9;
 

--- a/contracts/PBAB+Collabs/legends-of-metaterra/GenArt721CoreV2_LegendsOfMetaterra.sol
+++ b/contracts/PBAB+Collabs/legends-of-metaterra/GenArt721CoreV2_LegendsOfMetaterra.sol
@@ -4,9 +4,9 @@
 import "../../interfaces/0.8.x/IRandomizer.sol";
 import "../../interfaces/0.8.x/IGenArt721CoreV2_PBAB.sol";
 
-import "@openzeppelin/contracts/utils/Strings.sol";
+import "@openzeppelin-4.5/contracts/utils/Strings.sol";
 
-import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+import "@openzeppelin-4.5/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 
 pragma solidity 0.8.9;
 

--- a/contracts/PBAB+Collabs/legends-of-metaterra/GenArt721Minter_LegendsOfMetaterra.sol
+++ b/contracts/PBAB+Collabs/legends-of-metaterra/GenArt721Minter_LegendsOfMetaterra.sol
@@ -4,9 +4,9 @@
 import "../../interfaces/0.8.x/IGenArt721CoreV2_PBAB.sol";
 import "../../interfaces/0.8.x/IBonusContract.sol";
 
-import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
-import "@openzeppelin/contracts/utils/Strings.sol";
-import "@openzeppelin/contracts/interfaces/IERC20.sol";
+import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin-4.5/contracts/utils/Strings.sol";
+import "@openzeppelin-4.5/contracts/interfaces/IERC20.sol";
 
 pragma solidity 0.8.9;
 

--- a/contracts/interfaces/0.8.x/IArtblocksRoyaltyOverride.sol
+++ b/contracts/interfaces/0.8.x/IArtblocksRoyaltyOverride.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Created By: Art Blocks Inc.
 
-import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import "@openzeppelin-4.5/contracts/utils/introspection/IERC165.sol";
 
 pragma solidity ^0.8.0;
 

--- a/contracts/minter-suite/MinterDAExpV0.sol
+++ b/contracts/minter-suite/MinterDAExpV0.sol
@@ -5,7 +5,7 @@ import "../interfaces/0.8.x/IGenArt721CoreContractV1.sol";
 import "../interfaces/0.8.x/IMinterFilterV0.sol";
 import "../interfaces/0.8.x/IFilteredMinterV0.sol";
 
-import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 
 pragma solidity 0.8.9;
 

--- a/contracts/minter-suite/MinterDAExpV1.sol
+++ b/contracts/minter-suite/MinterDAExpV1.sol
@@ -5,7 +5,7 @@ import "../interfaces/0.8.x/IGenArt721CoreContractV1.sol";
 import "../interfaces/0.8.x/IMinterFilterV0.sol";
 import "../interfaces/0.8.x/IFilteredMinterV0.sol";
 
-import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 
 pragma solidity 0.8.9;
 

--- a/contracts/minter-suite/MinterDALinV0.sol
+++ b/contracts/minter-suite/MinterDALinV0.sol
@@ -5,7 +5,7 @@ import "../interfaces/0.8.x/IGenArt721CoreContractV1.sol";
 import "../interfaces/0.8.x/IMinterFilterV0.sol";
 import "../interfaces/0.8.x/IFilteredMinterV0.sol";
 
-import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 
 pragma solidity 0.8.9;
 

--- a/contracts/minter-suite/MinterDALinV1.sol
+++ b/contracts/minter-suite/MinterDALinV1.sol
@@ -5,7 +5,7 @@ import "../interfaces/0.8.x/IGenArt721CoreContractV1.sol";
 import "../interfaces/0.8.x/IMinterFilterV0.sol";
 import "../interfaces/0.8.x/IFilteredMinterV0.sol";
 
-import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 
 pragma solidity 0.8.9;
 

--- a/contracts/minter-suite/MinterFilterV0.sol
+++ b/contracts/minter-suite/MinterFilterV0.sol
@@ -5,7 +5,7 @@ import "../interfaces/0.8.x/IMinterFilterV0.sol";
 import "../interfaces/0.8.x/IFilteredMinterV0.sol";
 import "../interfaces/0.8.x/IGenArt721CoreContractV1.sol";
 
-import "@openzeppelin/contracts/utils/structs/EnumerableMap.sol";
+import "@openzeppelin-4.5/contracts/utils/structs/EnumerableMap.sol";
 
 pragma solidity 0.8.9;
 

--- a/contracts/minter-suite/MinterHolderV0.sol
+++ b/contracts/minter-suite/MinterHolderV0.sol
@@ -5,11 +5,11 @@ import "../interfaces/0.8.x/IGenArt721CoreContractV1.sol";
 import "../interfaces/0.8.x/IMinterFilterV0.sol";
 import "../interfaces/0.8.x/IFilteredMinterHolderV0.sol";
 
-import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
-import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
-import "@openzeppelin/contracts/utils/structs/EnumerableMap.sol";
+import "@openzeppelin-4.5/contracts/token/ERC721/IERC721.sol";
+import "@openzeppelin-4.5/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin-4.5/contracts/utils/structs/EnumerableSet.sol";
+import "@openzeppelin-4.5/contracts/utils/structs/EnumerableMap.sol";
 
 pragma solidity 0.8.9;
 

--- a/contracts/minter-suite/MinterMerkleV0.sol
+++ b/contracts/minter-suite/MinterMerkleV0.sol
@@ -5,9 +5,9 @@ import "../interfaces/0.8.x/IGenArt721CoreContractV1.sol";
 import "../interfaces/0.8.x/IMinterFilterV0.sol";
 import "../interfaces/0.8.x/IFilteredMinterMerkleV0.sol";
 
-import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin-4.5/contracts/utils/cryptography/MerkleProof.sol";
+import "@openzeppelin-4.5/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 
 pragma solidity 0.8.9;
 

--- a/contracts/minter-suite/MinterMerkleV0.sol
+++ b/contracts/minter-suite/MinterMerkleV0.sol
@@ -5,9 +5,9 @@ import "../interfaces/0.8.x/IGenArt721CoreContractV1.sol";
 import "../interfaces/0.8.x/IMinterFilterV0.sol";
 import "../interfaces/0.8.x/IFilteredMinterMerkleV0.sol";
 
-import "@openzeppelin-4.5/contracts/utils/cryptography/MerkleProof.sol";
-import "@openzeppelin-4.5/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin-4.7/contracts/utils/cryptography/MerkleProof.sol";
+import "@openzeppelin-4.7/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin-4.7/contracts/security/ReentrancyGuard.sol";
 
 pragma solidity 0.8.9;
 
@@ -131,11 +131,14 @@ contract MinterMerkleV0 is ReentrancyGuard, IFilteredMinterMerkleV0 {
      */
     function verifyAddress(
         uint256 _projectId,
-        bytes32[] memory _proof,
+        bytes32[] calldata _proof,
         address _address
     ) public view returns (bool) {
         return
-            _proof.verify(projectMerkleRoot[_projectId], hashAddress(_address));
+            _proof.verifyCalldata(
+                projectMerkleRoot[_projectId],
+                hashAddress(_address)
+            );
     }
 
     /**
@@ -226,7 +229,7 @@ contract MinterMerkleV0 is ReentrancyGuard, IFilteredMinterMerkleV0 {
      * @param _proof Merkle proof.
      * @return tokenId Token ID of minted token
      */
-    function purchase(uint256 _projectId, bytes32[] memory _proof)
+    function purchase(uint256 _projectId, bytes32[] calldata _proof)
         external
         payable
         returns (uint256 tokenId)
@@ -246,7 +249,7 @@ contract MinterMerkleV0 is ReentrancyGuard, IFilteredMinterMerkleV0 {
     function purchaseTo(
         address _to,
         uint256 _projectId,
-        bytes32[] memory _proof
+        bytes32[] calldata _proof
     ) public payable nonReentrant returns (uint256 tokenId) {
         // CHECKS
         require(
@@ -364,12 +367,12 @@ contract MinterMerkleV0 is ReentrancyGuard, IFilteredMinterMerkleV0 {
      * @param _address Address to process.
      * @return merkleRoot Merkle root for `_address` and `_proof`
      */
-    function processProofForAddress(bytes32[] memory _proof, address _address)
+    function processProofForAddress(bytes32[] calldata _proof, address _address)
         external
         pure
         returns (bytes32)
     {
-        return _proof.processProof(hashAddress(_address));
+        return _proof.processProofCalldata(hashAddress(_address));
     }
 
     /**

--- a/contracts/minter-suite/MinterSetPriceERC20V0.sol
+++ b/contracts/minter-suite/MinterSetPriceERC20V0.sol
@@ -5,8 +5,8 @@ import "../interfaces/0.8.x/IGenArt721CoreContractV1.sol";
 import "../interfaces/0.8.x/IMinterFilterV0.sol";
 import "../interfaces/0.8.x/IFilteredMinterV0.sol";
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin-4.5/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 
 pragma solidity 0.8.9;
 

--- a/contracts/minter-suite/MinterSetPriceERC20V1.sol
+++ b/contracts/minter-suite/MinterSetPriceERC20V1.sol
@@ -5,8 +5,8 @@ import "../interfaces/0.8.x/IGenArt721CoreContractV1.sol";
 import "../interfaces/0.8.x/IMinterFilterV0.sol";
 import "../interfaces/0.8.x/IFilteredMinterV0.sol";
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin-4.5/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 
 pragma solidity 0.8.9;
 

--- a/contracts/minter-suite/MinterSetPriceV0.sol
+++ b/contracts/minter-suite/MinterSetPriceV0.sol
@@ -5,7 +5,7 @@ import "../interfaces/0.8.x/IGenArt721CoreContractV1.sol";
 import "../interfaces/0.8.x/IMinterFilterV0.sol";
 import "../interfaces/0.8.x/IFilteredMinterV0.sol";
 
-import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 
 pragma solidity 0.8.9;
 

--- a/contracts/minter-suite/MinterSetPriceV1.sol
+++ b/contracts/minter-suite/MinterSetPriceV1.sol
@@ -5,7 +5,7 @@ import "../interfaces/0.8.x/IGenArt721CoreContractV1.sol";
 import "../interfaces/0.8.x/IMinterFilterV0.sol";
 import "../interfaces/0.8.x/IFilteredMinterV0.sol";
 
-import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 
 pragma solidity 0.8.9;
 

--- a/contracts/mock/ERC20Mock.sol
+++ b/contracts/mock/ERC20Mock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin-4.5/contracts/token/ERC20/ERC20.sol";
 
 contract ERC20Mock is ERC20 {
     constructor(uint256 initialSupply) ERC20("Mock Token", "MOCK") {

--- a/contracts/royalty-registry/GenArt721RoyaltyOverride.sol
+++ b/contracts/royalty-registry/GenArt721RoyaltyOverride.sol
@@ -4,7 +4,7 @@
 import "../interfaces/0.8.x/IArtblocksRoyaltyOverride.sol";
 import "../interfaces/0.8.x/IGenArt721CoreContractV3.sol";
 
-import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import "@openzeppelin-4.5/contracts/utils/introspection/ERC165.sol";
 
 pragma solidity 0.8.9;
 

--- a/contracts/royalty-registry/GenArt721RoyaltyOverride_PBAB.sol
+++ b/contracts/royalty-registry/GenArt721RoyaltyOverride_PBAB.sol
@@ -4,7 +4,7 @@
 import "../interfaces/0.8.x/IArtblocksRoyaltyOverride.sol";
 import "../interfaces/0.8.x/IGenArt721CoreV2_PBAB.sol";
 
-import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import "@openzeppelin-4.5/contracts/utils/introspection/ERC165.sol";
 
 pragma solidity 0.8.9;
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   "license": "LGPL-3.0-only",
   "dependencies": {
     "@openzeppelin-0.5/contracts": "npm:@openzeppelin/contracts@2.5.1",
-    "@openzeppelin/contracts": "^4.5.0"
+    "@openzeppelin-4.5/contracts": "npm:@openzeppelin/contracts@4.5.0",
+    "@openzeppelin-4.7/contracts": "npm:@openzeppelin/contracts@4.7.0"
   }
 }

--- a/posterity/contracts/mock/ERC721ReceiverMock.sol
+++ b/posterity/contracts/mock/ERC721ReceiverMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.5.0;
 
-import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import "@openzeppelin-4.5/contracts/token/ERC721/IERC721Receiver.sol";
 
 contract ERC721ReceiverMock is IERC721Receiver {
     bytes4 private _retval;

--- a/test/minter-suite-minters/MinterMerkle/MinterMerkleV0.test.ts
+++ b/test/minter-suite-minters/MinterMerkle/MinterMerkleV0.test.ts
@@ -737,14 +737,15 @@ describe("MinterMerkleV0", async function () {
         });
 
       const receipt = await ethers.provider.getTransactionReceipt(tx.hash);
-      const txCost = receipt.effectiveGasPrice.mul(receipt.gasUsed).toString();
+      const txCost = receipt.effectiveGasPrice.mul(receipt.gasUsed);
 
       console.log(
         "Gas cost for a successful ERC20 mint: ",
-        ethers.utils.formatUnits(txCost, "ether").toString(),
+        ethers.utils.formatUnits(txCost.toString(), "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0387635"));
+      expect(compareBN(txCost, ethers.utils.parseEther("0.03874"), 1)).to.be
+        .true;
     });
 
     it("is gas performant at 1k length allowlist", async function () {
@@ -785,7 +786,7 @@ describe("MinterMerkleV0", async function () {
         "ETH"
       );
       // the following is not much more than the gas cost with a very small allowlist
-      expect(compareBN(txCost, ethers.utils.parseEther("0.0396386"), 1)).to.be
+      expect(compareBN(txCost, ethers.utils.parseEther("0.03957"), 1)).to.be
         .true;
     });
   });

--- a/test/util/common.ts
+++ b/test/util/common.ts
@@ -4,7 +4,7 @@
 import { BN } from "@openzeppelin/test-helpers";
 import { ethers } from "hardhat";
 import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { Contract } from "ethers";
+import { Contract, BigNumber } from "ethers";
 
 export type TestAccountsArtBlocks = {
   deployer: SignerWithAddress;
@@ -112,4 +112,15 @@ export async function safeAddProject(
       .connect(caller)
       .addProject("TestProject", artistAddress, 0, false);
   }
+}
+
+// utility funciton to compare Big Numbers, expecting them to be within x%, +/-
+export function compareBN(
+  actual: BigNumber,
+  expected: BigNumber,
+  tolerancePercent: number = 1
+): boolean {
+  const diff = actual.sub(expected);
+  const percentDiff = diff.mul(BigNumber.from("100")).div(expected);
+  return percentDiff.abs().lte(BigNumber.from(tolerancePercent.toString()));
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2086,6 +2086,16 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-2.5.1.tgz#c76e3fc57aa224da3718ec351812a4251289db31"
   integrity sha512-qIy6tLx8rtybEsIOAlrM4J/85s2q2nPkDqj/Rx46VakBZ0LwtFhXIVub96LXHczQX0vaqmAueDqNPXtbSXSaYQ==
 
+"@openzeppelin-4.5/contracts@npm:@openzeppelin/contracts@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.5.0.tgz#3fd75d57de172b3743cdfc1206883f56430409cc"
+  integrity sha512-fdkzKPYMjrRiPK6K4y64e6GzULR7R7RwxSigHS8DDp7aWDeoReqsQI+cxHV1UuhAqX69L1lAaWDxenfP+xiqzA==
+
+"@openzeppelin-4.7/contracts@npm:@openzeppelin/contracts@4.7.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.7.0.tgz#3092d70ea60e3d1835466266b1d68ad47035a2d5"
+  integrity sha512-52Qb+A1DdOss8QvJrijYYPSf32GUg2pGaG/yCxtaA3cu4jduouTdg4XZSMLW9op54m1jH7J8hoajhHKOPsoJFw==
+
 "@openzeppelin/contract-loader@^0.6.2":
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contract-loader/-/contract-loader-0.6.3.tgz#61a7b44de327e40b7d53f39e0fb59bbf847335c3"
@@ -2093,11 +2103,6 @@
   dependencies:
     find-up "^4.1.0"
     fs-extra "^8.1.0"
-
-"@openzeppelin/contracts@^4.5.0":
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.5.0.tgz#3fd75d57de172b3743cdfc1206883f56430409cc"
-  integrity sha512-fdkzKPYMjrRiPK6K4y64e6GzULR7R7RwxSigHS8DDp7aWDeoReqsQI+cxHV1UuhAqX69L1lAaWDxenfP+xiqzA==
 
 "@openzeppelin/test-helpers@^0.5.6":
   version "0.5.13"


### PR DESCRIPTION
## Motivation
Use recent OpenZeppelin library update to pass proofs as calldata instead of memory to be more gas performant on Merkle Minter. Reduces mint costs by ~1% for 1k allowlist, based on the added test in this PR.

## Change Summary
 - alias all OpenZeppelin versions to leave existing contracts unchanged (to ensure our test suite properly tests against already-deployed contracts)
 - Add OpenZeppelin 4.7.0 because it includes new Merkle-calldata functions (instead of memory)
 - Update MerkleMinter to use calldata functions to reduce gas
   - _no change to interface of minter_
 - Add gas test for MerkleMinter for a 1k-length allowlist
 
 ## Notes
 - I'm fine with skipping deployment of this to dev and moving straight to artist-staging when we are ready (changes are very minimal here, don't affect any interfaces/any frontend or subgraph actions)
 - 1k-length allowlist adds very minimal gas. Opted to not include a 1M-length allowlist due to excessive time to generate address array, and excessive time to generate the Merkle tree. This makes me think we should recommend artists do not use allowlists longer than ~10k unless we better optimize the frontend to store the Merkle tree in our db.