### PR TITLE
Make v3 ownable

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Core contracts use the versioning schema below:
 |      PRTNR Cores      | V2_PRTNR |   All PRTNR   | Various - see PBAB+Collabs directory [DEPLOYMENTS.md files](https://github.com/search?q=repo%3AArtBlocks%2Fartblocks-contracts+extension%3Amd+filename%3ADEPLOYMENTS&type=Code&ref=advsearch&l=&l=) |
 | Current Draft AB Core |    V3    |     (TBR)     | -                                                                                                                                                                                                   |
 
+> The current draft AB Core is a work in progress, ongoing [changelog here](./contracts/V3_CHANGELOG.md).
+
 ### MinterFilter Suite Compatibility Chart
 
 - We like new minters

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -5,7 +5,7 @@ import "./interfaces/0.8.x/IRandomizer.sol";
 import "./interfaces/0.8.x/IGenArt721CoreContractV3.sol";
 
 import "@openzeppelin-4.7/contracts/utils/Strings.sol";
-
+import "@openzeppelin-4.7/contracts/access/Ownable.sol";
 import "@openzeppelin-4.7/contracts/token/ERC721/ERC721.sol";
 
 pragma solidity 0.8.9;
@@ -14,7 +14,7 @@ pragma solidity 0.8.9;
  * @title Art Blocks ERC-721 core contract, V3.
  * @author Art Blocks Inc.
  */
-contract GenArt721CoreV3 is ERC721, IGenArt721CoreContractV3 {
+contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     /// randomizer contract
     IRandomizer public randomizerContract;
 
@@ -52,8 +52,6 @@ contract GenArt721CoreV3 is ERC721, IGenArt721CoreContractV3 {
 
     mapping(uint256 => bytes32) public tokenIdToHash;
 
-    /// admin for contract
-    address public admin;
     /// true if address is whitelisted
     mapping(address => bool) public isWhitelisted;
 
@@ -84,11 +82,6 @@ contract GenArt721CoreV3 is ERC721, IGenArt721CoreContractV3 {
         _;
     }
 
-    modifier onlyAdmin() {
-        require(msg.sender == admin, "Only admin");
-        _;
-    }
-
     modifier onlyWhitelisted() {
         require(isWhitelisted[msg.sender], "Only whitelisted");
         _;
@@ -114,7 +107,6 @@ contract GenArt721CoreV3 is ERC721, IGenArt721CoreContractV3 {
         string memory _tokenSymbol,
         address _randomizerContract
     ) ERC721(_tokenName, _tokenSymbol) {
-        admin = msg.sender;
         isWhitelisted[msg.sender] = true;
         artblocksAddress = payable(msg.sender);
         randomizerContract = IRandomizer(_randomizerContract);
@@ -186,18 +178,11 @@ contract GenArt721CoreV3 is ERC721, IGenArt721CoreContractV3 {
     }
 
     /**
-     * @notice Updates contract admin to `_adminAddress`.
-     */
-    function updateAdmin(address _adminAddress) public onlyAdmin {
-        admin = _adminAddress;
-    }
-
-    /**
      * @notice Updates artblocksAddress to `_artblocksAddress`.
      */
     function updateArtblocksAddress(address payable _artblocksAddress)
         public
-        onlyAdmin
+        onlyOwner
     {
         artblocksAddress = _artblocksAddress;
     }
@@ -208,7 +193,7 @@ contract GenArt721CoreV3 is ERC721, IGenArt721CoreContractV3 {
      */
     function updateArtblocksPercentage(uint256 _artblocksPercentage)
         public
-        onlyAdmin
+        onlyOwner
     {
         require(_artblocksPercentage <= 25, "Max of 25%");
         artblocksPercentage = _artblocksPercentage;
@@ -217,21 +202,21 @@ contract GenArt721CoreV3 is ERC721, IGenArt721CoreContractV3 {
     /**
      * @notice Whitelists `_address`.
      */
-    function addWhitelisted(address _address) public onlyAdmin {
+    function addWhitelisted(address _address) public onlyOwner {
         isWhitelisted[_address] = true;
     }
 
     /**
      * @notice Revokes whitelisting of `_address`.
      */
-    function removeWhitelisted(address _address) public onlyAdmin {
+    function removeWhitelisted(address _address) public onlyOwner {
         isWhitelisted[_address] = false;
     }
 
     /**
      * @notice updates minter to `_address`.
      */
-    function updateMinterContract(address _address) public onlyAdmin {
+    function updateMinterContract(address _address) public onlyOwner {
         minterContract = _address;
         emit MinterUpdated(_address);
     }
@@ -665,5 +650,22 @@ contract GenArt721CoreV3 is ERC721, IGenArt721CoreContractV3 {
                     Strings.toString(_tokenId)
                 )
             );
+    }
+
+    function owner()
+        public
+        view
+        override(Ownable, IGenArt721CoreContractV3)
+        returns (address)
+    {
+        return Ownable.owner();
+    }
+
+    /**
+     * @notice Backwards-compatible (pre-V3) getter returning contract admin
+     * @return admin_ Address of contract owner
+     */
+    function admin() public view returns (address) {
+        return owner();
     }
 }

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -63,8 +63,8 @@ contract GenArt721CoreV3 is ERC721, IGenArt721CoreContractV3 {
     /// next project ID to be created
     uint256 public nextProjectId = 0;
 
-    /// version for this core contract
-    string public constant coreVersion = "3.0.0";
+    /// version of this core contract
+    string public constant coreVersion = "v3.0.0";
 
     modifier onlyValidTokenId(uint256 _tokenId) {
         require(_exists(_tokenId), "Token ID does not exist");

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -4,9 +4,9 @@
 import "./interfaces/0.8.x/IRandomizer.sol";
 import "./interfaces/0.8.x/IGenArt721CoreContractV3.sol";
 
-import "@openzeppelin-4.5/contracts/utils/Strings.sol";
+import "@openzeppelin-4.7/contracts/utils/Strings.sol";
 
-import "@openzeppelin-4.5/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+import "@openzeppelin-4.7/contracts/token/ERC721/ERC721.sol";
 
 pragma solidity 0.8.9;
 
@@ -14,7 +14,7 @@ pragma solidity 0.8.9;
  * @title Art Blocks ERC-721 core contract, V3.
  * @author Art Blocks Inc.
  */
-contract GenArt721CoreV3 is ERC721Enumerable, IGenArt721CoreContractV3 {
+contract GenArt721CoreV3 is ERC721, IGenArt721CoreContractV3 {
     /// randomizer contract
     IRandomizer public randomizerContract;
 

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -653,6 +653,12 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
             );
     }
 
+    /**
+     * @notice Returns contract owner. Set to deployer's address by default on
+     * contract deployment.
+     * @dev ref: https://docs.openzeppelin.com/contracts/4.x/api/access#Ownable
+     * @dev owner role was called `admin` prior to V3 core contract
+     */
     function owner()
         public
         view

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -63,6 +63,9 @@ contract GenArt721CoreV3 is ERC721, IGenArt721CoreContractV3 {
     /// next project ID to be created
     uint256 public nextProjectId = 0;
 
+    /// version for this core contract
+    string public constant coreVersion = "3.0.0";
+
     modifier onlyValidTokenId(uint256 _tokenId) {
         require(_exists(_tokenId), "Token ID does not exist");
         _;

--- a/contracts/V3_CHANGELOG.md
+++ b/contracts/V3_CHANGELOG.md
@@ -1,0 +1,15 @@
+# Core V3 Changelog
+
+_This document is intended to document and explain the Art Blocks Core V3 changes, relative to the Art Blocks Core V1 contract_
+
+## The following changes were made in the Core V3 contract:
+
+- Force 1:1 relationship between core contract and minter filter
+  - This is to ensure that the minter filter is always in sync with the core contract. Minter filters were developed after the V1 core contract was deployed.
+- Remove price and currency info from the core contract
+  - Price and currency info was moved to the minter contracts when we switched to the new minter suite system (after the V1 core contract was deployed).
+- Add a public version/type field on the contract (similr to minter type in minter suite minters)
+  - This improves ability for client-side code to choose correct ABI when making contract calls based on the contract associated with the calls.
+- implement "Ownable"
+  - Main benefit is OpenSea/aggregator support by default
+  - Added a getter function admin() that returns contract owner to maintain backwards-compatibility of interface with before-V3 contracts.

--- a/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
+++ b/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
@@ -15,6 +15,9 @@ interface IGenArt721CoreContractV3 {
      */
     event MinterUpdated(address indexed _currentMinter);
 
+    // version of the core contract
+    function coreVersion() external view returns (string memory);
+
     // getter function of public variable
     function admin() external view returns (address);
 

--- a/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
+++ b/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
@@ -18,7 +18,10 @@ interface IGenArt721CoreContractV3 {
     // version of the core contract
     function coreVersion() external view returns (string memory);
 
-    // getter function of public variable
+    // owner (pre-V3 was named admin) of contract
+    function owner() external view returns (address);
+
+    // backwards-compatible admin - equal to owner()
     function admin() external view returns (address);
 
     // getter function of public variable

--- a/test/core/GenArt721CoreV3_Integration.test.ts
+++ b/test/core/GenArt721CoreV3_Integration.test.ts
@@ -98,6 +98,15 @@ describe("GenArt721CoreV3", async function () {
     });
   });
 
+  describe("coreVersion", function () {
+    it("returns expected value", async function () {
+      const coreVersion = await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .coreVersion();
+      expect(coreVersion).to.be.equal("v3.0.0");
+    });
+  });
+
   describe("projectInfo", function () {
     it("returns expected deprecated values", async function () {
       const tokenInfo = await this.genArt721Core

--- a/test/core/GenArt721CoreV3_Integration.test.ts
+++ b/test/core/GenArt721CoreV3_Integration.test.ts
@@ -116,4 +116,22 @@ describe("GenArt721CoreV3", async function () {
       expect(tokenInfo.maxInvocations).to.be.equal(15);
     });
   });
+
+  describe("owner", function () {
+    it("returns expected owner", async function () {
+      const ownerAddress = await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .owner();
+      expect(ownerAddress).to.be.equal(this.accounts.deployer.address);
+    });
+  });
+
+  describe("admin", function () {
+    it("returns expected backwards-compatible admin (owner)", async function () {
+      const adminAddress = await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .owner();
+      expect(adminAddress).to.be.equal(this.accounts.deployer.address);
+    });
+  });
 });


### PR DESCRIPTION
## Change Summary
- Implements OpenZeppelin's `Ownable` of V3 core.
- Adds a public getter `admin()` for backwards-compatibility purposes only, which returns the contract owner.
- Adds changelog to track core changes from V1 -> V3 core

## Motivation
The main benefit here is better automatic integration with third-party OpenSea/aggregators.