### PR TITLE
Add Art Blocks Reference Contracts

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -560,6 +560,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         _referenceContractsDescriptions[
             _referenceContract
         ] = _referenceContractDescription;
+
         // TODO - emit event when generic platform events are implemented
     }
 
@@ -816,7 +817,9 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
 
     /**
      * @notice Get reference Art Blocks contract address and description at
-     * index `_index` of enumerable mapping.
+     * index `_index` of enumerable mapping. Note that the index of a specific
+     * reference may change if references are added or removed by contract
+     * administrators.
      * @param _index enumerable map index to query.
      * @return referenceContractAddress Reference Art Blocks contract address
      * @return referenceContractDescription Reference Art Blocks contract
@@ -831,6 +834,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
             string memory referenceContractDescription
         )
     {
+        // .at function reverts if index is out of bounds
         referenceContractAddress = _referenceContracts.at(_index);
         referenceContractDescription = _referenceContractsDescriptions[
             referenceContractAddress


### PR DESCRIPTION
Add enumerable mapping of reference contracts to be used for documenting items such as prior Art Blocks core contracts, dependency registry, curation registry, etc.

This adds a very general enumerable mapping of `address -> string` of reference contracts. Helps Art Blocks concretely identify canon information.

OpenZeppelin does not yet support an enumerable mapping For this implementation, we use an enumerable set of addresses and a private mapping of `address -> string` to document description. From the user's perspective, the enumerable map's length and address+description at indexes are available via new view functions.

## Design Decisions
We could break out previous token contracts into a separate mapping if desired. This mapping is quite general, so I can see a slight benefit in doing that. We could even make a static function `previousContracts` that returns the two previous AB contracts because they are known a priori.

Description strings could be limited to a bytes32 encoded string to remain more gas efficient, but I expect descriptions to generally be much longer than 32 bytes, so opted to not limit to bytes32 encoded strings.

Add/remove of reference contracts is gated to be `onlyWhitelisted`. It could be `onlyAdmin`, but would add overhead for admin, and this is just metadata.

## Follow-on PRs
Add generic platform events for add/remove references when converting V3 contract to emit events for everything (to remove subgraph call handlers).

## TODO

- [ ] Add tests