### PR TITLE
Gate update project description

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -370,11 +370,20 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
 
     /**
      * @notice Updates description of project `_projectId`.
+     * Only artist may call when unlocked, only admin may call when locked.
      */
     function updateProjectDescription(
         uint256 _projectId,
         string memory _projectDescription
-    ) public onlyArtist(_projectId) {
+    ) public {
+        // checks
+        require(
+            _projectUnlocked(_projectId)
+                ? msg.sender == projectIdToArtistAddress[_projectId]
+                : msg.sender == owner(),
+            "Only artist when unlocked, owner when locked"
+        );
+        // effects
         projects[_projectId].description = _projectDescription;
     }
 

--- a/contracts/V3_CHANGELOG.md
+++ b/contracts/V3_CHANGELOG.md
@@ -23,3 +23,4 @@ _This document is intended to document and explain the Art Blocks Core V3 change
     - `projectArtistPaymentInfo` - Information relevant to artists as they manage their primary and additional payment accounts
 - Never allow an increase in Project edition size
   - IMPORTANT for artists to understand the impact of the change. Internal artist communication plan required for this type of change.
+- Only allow artist to update project description when project is unlocked; only allow admin to update project description when project is locked.

--- a/test/core/V3/GenArt721CoreV3_Integration.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Integration.test.ts
@@ -15,19 +15,10 @@ import {
   assignDefaultConstants,
   deployAndGet,
   deployCoreWithMinterFilter,
+  fullyMintProject,
+  advanceEVMByTime,
 } from "../../util/common";
 import { FOUR_WEEKS } from "../../util/constants";
-
-async function fullyMintProject(
-  _projectId: BN,
-  _minterAccount: SignerWithAddress
-) {
-  for (let i = 0; i < this.maxInvocations; i++) {
-    await this.genArt721Core
-      .connect(_minterAccount)
-      .mint(_minterAccount.address, _projectId, _minterAccount.address);
-  }
-}
 
 /**
  * General Integration tests for V3 core.
@@ -90,8 +81,7 @@ describe("GenArt721CoreV3 Integration", async function () {
     it("reverts if try to modify script", async function () {
       await fullyMintProject.call(this, this.projectZero, this.accounts.artist);
       // wait until project is locked
-      await ethers.provider.send("evm_increaseTime", [FOUR_WEEKS + 1]);
-      await ethers.provider.send("evm_mine", []);
+      await advanceEVMByTime(FOUR_WEEKS + 1);
       // expect revert
       await expectRevert(
         this.genArt721Core

--- a/test/util/common.ts
+++ b/test/util/common.ts
@@ -114,6 +114,23 @@ export async function safeAddProject(
   }
 }
 
+export async function fullyMintProject(
+  _projectId: BN,
+  _minterAccount: SignerWithAddress
+) {
+  for (let i = 0; i < this.maxInvocations; i++) {
+    await this.genArt721Core
+      .connect(_minterAccount)
+      .mint(_minterAccount.address, _projectId, _minterAccount.address);
+  }
+}
+
+export async function advanceEVMByTime(_timeSeconds: number) {
+  // advance with evm_increaseTime, then mine to advance time
+  await ethers.provider.send("evm_increaseTime", [_timeSeconds]);
+  await ethers.provider.send("evm_mine", []);
+}
+
 // utility funciton to compare Big Numbers, expecting them to be within x%, +/-
 export function compareBN(
   actual: BigNumber,


### PR DESCRIPTION
## Merge only after #212 

Gate V3 `updateProjectDescription` to be artist only when project is unlocked, owner (admin) only when project is locked.

Uses simple logic to gate calls to `updateProjectDescription`. If this pattern becomes common, will break this pattern into its own modifier.

Tests added for the new logic.