### PR TITLE
Automatically lock projects after four weeks

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -15,10 +15,7 @@ pragma solidity 0.8.9;
  * @author Art Blocks Inc.
  */
 contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
-    event ProjectCompleted(
-        uint256 indexed _projectId,
-        uint256 _completedTimestamp
-    );
+    event ProjectCompleted(uint256 indexed _projectId);
 
     uint256 constant ONE_MILLION = 1_000_000;
     uint256 constant FOUR_WEEKS_IN_SECONDS = 2_419_200;
@@ -221,7 +218,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
      */
     function _completeProject(uint256 _projectId) internal {
         projects[_projectId].completedTimestamp = block.timestamp;
-        emit ProjectCompleted(_projectId, block.timestamp);
+        emit ProjectCompleted(_projectId);
     }
 
     /**

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -137,7 +137,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
             "Must mint from the allowed minter contract."
         );
         require(
-            projects[_projectId].completedTimestamp != 0,
+            projects[_projectId].completedTimestamp == 0,
             "Must not exceed max invocations"
         );
         require(

--- a/contracts/V3_CHANGELOG.md
+++ b/contracts/V3_CHANGELOG.md
@@ -23,3 +23,5 @@ _This document is intended to document and explain the Art Blocks Core V3 change
     - `projectArtistPaymentInfo` - Information relevant to artists as they manage their primary and additional payment accounts
 - Never allow an increase in Project edition size
   - IMPORTANT for artists to understand the impact of the change. Internal artist communication plan required for this type of change.
+- Automatically lock projects four weeks after they are fully minted
+  - IMPORTANT for artists to understand the impact of the change. Internal artist communication plan required for this type of change.

--- a/test/core/V3/GenArt721CoreV3_Events.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Events.test.ts
@@ -19,7 +19,7 @@ import {
 /**
  * Tests for V3 core dealing with configuring projects.
  */
