### PR TITLE
Never allow increases in edition size

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -376,22 +376,25 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
 
     /**
      * @notice Updates maximum invocations for project `_projectId` to
-     * `_maxInvocations`.
+     * `_maxInvocations`. Maximum invocations may only be decreased by the
+     * artist, and must be greater than or equal to current invocations.
+     * New projects are created with maximum invocations of 1 million by
+     * default.
      */
     function updateProjectMaxInvocations(
         uint256 _projectId,
         uint256 _maxInvocations
     ) public onlyArtist(_projectId) {
+        // checks
         require(
-            (!projects[_projectId].locked ||
-                _maxInvocations < projects[_projectId].maxInvocations),
-            "Only if unlocked"
+            (_maxInvocations < projects[_projectId].maxInvocations),
+            "_maxInvocations may only be decreased"
         );
         require(
-            _maxInvocations > projects[_projectId].invocations,
-            "You must set max invocations greater than current invocations"
+            _maxInvocations >= projects[_projectId].invocations,
+            "You must set max invocations gte current invocations"
         );
-        require(_maxInvocations <= ONE_MILLION, "Cannot exceed 1000000");
+        // effects
         projects[_projectId].maxInvocations = _maxInvocations;
     }
 

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -388,11 +388,11 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         // checks
         require(
             (_maxInvocations < projects[_projectId].maxInvocations),
-            "_maxInvocations may only be decreased"
+            "maxInvocations may only be decreased"
         );
         require(
             _maxInvocations >= projects[_projectId].invocations,
-            "You must set max invocations gte current invocations"
+            "Only max invocations gte current invocations"
         );
         // effects
         projects[_projectId].maxInvocations = _maxInvocations;

--- a/contracts/V3_CHANGELOG.md
+++ b/contracts/V3_CHANGELOG.md
@@ -21,3 +21,4 @@ _This document is intended to document and explain the Art Blocks Core V3 change
     - `projectScriptDetails` - Information relevant to rendering tokens
     - `projectMetadata` - Information relevant to understanding the project as a work of art
     - `projectArtistPaymentInfo` - Information relevant to artists as they manage their primary and additional payment accounts
+- Never allow an increase in Project edition size

--- a/contracts/V3_CHANGELOG.md
+++ b/contracts/V3_CHANGELOG.md
@@ -22,3 +22,4 @@ _This document is intended to document and explain the Art Blocks Core V3 change
     - `projectMetadata` - Information relevant to understanding the project as a work of art
     - `projectArtistPaymentInfo` - Information relevant to artists as they manage their primary and additional payment accounts
 - Never allow an increase in Project edition size
+  - IMPORTANT for artists to understand the impact of the change. Internal artist communication plan required for this type of change.

--- a/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
+++ b/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
@@ -1,0 +1,119 @@
+import {
+  BN,
+  constants,
+  expectEvent,
+  expectRevert,
+  balance,
+  ether,
+} from "@openzeppelin/test-helpers";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import {
+  getAccounts,
+  assignDefaultConstants,
+  deployAndGet,
+  deployCoreWithMinterFilter,
+} from "../../util/common";
+
+/**
+ * Tests for V3 core dealing with configuring projects.
+ */
+describe("GenArt721CoreV3", async function () {
+  beforeEach(async function () {
+    // standard accounts and constants
+    this.accounts = await getAccounts();
+    await assignDefaultConstants.call(this);
+
+    const randomizerFactory = await ethers.getContractFactory(
+      "BasicRandomizer"
+    );
+    this.randomizer = await randomizerFactory.deploy();
+    const artblocksFactory = await ethers.getContractFactory("GenArt721CoreV3");
+    this.genArt721Core = await artblocksFactory
+      .connect(this.accounts.deployer)
+      .deploy(this.name, this.symbol, this.randomizer.address);
+
+    // TBD - V3 DOES NOT CURRENTLY HAVE A WORKING MINTER
+
+    // allow artist to mint on contract
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .updateMinterContract(this.accounts.artist.address);
+
+    // add project zero
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .addProject("name", this.accounts.artist.address);
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .toggleProjectIsActive(this.projectZero);
+    await this.genArt721Core
+      .connect(this.accounts.artist)
+      .updateProjectMaxInvocations(this.projectZero, this.maxInvocations);
+
+    // add project one without setting it to active or setting max invocations
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .addProject("name", this.accounts.artist2.address);
+  });
+
+  describe("updateProjectMaxInvocations", function () {
+    it("only allows artist to update", async function () {
+      // deployer cannot update
+      await expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.deployer)
+          .updateProjectMaxInvocations(
+            this.projectZero,
+            this.maxInvocations - 1
+          ),
+        "Only artist"
+      );
+      // artist can update
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .updateProjectMaxInvocations(this.projectZero, this.maxInvocations - 1);
+    });
+
+    it("only allows maxInvocations to be reduced", async function () {
+      // invocations must be reduced
+      await expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.artist)
+          .updateProjectMaxInvocations(this.projectZero, this.maxInvocations),
+        "maxInvocations may only be decreased"
+      );
+      // artist can reduce
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .updateProjectMaxInvocations(this.projectZero, this.maxInvocations - 1);
+    });
+
+    it("only allows maxInvocations to be gte current invocations", async function () {
+      // mint a token on project zero
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .mint(
+          this.accounts.artist.address,
+          this.projectZero,
+          this.accounts.artist.address
+        );
+      // invocations cannot be < current invocations
+      await expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.artist)
+          .updateProjectMaxInvocations(this.projectZero, 0),
+        "Only max invocations gte current invocations"
+      );
+      // artist can set to greater than current invocations
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .updateProjectMaxInvocations(this.projectZero, 2);
+      // artist can set to equal to current invocations
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .updateProjectMaxInvocations(this.projectZero, 1);
+    });
+  });
+});


### PR DESCRIPTION
Never allow artists to increase edition size.

V3 (and V1) core already defaults every project to have 1M invocations when created. Artists may now only reduce maxInvocations to any value greater than or equal to current invocations.

## Design Comments
We could have stuck with the old requirement to only allow maxInvocations to be `>` current invocations. However, that is pretty quirky (e.g. "the last Rhythm"), so preferred to let artists set maxInvocations to be `>=` current invocations.

There is a side-effect of this update - artists can no longer set maxInvocations to some value for a given minter, then increase it later for a different minter. This has been done in the past, at least for PBAB partners. This side-effect is considered acceptable, and as our minter suite is expanded, more intentional ways of limiting portions of mints to certain methods are becoming available (e.g. use of allowlists).