### PR TITLE
Artist address updates

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -390,7 +390,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         uint256 _projectId,
         uint256 _secondMarketRoyalty
     ) public onlyArtist(_projectId) {
-        require(_secondMarketRoyalty <= 100, "Max of 100%");
+        require(_secondMarketRoyalty <= 30, "Max of 30%");
         projectIdToSecondaryMarketRoyaltyPercentage[
             _projectId
         ] = _secondMarketRoyalty;

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -349,34 +349,41 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
      * @param _projectId Project ID.
      * @param _additionalPayeePrimarySales Address that may receive a
      * percentage split of the artit's primary sales revenue.
-     * @param _additionalPayeePercentagePrimarySales Percent of artist's
+     * @param _additionalPayeePrimarySalesPercentage Percent of artist's
      * portion of primary sale revenue that will be split to address
      * `_additionalPayeePrimarySales`.
-     * @param _additionalPayeeRoyalties Address that may receive a percentage
+     * @param _additionalPayeeSecondarySales Address that may receive a percentage
      * split of the secondary sales royalties.
-     * @param _additionalPayeePercentageRoyalties Percent of artist's portion
+     * @param _additionalPayeeSecondarySalesPercentage Percent of artist's portion
      * of secondary sale royalties that will be split to address
      * `_additionalPayeeRoyalties`.
      */
     function updateProjectAdditionalPayees(
         uint256 _projectId,
         address payable _additionalPayeePrimarySales,
-        uint256 _additionalPayeePercentagePrimarySales,
-        address payable _additionalPayeeRoyalties,
-        uint256 _additionalPayeePercentageRoyalties
+        uint256 _additionalPayeePrimarySalesPercentage,
+        address payable _additionalPayeeSecondarySales,
+        uint256 _additionalPayeeSecondarySalesPercentage
     ) external onlyArtist(_projectId) {
+        // checks
+        require(
+            _additionalPayeePrimarySalesPercentage <= 100 &&
+                _additionalPayeeSecondarySalesPercentage <= 100,
+            "Max of 100%"
+        );
+        // effects
         projectIdToAdditionalPayeePrimarySales[
             _projectId
         ] = _additionalPayeePrimarySales;
         projectIdToAdditionalPayeePrimarySalesPercentage[
             _projectId
-        ] = _additionalPayeePercentagePrimarySales;
+        ] = _additionalPayeePrimarySalesPercentage;
         projectIdToAdditionalPayeeSecondarySales[
             _projectId
-        ] = _additionalPayeeRoyalties;
+        ] = _additionalPayeeSecondarySales;
         projectIdToAdditionalPayeeSecondarySalesPercentage[
             _projectId
-        ] = _additionalPayeePercentageRoyalties;
+        ] = _additionalPayeeSecondarySalesPercentage;
     }
 
     /**

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -624,9 +624,15 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
      * @notice Returns artist payment information for project `_projectId`.
      * @param _projectId Project to be queried
      * @return artistAddress Project Artist's address
-     * @return additionalPayee Additional payee address
-     * @return additionalPayeePercentage Percentage of artist revenue
-     * to be sent to the additional payee's address
+     * @return additionalPayeePrimarySales Additional payee address for primary
+     * sales
+     * @return additionalPayeePrimarySalesPercentage Percentage of artist revenue
+     * to be sent to the additional payee address for primary sales
+     * @return additionalPayeeRoyalties Additional payee address for secondary
+     * sales royalties
+     * @return additionalPayeeRoyaltiesPercentage Percentage of artist revenue
+     * to be sent to the additional payee address for secondary sales royalties
+
      */
     function projectArtistPaymentInfo(uint256 _projectId)
         public

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -47,8 +47,14 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
 
     // All financial functions are stripped from struct for visibility
     mapping(uint256 => address payable) public projectIdToArtistAddress;
-    mapping(uint256 => address payable) public projectIdToAdditionalPayee;
-    mapping(uint256 => uint256) public projectIdToAdditionalPayeePercentage;
+    mapping(uint256 => address payable)
+        public projectIdToAdditionalPayeePrimarySales;
+    mapping(uint256 => uint256)
+        public projectIdToAdditionalPayeePrimarySalesPercentage;
+    mapping(uint256 => address payable)
+        public projectIdToAdditionalPayeeRoyalties;
+    mapping(uint256 => uint256)
+        public projectIdToAdditionalPayeeRoyaltiesPercentage;
     mapping(uint256 => uint256)
         public projectIdToSecondaryMarketRoyaltyPercentage;
 