-describe("GenArt721CoreV3", async function () {
+describe("GenArt721CoreV3 Events", async function () {
   beforeEach(async function () {
     // standard accounts and constants
     this.accounts = await getAccounts();

--- a/test/core/V3/GenArt721CoreV3_Events.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Events.test.ts
@@ -1,0 +1,86 @@
+import {
+  BN,
+  constants,
+  expectEvent,
+  expectRevert,
+  balance,
+  ether,
+} from "@openzeppelin/test-helpers";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import {
+  getAccounts,
+  assignDefaultConstants,
+  deployAndGet,
+  deployCoreWithMinterFilter,
+} from "../../util/common";
+
+/**
+ * Tests for V3 core dealing with configuring projects.
+ */
+describe("GenArt721CoreV3", async function () {
+  beforeEach(async function () {
+    // standard accounts and constants
+    this.accounts = await getAccounts();
+    await assignDefaultConstants.call(this);
+
+    const randomizerFactory = await ethers.getContractFactory(
+      "BasicRandomizer"
+    );
+    this.randomizer = await randomizerFactory.deploy();
+    const artblocksFactory = await ethers.getContractFactory("GenArt721CoreV3");
+    this.genArt721Core = await artblocksFactory
+      .connect(this.accounts.deployer)
+      .deploy(this.name, this.symbol, this.randomizer.address);
+
+    // TBD - V3 DOES NOT CURRENTLY HAVE A WORKING MINTER
+
+    // allow artist to mint on contract
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .updateMinterContract(this.accounts.artist.address);
+
+    // add project zero
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .addProject("name", this.accounts.artist.address);
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .toggleProjectIsActive(this.projectZero);
+    await this.genArt721Core
+      .connect(this.accounts.artist)
+      .updateProjectMaxInvocations(this.projectZero, this.maxInvocations);
+
+    // add project one without setting it to active or setting max invocations
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .addProject("name", this.accounts.artist2.address);
+  });
+
+  describe("ProjectCompleted", function () {
+    it("emits ProjectCompleted when being minted out", async function () {
+      for (let i = 0; i < this.maxInvocations - 1; i++) {
+        await this.genArt721Core
+          .connect(this.accounts.artist)
+          .mint(
+            this.accounts.artist.address,
+            this.projectZero,
+            this.accounts.artist.address
+          );
+      }
+      // emits event when being minted out
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.artist)
+          .mint(
+            this.accounts.artist.address,
+            this.projectZero,
+            this.accounts.artist.address
+          )
+      )
+        .to.emit(this.genArt721Core, "ProjectCompleted")
+        .withArgs(this.projectZero);
+    });
+  });
+});

--- a/test/core/V3/GenArt721CoreV3_Integration.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Integration.test.ts
@@ -32,7 +32,7 @@ async function fullyMintProject(
 /**
  * General Integration tests for V3 core.
  */
-describe("GenArt721CoreV3", async function () {
+describe("GenArt721CoreV3 Integration", async function () {
   beforeEach(async function () {
     // standard accounts and constants
     this.accounts = await getAccounts();

--- a/test/core/V3/GenArt721CoreV3_Integration.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Integration.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@openzeppelin/test-helpers";
 import { expect } from "chai";
 import { ethers } from "hardhat";
+import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 
 import {
   getAccounts,
@@ -15,6 +16,18 @@ import {
   deployAndGet,
   deployCoreWithMinterFilter,
 } from "../../util/common";
+import { FOUR_WEEKS } from "../../util/constants";
+
+async function fullyMintProject(
+  _projectId: BN,
+  _minterAccount: SignerWithAddress
+) {
+  for (let i = 0; i < this.maxInvocations; i++) {
+    await this.genArt721Core
+      .connect(_minterAccount)
+      .mint(_minterAccount.address, _projectId, _minterAccount.address);
+  }
+}
 
 /**
  * General Integration tests for V3 core.
@@ -35,6 +48,11 @@ describe("GenArt721CoreV3", async function () {
       .deploy(this.name, this.symbol, this.randomizer.address);
 
     // TBD - V3 DOES NOT CURRENTLY HAVE A WORKING MINTER
+
+    // allow artist to mint on contract
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .updateMinterContract(this.accounts.artist.address);
 
     // add project
     await this.genArt721Core
@@ -70,9 +88,11 @@ describe("GenArt721CoreV3", async function () {
 
   describe("reverts on project locked", async function () {
     it("reverts if try to modify script", async function () {
-      await this.genArt721Core
-        .connect(this.accounts.deployer)
-        .toggleProjectIsLocked(this.projectZero);
+      await fullyMintProject.call(this, this.projectZero, this.accounts.artist);
+      // wait until project is locked
+      await ethers.provider.send("evm_increaseTime", [FOUR_WEEKS + 1]);
+      await ethers.provider.send("evm_mine", []);
+      // expect revert
       await expectRevert(
         this.genArt721Core
           .connect(this.accounts.artist)

--- a/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
+++ b/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
@@ -20,7 +20,7 @@ import { FOUR_WEEKS } from "../../util/constants";
 /**
  * Tests for V3 core dealing with configuring projects.
  */
-describe("GenArt721CoreV3", async function () {
+describe("GenArt721CoreV3 Project Configure", async function () {
   beforeEach(async function () {
     // standard accounts and constants
     this.accounts = await getAccounts();
@@ -118,66 +118,7 @@ describe("GenArt721CoreV3", async function () {
     });
   });
 
-  describe("projectCompleted", function () {
-    it("project is not completed by default", async function () {
-      const isComplete = await this.genArt721Core
-        .connect(this.accounts.user)
-        .projectCompleted(this.projectZero);
-      expect(isComplete).to.equal(false);
-    });
-
-    it("project is not completed after a few mints", async function () {
-      for (let i = 0; i < this.maxInvocations - 1; i++) {
-        await this.genArt721Core
-          .connect(this.accounts.artist)
-          .mint(
-            this.accounts.artist.address,
-            this.projectZero,
-            this.accounts.artist.address
-          );
-      }
-      const isComplete = await this.genArt721Core
-        .connect(this.accounts.user)
-        .projectCompleted(this.projectZero);
-      expect(isComplete).to.equal(false);
-    });
-
-    it("project is completed after minting out", async function () {
-      for (let i = 0; i < this.maxInvocations; i++) {
-        await this.genArt721Core
-          .connect(this.accounts.artist)
-          .mint(
-            this.accounts.artist.address,
-            this.projectZero,
-            this.accounts.artist.address
-          );
-      }
-      const isComplete = await this.genArt721Core
-        .connect(this.accounts.user)
-        .projectCompleted(this.projectZero);
-      expect(isComplete).to.equal(true);
-    });
-
-    it("project is completed after setting maxInvocations to number of invocations", async function () {
-      // mint a token on project zero
-      await this.genArt721Core
-        .connect(this.accounts.artist)
-        .mint(
-          this.accounts.artist.address,
-          this.projectZero,
-          this.accounts.artist.address
-        );
-      // set max invocations to number of invocations
-      await this.genArt721Core
-        .connect(this.accounts.artist)
-        .updateProjectMaxInvocations(this.projectZero, 1);
-      // expect project to be completed
-      const isComplete = await this.genArt721Core
-        .connect(this.accounts.user)
-        .projectCompleted(this.projectZero);
-      expect(isComplete).to.equal(true);
-    });
-
+  describe("project complete state", function () {
     it("project may not mint when is completed due to reducing maxInvocations", async function () {
       // mint a token on project zero
       await this.genArt721Core
@@ -231,10 +172,10 @@ describe("GenArt721CoreV3", async function () {
 
   describe("projectLocked", function () {
     it("project is not locked by default", async function () {
-      const isLocked = await this.genArt721Core
+      const projectStateData = await this.genArt721Core
         .connect(this.accounts.user)
-        .projectLocked(this.projectZero);
-      expect(isLocked).to.equal(false);
+        .projectStateData(this.projectZero);
+      expect(projectStateData.locked).to.equal(false);
     });
 
     it("project is not locked < 4 weeks after being completed", async function () {
@@ -248,18 +189,18 @@ describe("GenArt721CoreV3", async function () {
             this.accounts.artist.address
           );
       }
-      let isLocked = await this.genArt721Core
+      let projectStateData = await this.genArt721Core
         .connect(this.accounts.user)
-        .projectLocked(this.projectZero);
-      expect(isLocked).to.equal(false);
+        .projectStateData(this.projectZero);
+      expect(projectStateData.locked).to.equal(false);
       // advance < 4 weeks
       await ethers.provider.send("evm_increaseTime", [FOUR_WEEKS - 1]);
       await ethers.provider.send("evm_mine", []);
-      isLocked = await this.genArt721Core
+      projectStateData = await this.genArt721Core
         .connect(this.accounts.user)
-        .projectLocked(this.projectZero);
+        .projectStateData(this.projectZero);
       // expect project to not be locked
-      expect(isLocked).to.equal(false);
+      expect(projectStateData.locked).to.equal(false);
     });
 
     it("project is locked > 4 weeks after being minted out", async function () {
@@ -276,11 +217,11 @@ describe("GenArt721CoreV3", async function () {
       // advance > 4 weeks
       await ethers.provider.send("evm_increaseTime", [FOUR_WEEKS + 1]);
       await ethers.provider.send("evm_mine", []);
-      const isLocked = await this.genArt721Core
+      const projectStateData = await this.genArt721Core
         .connect(this.accounts.user)
-        .projectLocked(this.projectZero);
+        .projectStateData(this.projectZero);
       // expect project to be locked
-      expect(isLocked).to.equal(true);
+      expect(projectStateData.locked).to.equal(true);
     });
   });
 });

--- a/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
+++ b/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
@@ -15,6 +15,7 @@ import {
   deployAndGet,
   deployCoreWithMinterFilter,
 } from "../../util/common";
+import { FOUR_WEEKS } from "../../util/constants";
 
 /**
  * Tests for V3 core dealing with configuring projects.
@@ -252,9 +253,7 @@ describe("GenArt721CoreV3", async function () {
         .projectLocked(this.projectZero);
       expect(isLocked).to.equal(false);
       // advance < 4 weeks
-      await ethers.provider.send("evm_increaseTime", [
-        4 * 7 * 24 * 60 * 60 - 1,
-      ]);
+      await ethers.provider.send("evm_increaseTime", [FOUR_WEEKS - 1]);
       await ethers.provider.send("evm_mine", []);
       isLocked = await this.genArt721Core
         .connect(this.accounts.user)
@@ -275,9 +274,7 @@ describe("GenArt721CoreV3", async function () {
           );
       }
       // advance > 4 weeks
-      await ethers.provider.send("evm_increaseTime", [
-        4 * 7 * 24 * 60 * 60 + 1,
-      ]);
+      await ethers.provider.send("evm_increaseTime", [FOUR_WEEKS + 1]);
       await ethers.provider.send("evm_mine", []);
       const isLocked = await this.genArt721Core
         .connect(this.accounts.user)

--- a/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
+++ b/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
@@ -116,4 +116,174 @@ describe("GenArt721CoreV3", async function () {
         .updateProjectMaxInvocations(this.projectZero, 1);
     });
   });
+
+  describe("projectCompleted", function () {
+    it("project is not completed by default", async function () {
+      const isComplete = await this.genArt721Core
+        .connect(this.accounts.user)
+        .projectCompleted(this.projectZero);
+      expect(isComplete).to.equal(false);
+    });
+
+    it("project is not completed after a few mints", async function () {
+      for (let i = 0; i < this.maxInvocations - 1; i++) {
+        await this.genArt721Core
+          .connect(this.accounts.artist)
+          .mint(
+            this.accounts.artist.address,
+            this.projectZero,
+            this.accounts.artist.address
+          );
+      }
+      const isComplete = await this.genArt721Core
+        .connect(this.accounts.user)
+        .projectCompleted(this.projectZero);
+      expect(isComplete).to.equal(false);
+    });
+
+    it("project is completed after minting out", async function () {
+      for (let i = 0; i < this.maxInvocations; i++) {
+        await this.genArt721Core
+          .connect(this.accounts.artist)
+          .mint(
+            this.accounts.artist.address,
+            this.projectZero,
+            this.accounts.artist.address
+          );
+      }
+      const isComplete = await this.genArt721Core
+        .connect(this.accounts.user)
+        .projectCompleted(this.projectZero);
+      expect(isComplete).to.equal(true);
+    });
+
+    it("project is completed after setting maxInvocations to number of invocations", async function () {
+      // mint a token on project zero
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .mint(
+          this.accounts.artist.address,
+          this.projectZero,
+          this.accounts.artist.address
+        );
+      // set max invocations to number of invocations
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .updateProjectMaxInvocations(this.projectZero, 1);
+      // expect project to be completed
+      const isComplete = await this.genArt721Core
+        .connect(this.accounts.user)
+        .projectCompleted(this.projectZero);
+      expect(isComplete).to.equal(true);
+    });
+
+    it("project may not mint when is completed due to reducing maxInvocations", async function () {
+      // mint a token on project zero
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .mint(
+          this.accounts.artist.address,
+          this.projectZero,
+          this.accounts.artist.address
+        );
+      // set max invocations to number of invocations
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .updateProjectMaxInvocations(this.projectZero, 1);
+      // expect project to not mint when completed
+      expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.artist)
+          .mint(
+            this.accounts.artist.address,
+            this.projectZero,
+            this.accounts.artist.address
+          ),
+        "Must not exceed max invocations"
+      );
+    });
+
+    it("project may not mint when is completed due to minting out", async function () {
+      // project mints out
+      for (let i = 0; i < this.maxInvocations; i++) {
+        await this.genArt721Core
+          .connect(this.accounts.artist)
+          .mint(
+            this.accounts.artist.address,
+            this.projectZero,
+            this.accounts.artist.address
+          );
+      }
+      // expect project to not mint when completed
+      expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.artist)
+          .mint(
+            this.accounts.artist.address,
+            this.projectZero,
+            this.accounts.artist.address
+          ),
+        "Must not exceed max invocations"
+      );
+    });
+  });
+
+  describe("projectLocked", function () {
+    it("project is not locked by default", async function () {
+      const isLocked = await this.genArt721Core
+        .connect(this.accounts.user)
+        .projectLocked(this.projectZero);
+      expect(isLocked).to.equal(false);
+    });
+
+    it("project is not locked < 4 weeks after being completed", async function () {
+      // project is completed
+      for (let i = 0; i < this.maxInvocations; i++) {
+        await this.genArt721Core
+          .connect(this.accounts.artist)
+          .mint(
+            this.accounts.artist.address,
+            this.projectZero,
+            this.accounts.artist.address
+          );
+      }
+      let isLocked = await this.genArt721Core
+        .connect(this.accounts.user)
+        .projectLocked(this.projectZero);
+      expect(isLocked).to.equal(false);
+      // advance < 4 weeks
+      await ethers.provider.send("evm_increaseTime", [
+        4 * 7 * 24 * 60 * 60 - 1,
+      ]);
+      await ethers.provider.send("evm_mine", []);
+      isLocked = await this.genArt721Core
+        .connect(this.accounts.user)
+        .projectLocked(this.projectZero);
+      // expect project to not be locked
+      expect(isLocked).to.equal(false);
+    });
+
+    it("project is locked > 4 weeks after being minted out", async function () {
+      // project is completed
+      for (let i = 0; i < this.maxInvocations; i++) {
+        await this.genArt721Core
+          .connect(this.accounts.artist)
+          .mint(
+            this.accounts.artist.address,
+            this.projectZero,
+            this.accounts.artist.address
+          );
+      }
+      // advance > 4 weeks
+      await ethers.provider.send("evm_increaseTime", [
+        4 * 7 * 24 * 60 * 60 + 1,
+      ]);
+      await ethers.provider.send("evm_mine", []);
+      const isLocked = await this.genArt721Core
+        .connect(this.accounts.user)
+        .projectLocked(this.projectZero);
+      // expect project to be locked
+      expect(isLocked).to.equal(true);
+    });
+  });
 });

--- a/test/core/V3/GenArt721CoreV3_Views.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Views.test.ts
@@ -19,7 +19,7 @@ import {
 /**
  * Tests regarding view functions for V3 core.
  */
-describe("GenArt721CoreV3", async function () {
+describe("GenArt721CoreV3 Views", async function () {
   beforeEach(async function () {
     // standard accounts and constants
     this.accounts = await getAccounts();

--- a/test/core/gas-tests/GenArt721CoreV3_GasOptimization.test.ts
+++ b/test/core/gas-tests/GenArt721CoreV3_GasOptimization.test.ts
@@ -1,0 +1,105 @@
+import {
+  BN,
+  constants,
+  expectEvent,
+  expectRevert,
+  balance,
+  ether,
+} from "@openzeppelin/test-helpers";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import {
+  getAccounts,
+  assignDefaultConstants,
+  deployAndGet,
+  deployCoreWithMinterFilter,
+} from "../../util/common";
+
+/**
+ * General Gas tests for V3 core.
+ * Used to test the gas cost of different operations on the core, specifically
+ * when optimizing for gas to quantify % reductions to aide in decision making.
+ */
+describe("GenArt721CoreV3 Gas Tests", async function () {
+  beforeEach(async function () {
+    // standard accounts and constants
+    this.accounts = await getAccounts();
+    await assignDefaultConstants.call(this);
+
+    const randomizerFactory = await ethers.getContractFactory(
+      "BasicRandomizer"
+    );
+    this.randomizer = await randomizerFactory.deploy();
+    const artblocksFactory = await ethers.getContractFactory("GenArt721CoreV3");
+    this.genArt721Core = await artblocksFactory
+      .connect(this.accounts.deployer)
+      .deploy(this.name, this.symbol, this.randomizer.address);
+
+    // allow user to mint on contract to remove any minter gas noise
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .updateMinterContract(this.accounts.user.address);
+
+    // add project zero
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .addProject("proj 0", this.accounts.artist.address);
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .toggleProjectIsActive(this.projectZero);
+    await this.genArt721Core
+      .connect(this.accounts.artist)
+      .updateProjectMaxInvocations(this.projectZero, this.maxInvocations);
+
+    // add project one to test cases where project is not a null byte
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .addProject("proj 1", this.accounts.artist.address);
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .toggleProjectIsActive(this.projectOne);
+    await this.genArt721Core
+      .connect(this.accounts.artist)
+      .toggleProjectIsPaused(this.projectOne);
+    await this.genArt721Core
+      .connect(this.accounts.artist)
+      .updateProjectMaxInvocations(this.projectOne, this.maxInvocations);
+
+    // mint token zero on project one to test cases where token is not a null byte
+    await this.genArt721Core
+      .connect(this.accounts.user)
+      .mint(
+        this.accounts.user.address,
+        this.projectOne,
+        this.accounts.user.address
+      );
+
+    // gas tests should mint token 1+ on project one+
+  });
+
+  describe("mint gas optimization", function () {
+    it("mints with expected gas cost", async function () {
+      // mint
+      const tx = await this.genArt721Core
+        .connect(this.accounts.user)
+        .mint(
+          this.accounts.user.address,
+          this.projectOne,
+          this.accounts.user.address
+        );
+      const receipt = await ethers.provider.getTransactionReceipt(tx.hash);
+      console.log(`gas used for mint optimization test: ${receipt.gasUsed}`);
+      const gasCostAt100gwei = receipt.effectiveGasPrice
+        .mul(receipt.gasUsed)
+        .toString();
+      const gasCostAt100gweiInETH = parseFloat(
+        ethers.utils.formatUnits(gasCostAt100gwei, "ether")
+      );
+      const gasCostAt100gweiAt2kUSDPerETH = gasCostAt100gweiInETH * 2e3;
+      console.log(
+        `=USD at 100gwei, $2k USD/ETH: \$${gasCostAt100gweiAt2kUSDPerETH}`
+      );
+    });
+  });
+});

--- a/test/util/constants.ts
+++ b/test/util/constants.ts
@@ -1,3 +1,4 @@
 export const ONE_MINUTE = 60;
 export const ONE_HOUR = ONE_MINUTE * 60;
 export const ONE_DAY = ONE_HOUR * 24;
+export const FOUR_WEEKS = ONE_DAY * 7 * 4;


### PR DESCRIPTION
Automatically lock projects four weeks after the project's completion.

Project's locked state now becomes a derived value based on time after project's complete timestamp. Project is considered "complete" when its invocations == maxInvocations. That can occur during a mint, or during an update to a project's maxInvocations (performed by artist).

A new event is emitted when a project is completed - this enables us to determine when a project will be considered "locked" on our subgraph, frontend, etc. (note that this will likely change to a generalized "ProjectUpdated" event when contract converted to use events for everything)

## follow-on work
Identified follow-on work will be to potentially adjust functions that are currently `onlyUnlocked` gated and determine if we want admin-overridable adjustments to be possible post-lock. This is because auto-locking a project could accidentally prematurely lock data, whereas in V1, locking is very intentional.