@@ -338,25 +344,47 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     }
 
     /**
-     * @notice Updates additional payee for project `_projectId` to be
-     * `_additionalPayee`, receiving `_additionalPayeePercentage` percent
-     * of artist mint and royalty revenues.
+     * @notice Updates additional payees and percentage splits for project
+     * `_projectId`.
+     * @param _projectId Project ID.
+     * @param _additionalPayeePrimarySales Address that may receive a
+     * percentage split of the artit's primary sales revenue.
+     * @param _additionalPayeePercentagePrimarySales Percent of artist's
+     * portion of primary sale revenue that will be split to address
+     * `_additionalPayeePrimarySales`.
+     * @param _additionalPayeeRoyalties Address that may receive a percentage
+     * split of the secondary sales royalties.
+     * @param _additionalPayeePercentageRoyalties Percent of artist's portion
+     * of secondary sale royalties that will be split to address
+     * `_additionalPayeeRoyalties`.
      */
-    function updateProjectAdditionalPayeeInfo(
+    function updateProjectAdditionalPayees(
         uint256 _projectId,
-        address payable _additionalPayee,
-        uint256 _additionalPayeePercentage
-    ) public onlyArtist(_projectId) {
-        require(_additionalPayeePercentage <= 100, "Max of 100%");
-        projectIdToAdditionalPayee[_projectId] = _additionalPayee;
-        projectIdToAdditionalPayeePercentage[
+        address payable _additionalPayeePrimarySales,
+        uint256 _additionalPayeePercentagePrimarySales,
+        address payable _additionalPayeeRoyalties,
+        uint256 _additionalPayeePercentageRoyalties
+    ) external onlyArtist(_projectId) {
+        projectIdToAdditionalPayeePrimarySales[
             _projectId
-        ] = _additionalPayeePercentage;
+        ] = _additionalPayeePrimarySales;
+        projectIdToAdditionalPayeePrimarySalesPercentage[
+            _projectId
+        ] = _additionalPayeePercentagePrimarySales;
+        projectIdToAdditionalPayeeRoyalties[
+            _projectId
+        ] = _additionalPayeeRoyalties;
+        projectIdToAdditionalPayeeRoyaltiesPercentage[
+            _projectId
+        ] = _additionalPayeePercentageRoyalties;
     }
 
     /**
      * @notice Updates artist secondary market royalties for project
      * `_projectId` to be `_secondMarketRoyalty` percent.
+     * This DOES NOT include the secondary market royalty percentages collected
+     * by Art Blocks; this is only the total percentage of royalties that will
+     * be split to artist and additionalSecondaryPayee.
      */
     function updateProjectSecondaryMarketRoyaltyPercentage(
         uint256 _projectId,
@@ -605,13 +633,23 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         view
         returns (
             address artistAddress,
-            address additionalPayee,
-            uint256 additionalPayeePercentage
+            address additionalPayeePrimarySales,
+            uint256 additionalPayeePrimarySalesPercentage,
+            address additionalPayeeRoyalties,
+            uint256 additionalPayeeRoyaltiesPercentage
         )
     {
         artistAddress = projectIdToArtistAddress[_projectId];
-        additionalPayee = projectIdToAdditionalPayee[_projectId];
-        additionalPayeePercentage = projectIdToAdditionalPayeePercentage[
+        additionalPayeePrimarySales = projectIdToAdditionalPayeePrimarySales[
+            _projectId
+        ];
+        additionalPayeePrimarySalesPercentage = projectIdToAdditionalPayeePrimarySalesPercentage[
+            _projectId
+        ];
+        additionalPayeeRoyalties = projectIdToAdditionalPayeeRoyalties[
+            _projectId
+        ];
+        additionalPayeeRoyaltiesPercentage = projectIdToAdditionalPayeeRoyaltiesPercentage[
             _projectId
         ];
     }
@@ -696,8 +734,8 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     {
         uint256 projectId = _tokenId / ONE_MILLION;
         artistAddress = projectIdToArtistAddress[projectId];
-        additionalPayee = projectIdToAdditionalPayee[projectId];
-        additionalPayeePercentage = projectIdToAdditionalPayeePercentage[
+        additionalPayee = projectIdToAdditionalPayeeRoyalties[projectId];
+        additionalPayeePercentage = projectIdToAdditionalPayeeRoyaltiesPercentage[
             projectId
         ];
         royaltyFeeByID = projectIdToSecondaryMarketRoyaltyPercentage[projectId];

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -52,9 +52,9 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     mapping(uint256 => uint256)
         public projectIdToAdditionalPayeePrimarySalesPercentage;
     mapping(uint256 => address payable)
-        public projectIdToAdditionalPayeeRoyalties;
+        public projectIdToAdditionalPayeeSecondarySales;
     mapping(uint256 => uint256)
-        public projectIdToAdditionalPayeeRoyaltiesPercentage;
+        public projectIdToAdditionalPayeeSecondarySalesPercentage;
     mapping(uint256 => uint256)
         public projectIdToSecondaryMarketRoyaltyPercentage;
 
@@ -371,10 +371,10 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         projectIdToAdditionalPayeePrimarySalesPercentage[
             _projectId
         ] = _additionalPayeePercentagePrimarySales;
-        projectIdToAdditionalPayeeRoyalties[
+        projectIdToAdditionalPayeeSecondarySales[
             _projectId
         ] = _additionalPayeeRoyalties;
-        projectIdToAdditionalPayeeRoyaltiesPercentage[
+        projectIdToAdditionalPayeeSecondarySalesPercentage[
             _projectId
         ] = _additionalPayeePercentageRoyalties;
     }
@@ -632,9 +632,9 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
      * sales
      * @return additionalPayeePrimarySalesPercentage Percentage of artist revenue
      * to be sent to the additional payee address for primary sales
-     * @return additionalPayeeRoyalties Additional payee address for secondary
+     * @return additionalPayeeSecondarySales Additional payee address for secondary
      * sales royalties
-     * @return additionalPayeeRoyaltiesPercentage Percentage of artist revenue
+     * @return additionalPayeeSecondarySalesPercentage Percentage of artist revenue
      * to be sent to the additional payee address for secondary sales royalties
 
      */
@@ -645,8 +645,8 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
             address artistAddress,
             address additionalPayeePrimarySales,
             uint256 additionalPayeePrimarySalesPercentage,
-            address additionalPayeeRoyalties,
-            uint256 additionalPayeeRoyaltiesPercentage
+            address additionalPayeeSecondarySales,
+            uint256 additionalPayeeSecondarySalesPercentage
         )
     {
         artistAddress = projectIdToArtistAddress[_projectId];
@@ -656,10 +656,10 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         additionalPayeePrimarySalesPercentage = projectIdToAdditionalPayeePrimarySalesPercentage[
             _projectId
         ];
-        additionalPayeeRoyalties = projectIdToAdditionalPayeeRoyalties[
+        additionalPayeeSecondarySales = projectIdToAdditionalPayeeSecondarySales[
             _projectId
         ];
-        additionalPayeeRoyaltiesPercentage = projectIdToAdditionalPayeeRoyaltiesPercentage[
+        additionalPayeeSecondarySalesPercentage = projectIdToAdditionalPayeeSecondarySalesPercentage[
             _projectId
         ];
     }
@@ -744,8 +744,8 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     {
         uint256 projectId = _tokenId / ONE_MILLION;
         artistAddress = projectIdToArtistAddress[projectId];
-        additionalPayee = projectIdToAdditionalPayeeRoyalties[projectId];
-        additionalPayeePercentage = projectIdToAdditionalPayeeRoyaltiesPercentage[
+        additionalPayee = projectIdToAdditionalPayeeSecondarySales[projectId];
+        additionalPayeePercentage = projectIdToAdditionalPayeeSecondarySalesPercentage[
             projectId
         ];
         royaltyFeeByID = projectIdToSecondaryMarketRoyaltyPercentage[projectId];

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -385,12 +385,16 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
      * This DOES NOT include the secondary market royalty percentages collected
      * by Art Blocks; this is only the total percentage of royalties that will
      * be split to artist and additionalSecondaryPayee.
+     * @param _projectId Project ID.
+     * @param _secondMarketRoyalty Percent of secondary sales revenue that will
+     * be split to artist and additionalSecondaryPayee. This must be less than
+     * or equal to 95 percent.
      */
     function updateProjectSecondaryMarketRoyaltyPercentage(
         uint256 _projectId,
         uint256 _secondMarketRoyalty
     ) public onlyArtist(_projectId) {
-        require(_secondMarketRoyalty <= 30, "Max of 30%");
+        require(_secondMarketRoyalty <= 95, "Max of 95%");
         projectIdToSecondaryMarketRoyaltyPercentage[
             _projectId
         ] = _secondMarketRoyalty;

--- a/contracts/V3_CHANGELOG.md
+++ b/contracts/V3_CHANGELOG.md
@@ -28,3 +28,5 @@ _This document is intended to document and explain the Art Blocks Core V3 change
 - Only allow artist to update project description when project is unlocked; only allow admin to update project description when project is locked.
 - Add artist additionalPrimary and additionalSecondary payment accounts
   - This is to allow artists to have different additional payee accounts for primary sales vs. secondary royalty sales. This supports the use case where an artist has a charity as a payee in primary sales, but not in secondary sales.
+- Limit artists to 30% secondary royalty fees
+  - Previously the limit was 100% secondary royalty fees. This is to prevent the artist from taking too much of the secondary royalty fees.

--- a/contracts/V3_CHANGELOG.md
+++ b/contracts/V3_CHANGELOG.md
@@ -26,3 +26,5 @@ _This document is intended to document and explain the Art Blocks Core V3 change
 - Automatically lock projects four weeks after they are fully minted
   - IMPORTANT for artists to understand the impact of the change. Internal artist communication plan required for this type of change.
 - Only allow artist to update project description when project is unlocked; only allow admin to update project description when project is locked.
+- Add artist additionalPrimary and additionalSecondary payment accounts
+  - This is to allow artists to have different additional payee accounts for primary sales vs. secondary royalty sales. This supports the use case where an artist has a charity as a payee in primary sales, but not in secondary sales.

--- a/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
+++ b/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
@@ -47,15 +47,14 @@ interface IGenArt721CoreContractV3 {
         view
         returns (address payable);
 
-    function projectIdToAdditionalPayee(uint256 _projectId)
+    function projectIdToAdditionalPayeePrimarySales(uint256 _projectId)
         external
         view
         returns (address payable);
 
-    function projectIdToAdditionalPayeePercentage(uint256 _projectId)
-        external
-        view
-        returns (uint256);
+    function projectIdToAdditionalPayeePrimarySalesPercentage(
+        uint256 _projectId
+    ) external view returns (uint256);
 
     // @dev new function in V3
     function projectStateData(uint256 _projectId)

--- a/package.json
+++ b/package.json
@@ -66,6 +66,6 @@
   "dependencies": {
     "@openzeppelin-0.5/contracts": "npm:@openzeppelin/contracts@2.5.1",
     "@openzeppelin-4.5/contracts": "npm:@openzeppelin/contracts@4.5.0",
-    "@openzeppelin-4.7/contracts": "npm:@openzeppelin/contracts@4.7.0"
+    "@openzeppelin-4.7/contracts": "npm:@openzeppelin/contracts@4.7.1"
   }
 }

--- a/test/core/V3/GenArt721CoreV3_Views.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Views.test.ts
@@ -177,10 +177,18 @@ describe("GenArt721CoreV3 Views", async function () {
       expect(projectArtistPaymentInfo.artistAddress).to.be.equal(
         this.accounts.artist.address
       );
-      expect(projectArtistPaymentInfo.additionalPayee).to.be.equal(
+      expect(projectArtistPaymentInfo.additionalPayeePrimarySales).to.be.equal(
         constants.ZERO_ADDRESS
       );
-      expect(projectArtistPaymentInfo.additionalPayeePercentage).to.be.equal(0);
+      expect(
+        projectArtistPaymentInfo.additionalPayeePrimarySalesPercentage
+      ).to.be.equal(0);
+      expect(projectArtistPaymentInfo.additionalPayeeRoyalties).to.be.equal(
+        constants.ZERO_ADDRESS
+      );
+      expect(
+        projectArtistPaymentInfo.additionalPayeeRoyaltiesPercentage
+      ).to.be.equal(0);
     });
 
     it("returns expected values after populating", async function () {
@@ -193,10 +201,12 @@ describe("GenArt721CoreV3 Views", async function () {
         );
       await this.genArt721Core
         .connect(this.accounts.artist2)
-        .updateProjectAdditionalPayeeInfo(
+        .updateProjectAdditionalPayees(
           this.projectZero,
+          this.accounts.additional.address,
+          50,
           this.accounts.additional2.address,
-          50
+          51
         );
 
       // check for expected values
@@ -206,12 +216,18 @@ describe("GenArt721CoreV3 Views", async function () {
       expect(projectArtistPaymentInfo.artistAddress).to.be.equal(
         this.accounts.artist2.address
       );
-      expect(projectArtistPaymentInfo.additionalPayee).to.be.equal(
+      expect(projectArtistPaymentInfo.additionalPayeePrimarySales).to.be.equal(
+        this.accounts.additional.address
+      );
+      expect(
+        projectArtistPaymentInfo.additionalPayeePrimarySalesPercentage
+      ).to.be.equal(50);
+      expect(projectArtistPaymentInfo.additionalPayeeRoyalties).to.be.equal(
         this.accounts.additional2.address
       );
-      expect(projectArtistPaymentInfo.additionalPayeePercentage).to.be.equal(
-        50
-      );
+      expect(
+        projectArtistPaymentInfo.additionalPayeeRoyaltiesPercentage
+      ).to.be.equal(51);
     });
   });
 });

--- a/test/core/V3/GenArt721CoreV3_Views.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Views.test.ts
@@ -183,11 +183,11 @@ describe("GenArt721CoreV3 Views", async function () {
       expect(
         projectArtistPaymentInfo.additionalPayeePrimarySalesPercentage
       ).to.be.equal(0);
-      expect(projectArtistPaymentInfo.additionalPayeeRoyalties).to.be.equal(
-        constants.ZERO_ADDRESS
-      );
       expect(
-        projectArtistPaymentInfo.additionalPayeeRoyaltiesPercentage
+        projectArtistPaymentInfo.additionalPayeeSecondarySales
+      ).to.be.equal(constants.ZERO_ADDRESS);
+      expect(
+        projectArtistPaymentInfo.additionalPayeeSecondarySalesPercentage
       ).to.be.equal(0);
     });
 
@@ -222,11 +222,11 @@ describe("GenArt721CoreV3 Views", async function () {
       expect(
         projectArtistPaymentInfo.additionalPayeePrimarySalesPercentage
       ).to.be.equal(50);
-      expect(projectArtistPaymentInfo.additionalPayeeRoyalties).to.be.equal(
-        this.accounts.additional2.address
-      );
       expect(
-        projectArtistPaymentInfo.additionalPayeeRoyaltiesPercentage
+        projectArtistPaymentInfo.additionalPayeeSecondarySales
+      ).to.be.equal(this.accounts.additional2.address);
+      expect(
+        projectArtistPaymentInfo.additionalPayeeSecondarySalesPercentage
       ).to.be.equal(51);
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2091,10 +2091,10 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.5.0.tgz#3fd75d57de172b3743cdfc1206883f56430409cc"
   integrity sha512-fdkzKPYMjrRiPK6K4y64e6GzULR7R7RwxSigHS8DDp7aWDeoReqsQI+cxHV1UuhAqX69L1lAaWDxenfP+xiqzA==
 
-"@openzeppelin-4.7/contracts@npm:@openzeppelin/contracts@4.7.0":
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.7.0.tgz#3092d70ea60e3d1835466266b1d68ad47035a2d5"
-  integrity sha512-52Qb+A1DdOss8QvJrijYYPSf32GUg2pGaG/yCxtaA3cu4jduouTdg4XZSMLW9op54m1jH7J8hoajhHKOPsoJFw==
+"@openzeppelin-4.7/contracts@npm:@openzeppelin/contracts@4.7.1":
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.7.1.tgz#33d0a857b76b18d313e6bb6ed28cdaf367e90cfe"
+  integrity sha512-UXmAjKARsXORHlHZu5GCD7ZbRKm6nU8UHnbuT/QJJa2JEOEcbvV/X8w/sUk62Sl9VZuuljM1akrZLyAtzUgsxw==
 
 "@openzeppelin/contract-loader@^0.6.2":
   version "0.6.3"


### PR DESCRIPTION
Replace artist additionalPayee address and percentage with additionalPayeePrimarySales and additionalPayeeSecondaryRoyalties, each with a configurable percentage split.

Straightforward change that gives the artist the ability to have different additional payees for primary and secondary sales revenues. Opted to only include the primary sales payee + address in V3 core interface since those are the only values used by minters, and we already expose secondary royalties address/percentages in the getRoyaltyData function.

While digging into royalty address/percentage stuff, I reduced the cap of artist royalty percentage to 30% instead of the V1 cap of 100% (which didn't make sense, considering Art Blocks always gets 2.5%, making the cap at 102.5%).

This was the result of a discussion between accounting, creative, and engineering.

## Follow-on
This is the first step of re-organizing how artist additional payee wallets are updated. It DOES NOT implement the proposal/execute flow of updating the addresses. For this reason, full coverage of tests for this functionality are not yet included, and will be included in a follow-on PR (due to the amount of additional changes that are coming).

## ~unrelated
bumped OpenZeppelin version to from 4.7.0 to 4.7.1 to catch some bug fixes in at least one of their library (don't think it would affect us).