### PR TITLE
Delegate V3 Admin to Admin ACL contract

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -24,6 +24,9 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     /// randomizer contract
     IRandomizer public randomizerContract;
 
+    /// admin ACL contract
+    IAdminACLV0 public adminACLContract;
+
     struct Project {
         string name;
         string artist;
@@ -128,6 +131,17 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     }
 
     /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Internal function without access restriction.
+     * @dev Overrides and wraps OpenZeppelin's _transferOwnership function to
+     * also update adminACLContract for improved introspection.
+     */
+    function _transferOwnership(address newOwner) internal override {
+        Ownable._transferOwnership(newOwner);
+        adminACLContract = IAdminACLV0(newOwner);
+    }
+
+    /**
      * @notice Mints a token from project `_projectId` and sets the
      * token's owner to `_to`.
      * @param _to Address to be the minted token's owner.
@@ -203,11 +217,13 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
      * call function with selector `_selector`, as determined by the Admin ACL
      * contract.
      * @param _selector Function selector to check.
-     * @dev assumes the Admin ACL contract is the owner of this contract
-     * @dev assumes the Admin ACL contract implements the IAdminACLV0 interface
+     * @dev assumes the Admin ACL contract is the owner of this contract, which
+     * is expected to always be true.
      */
     function _adminAllowed(bytes4 _selector) internal returns (bool) {
-        return IAdminACLV0(owner()).allowed(msg.sender, _selector);
+        return
+            owner() != address(0) &&
+            adminACLContract.allowed(msg.sender, address(this), _selector);
     }
 
     /**

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -206,7 +206,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
      * @dev assumes the Admin ACL contract is the owner of this contract
      * @dev assumes the Admin ACL contract implements the IAdminACLV0 interface
      */
-    function _adminAllowed(bytes4 _selector) internal view returns (bool) {
+    function _adminAllowed(bytes4 _selector) internal returns (bool) {
         return IAdminACLV0(owner()).allowed(msg.sender, _selector);
     }
 
@@ -435,7 +435,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         require(
             _projectUnlocked(_projectId)
                 ? msg.sender == projectIdToArtistAddress[_projectId]
-                : msg.sender == owner(),
+                : _adminAllowed(this.updateProjectDescription.selector),
             "Only artist when unlocked, owner when locked"
         );
         // effects

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -114,15 +114,20 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
      * @param _tokenName Name of token.
      * @param _tokenSymbol Token symbol.
      * @param _randomizerContract Randomizer contract.
+     * @param _adminACLContract Address of admin access control contract, to be
+     * set as contract owner.
      */
     constructor(
         string memory _tokenName,
         string memory _tokenSymbol,
-        address _randomizerContract
+        address _randomizerContract,
+        address _adminACLContract
     ) ERC721(_tokenName, _tokenSymbol) {
+        // set ACL management contract as owner
         isWhitelisted[msg.sender] = true;
         artblocksAddress = payable(msg.sender);
         randomizerContract = IRandomizer(_randomizerContract);
+        _transferOwnership(_adminACLContract);
     }
 
     /**

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -219,6 +219,9 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
      * @param _selector Function selector to check.
      * @dev assumes the Admin ACL contract is the owner of this contract, which
      * is expected to always be true.
+     * @dev adminACLContract is expected to either be null address (if owner
+     * has renounced ownership), or conform to IAdminACLV0 interface. Check for
+     * null address first to avoid revert when admin has renounced ownership.
      */
     function _adminAllowed(bytes4 _selector) internal returns (bool) {
         return

--- a/contracts/V3_CHANGELOG.md
+++ b/contracts/V3_CHANGELOG.md
@@ -30,3 +30,6 @@ _This document is intended to document and explain the Art Blocks Core V3 change
   - This is to allow artists to have different additional payee accounts for primary sales vs. secondary royalty sales. This supports the use case where an artist has a charity as a payee in primary sales, but not in secondary sales.
 - Limit artists to 30% secondary royalty fees
   - Previously the limit was 100% secondary royalty fees. This is to prevent the artist from taking too much of the secondary royalty fees.
+- Delegate all admin access checks to new AdminACL contract
+  - This is to allow for more flexible admin access control, and to allow for future admin access control changes without having to redeploy the core contract.
+  - The core contract now does not distinguish between admin and whitelisted addresses. All admin access checks are delegated to the AdminACL contract.

--- a/contracts/interfaces/0.8.x/IAdminACLV0.sol
+++ b/contracts/interfaces/0.8.x/IAdminACLV0.sol
@@ -8,8 +8,5 @@ interface IAdminACLV0 {
     function AdminACLType() external view returns (string memory);
 
     // Checks if sender is allowed to call function with selector `_selector`
-    function allowed(address _sender, bytes4 _selector)
-        external
-        view
-        returns (bool);
+    function allowed(address _sender, bytes4 _selector) external returns (bool);
 }

--- a/contracts/interfaces/0.8.x/IAdminACLV0.sol
+++ b/contracts/interfaces/0.8.x/IAdminACLV0.sol
@@ -7,6 +7,13 @@ interface IAdminACLV0 {
     // Type of the Admin ACL contract of the form "AdminACLV0"
     function AdminACLType() external view returns (string memory);
 
-    // Checks if sender is allowed to call function with selector `_selector`
-    function allowed(address _sender, bytes4 _selector) external returns (bool);
+    /**
+     * Checks if sender `_sender` is allowed to call function with selector
+     * `_selector` on contract `_contract`.
+     */
+    function allowed(
+        address _sender,
+        address _contract,
+        bytes4 _selector
+    ) external returns (bool);
 }

--- a/contracts/interfaces/0.8.x/IAdminACLV0.sol
+++ b/contracts/interfaces/0.8.x/IAdminACLV0.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Created By: Art Blocks Inc.
+
+pragma solidity ^0.8.0;
+
+interface IAdminACLV0 {
+    // Type of the Admin ACL contract of the form "AdminACLV0"
+    function AdminACLType() external view returns (string memory);
+
+    // Checks if sender is allowed to call function with selector `_selector`
+    function allowed(address _sender, bytes4 _selector)
+        external
+        view
+        returns (bool);
+}

--- a/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
+++ b/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
@@ -3,6 +3,8 @@
 
 pragma solidity ^0.8.0;
 
+import "./IAdminACLV0.sol";
+
 interface IGenArt721CoreContractV3 {
     /**
      * @notice Token ID `_tokenId` minted to `_to`.
@@ -25,6 +27,9 @@ interface IGenArt721CoreContractV3 {
     // owner (pre-V3 was named admin) of contract
     // this is expected to be an Admin ACL contract for V3
     function owner() external view returns (address);
+
+    // Admin ACL contract for V3, will be at the address owner()
+    function adminACLContract() external returns (IAdminACLV0);
 
     // backwards-compatible admin - equal to owner()
     function admin() external view returns (address);

--- a/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
+++ b/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
@@ -23,6 +23,7 @@ interface IGenArt721CoreContractV3 {
     function coreType() external view returns (string memory);
 
     // owner (pre-V3 was named admin) of contract
+    // this is expected to be an Admin ACL contract for V3
     function owner() external view returns (address);
 
     // backwards-compatible admin - equal to owner()
@@ -36,8 +37,6 @@ interface IGenArt721CoreContractV3 {
         external
         view
         returns (uint256 projectId);
-
-    function isWhitelisted(address sender) external view returns (bool);
 
     // @dev this is not available in V0
     function isMintWhitelisted(address minter) external view returns (bool);

--- a/contracts/mock/MockAdminACLV0.sol
+++ b/contracts/mock/MockAdminACLV0.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "../interfaces/0.8.x/IAdminACLV0.sol";
+
+contract MockAdminACLV0 is IAdminACLV0 {
+    string public AdminACLType = "MockAdminACLV0";
+
+    // Dummy implementation that always returns true
+    function allowed(
+        address, /*_sender*/
+        bytes4 /*_selector*/
+    ) external pure returns (bool) {
+        return true;
+    }
+}

--- a/contracts/mock/MockAdminACLV0.sol
+++ b/contracts/mock/MockAdminACLV0.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.0;
 
 import "../interfaces/0.8.x/IAdminACLV0.sol";
+import "@openzeppelin-4.7/contracts/access/Ownable.sol";
 
 /**
  * @dev Mock contract for testing purposes.
@@ -29,11 +30,32 @@ contract MockAdminACLV0Events is IAdminACLV0 {
      * @dev Returns true for all ACL checks.
      * Also emits event for testing purposes.
      */
-    function allowed(address _sender, bytes4 _selector)
-        external
-        returns (bool)
-    {
+    function allowed(
+        address _sender,
+        address, /*_contract*/
+        bytes4 _selector
+    ) external returns (bool) {
         emit ACLCheck(_sender, _selector);
         return superAdmin == _sender;
+    }
+
+    /**
+     * @dev Allows superAdmin to call transferOwnership on other contract from
+     * this contract.
+     */
+    function transferOwnershipOn(address _contract, address _newOwner)
+        external
+    {
+        require(msg.sender == superAdmin, "Only superAdmin");
+        Ownable(_contract).transferOwnership(_newOwner);
+    }
+
+    /**
+     * @dev Allows superAdmin to call renounceOwnership on other contract from
+     * this contract.
+     */
+    function renounceOwnershipOn(address _contract) external {
+        require(msg.sender == superAdmin, "Only superAdmin");
+        Ownable(_contract).renounceOwnership();
     }
 }

--- a/contracts/mock/MockAdminACLV0.sol
+++ b/contracts/mock/MockAdminACLV0.sol
@@ -4,10 +4,23 @@ pragma solidity ^0.8.0;
 
 import "../interfaces/0.8.x/IAdminACLV0.sol";
 
-contract MockAdminACLV0 is IAdminACLV0 {
-    string public AdminACLType = "MockAdminACLV0";
+/**
+ * @dev Mock contract for testing purposes.
+ * This contract always returns true for all ACL checks.
+ * It also emits an event for all ACL checks, allowing our test suite to verify
+ * that the ACL was checked with the correct parameters.
+ */
+contract MockAdminACLV0EventsTrue is IAdminACLV0 {
+    // event used for testing purposes to diagnose what core contract is asking
+    // approval for.
+    event ACLCheck(address indexed sender, bytes4 indexed selector);
 
-    // Dummy implementation that always returns true
+    string public AdminACLType = "MockAdminACLV0EventsTrue";
+
+    /**
+     * @dev Returns true for all ACL checks.
+     * Also emits event for testing purposes.
+     */
     function allowed(
         address, /*_sender*/
         bytes4 /*_selector*/

--- a/contracts/mock/MockAdminACLV0.sol
+++ b/contracts/mock/MockAdminACLV0.sol
@@ -6,25 +6,34 @@ import "../interfaces/0.8.x/IAdminACLV0.sol";
 
 /**
  * @dev Mock contract for testing purposes.
- * This contract always returns true for all ACL checks.
- * It also emits an event for all ACL checks, allowing our test suite to verify
+ * This contract has a single superAdmin that passes all ACL checks. All checks
+ * for any other address will return false.
+ * It also emits an event for all ACL checks, enabling our test suite to verify
  * that the ACL was checked with the correct parameters.
  */
-contract MockAdminACLV0EventsTrue is IAdminACLV0 {
+contract MockAdminACLV0Events is IAdminACLV0 {
     // event used for testing purposes to diagnose what core contract is asking
     // approval for.
     event ACLCheck(address indexed sender, bytes4 indexed selector);
 
-    string public AdminACLType = "MockAdminACLV0EventsTrue";
+    string public AdminACLType = "MockAdminACLV0Events";
+
+    // superAdmin is the only address that passes any and all ACL checks
+    address public superAdmin;
+
+    constructor() {
+        superAdmin = msg.sender;
+    }
 
     /**
      * @dev Returns true for all ACL checks.
      * Also emits event for testing purposes.
      */
-    function allowed(
-        address, /*_sender*/
-        bytes4 /*_selector*/
-    ) external pure returns (bool) {
-        return true;
+    function allowed(address _sender, bytes4 _selector)
+        external
+        returns (bool)
+    {
+        emit ACLCheck(_sender, _selector);
+        return superAdmin == _sender;
     }
 }

--- a/test/core/V3/GenArt721CoreV3_AdminACLRequests.test.ts
+++ b/test/core/V3/GenArt721CoreV3_AdminACLRequests.test.ts
@@ -1,0 +1,221 @@
+import {
+  BN,
+  constants,
+  expectEvent,
+  expectRevert,
+  balance,
+  ether,
+} from "@openzeppelin/test-helpers";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import {
+  getAccounts,
+  assignDefaultConstants,
+  deployAndGet,
+  fullyMintProject,
+  advanceEVMByTime,
+  deployCoreWithMinterFilter,
+} from "../../util/common";
+import { FOUR_WEEKS } from "../../util/constants";
+
+async function validateAdminACLRequest(functionName: string, args: any[]) {
+  const targetSelector = this.coreInterface.getSighash(functionName);
+  // emits event when being minted out
+  expect(
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      [functionName](...args)
+  )
+    .to.emit(this.adminACL, "ACLCheck")
+    .withArgs(this.accounts.deployer.address, targetSelector);
+}
+
+/**
+ * Tests for V3 core dealing with funcitons requesting proper Admin ACL while
+ * authenticating caller.
+ * @dev Most or all of these tests rely on our mock AdminACL contract, which
+ * emits an event for debugging purposes indicating what the core contract is
+ * requesting to authenticate.
+ */
+describe("GenArt721CoreV3 AminACL Requests", async function () {
+  beforeEach(async function () {
+    // standard accounts and constants
+    this.accounts = await getAccounts();
+    await assignDefaultConstants.call(this);
+
+    const randomizerFactory = await ethers.getContractFactory(
+      "BasicRandomizer"
+    );
+    this.randomizer = await randomizerFactory.deploy();
+    const adminACLFactory = await ethers.getContractFactory(
+      "MockAdminACLV0Events"
+    );
+    this.adminACL = await adminACLFactory.deploy();
+    this.artblocksFactory = await ethers.getContractFactory("GenArt721CoreV3");
+    this.coreInterface = this.artblocksFactory.interface;
+    this.genArt721Core = await this.artblocksFactory
+      .connect(this.accounts.deployer)
+      .deploy(
+        this.name,
+        this.symbol,
+        this.randomizer.address,
+        this.adminACL.address
+      );
+
+    // TBD - V3 DOES NOT CURRENTLY HAVE A WORKING MINTER
+
+    // allow artist to mint on contract
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .updateMinterContract(this.accounts.artist.address);
+
+    // add project zero
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .addProject("name", this.accounts.artist.address);
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .toggleProjectIsActive(this.projectZero);
+    await this.genArt721Core
+      .connect(this.accounts.artist)
+      .updateProjectMaxInvocations(this.projectZero, this.maxInvocations);
+
+    // add project one without setting it to active or setting max invocations
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .addProject("name", this.accounts.artist2.address);
+  });
+
+  describe("requests appropriate selectors from AdminACL", function () {
+    it("updateArtblocksAddress", async function () {
+      await validateAdminACLRequest.call(this, "updateArtblocksAddress", [
+        this.accounts.user.address,
+      ]);
+    });
+
+    it("updateArtblocksPercentage", async function () {
+      await validateAdminACLRequest.call(this, "updateArtblocksPercentage", [
+        11,
+      ]);
+    });
+
+    it("updateMinterContract", async function () {
+      await validateAdminACLRequest.call(this, "updateMinterContract", [
+        this.accounts.user.address,
+      ]);
+    });
+
+    it("updateRandomizerAddress", async function () {
+      await validateAdminACLRequest.call(this, "updateRandomizerAddress", [
+        this.accounts.user.address,
+      ]);
+    });
+
+    it("toggleProjectIsActive", async function () {
+      await validateAdminACLRequest.call(this, "toggleProjectIsActive", [
+        this.projectZero,
+      ]);
+    });
+
+    it("updateProjectArtistAddress", async function () {
+      await validateAdminACLRequest.call(this, "updateProjectArtistAddress", [
+        this.projectZero,
+        this.accounts.artist2.address,
+      ]);
+    });
+
+    it("addProject", async function () {
+      await validateAdminACLRequest.call(this, "addProject", [
+        "Project Name",
+        this.accounts.artist2.address,
+      ]);
+    });
+
+    it("updateProjectName", async function () {
+      await validateAdminACLRequest.call(this, "updateProjectName", [
+        this.projectZero,
+        "New Project Name",
+      ]);
+    });
+
+    it("updateProjectArtistName", async function () {
+      await validateAdminACLRequest.call(this, "updateProjectArtistName", [
+        this.projectZero,
+        "New Artist Name",
+      ]);
+    });
+
+    it("updateProjectLicense", async function () {
+      await validateAdminACLRequest.call(this, "updateProjectLicense", [
+        this.projectZero,
+        "New Project License",
+      ]);
+    });
+
+    it("addProjectScript", async function () {
+      await validateAdminACLRequest.call(this, "addProjectScript", [
+        this.projectZero,
+        "console.log('hello world')",
+      ]);
+    });
+
+    describe("update/remove project scripts", async function () {
+      beforeEach(async function () {
+        // add a project to be modified
+        await this.genArt721Core
+          .connect(this.accounts.deployer)
+          .addProjectScript(this.projectZero, "console.log('hello world')");
+      });
+
+      it("updateProjectScript", async function () {
+        // update the script
+        await validateAdminACLRequest.call(this, "updateProjectScript", [
+          this.projectZero,
+          0,
+          "console.log('hello big world')",
+        ]);
+      });
+
+      it("removeProjectLastScript", async function () {
+        // update the script
+        await validateAdminACLRequest.call(this, "removeProjectLastScript", [
+          this.projectZero,
+        ]);
+      });
+    });
+
+    it("updateProjectScriptType", async function () {
+      await validateAdminACLRequest.call(this, "updateProjectScriptType", [
+        this.projectZero,
+        "p5js",
+        "v1.4.2",
+      ]);
+    });
+
+    it("updateProjectAspectRatio", async function () {
+      await validateAdminACLRequest.call(this, "updateProjectAspectRatio", [
+        this.projectZero,
+        "1.7777778",
+      ]);
+    });
+
+    it("updateProjectIpfsHash", async function () {
+      await validateAdminACLRequest.call(this, "updateProjectAspectRatio", [
+        this.projectZero,
+        "0x",
+      ]);
+    });
+
+    it("updateProjectDescription", async function () {
+      // admin may only call when in a locked state
+      await fullyMintProject.call(this, this.projectZero, this.accounts.artist);
+      await advanceEVMByTime(FOUR_WEEKS + 1);
+      // ensure admin requests expected selector
+      await validateAdminACLRequest.call(this, "updateProjectDescription", [
+        this.projectZero,
+        "post-locked admin description",
+      ]);
+    });
+  });
+});

--- a/test/core/V3/GenArt721CoreV3_Events.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Events.test.ts
@@ -29,7 +29,9 @@ describe("GenArt721CoreV3 Events", async function () {
       "BasicRandomizer"
     );
     this.randomizer = await randomizerFactory.deploy();
-    const adminACLFactory = await ethers.getContractFactory("MockAdminACLV0");
+    const adminACLFactory = await ethers.getContractFactory(
+      "MockAdminACLV0EventsTrue"
+    );
     this.adminACL = await adminACLFactory.deploy();
     const artblocksFactory = await ethers.getContractFactory("GenArt721CoreV3");
     this.genArt721Core = await artblocksFactory

--- a/test/core/V3/GenArt721CoreV3_Events.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Events.test.ts
@@ -17,7 +17,7 @@ import {
 } from "../../util/common";
 
 /**
- * Tests for V3 core dealing with configuring projects.
+ * Tests for V3 core dealing with emitted events
  */
 describe("GenArt721CoreV3 Events", async function () {
   beforeEach(async function () {

--- a/test/core/V3/GenArt721CoreV3_Events.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Events.test.ts
@@ -29,10 +29,17 @@ describe("GenArt721CoreV3 Events", async function () {
       "BasicRandomizer"
     );
     this.randomizer = await randomizerFactory.deploy();
+    const adminACLFactory = await ethers.getContractFactory("MockAdminACLV0");
+    this.adminACL = await adminACLFactory.deploy();
     const artblocksFactory = await ethers.getContractFactory("GenArt721CoreV3");
     this.genArt721Core = await artblocksFactory
       .connect(this.accounts.deployer)
-      .deploy(this.name, this.symbol, this.randomizer.address);
+      .deploy(
+        this.name,
+        this.symbol,
+        this.randomizer.address,
+        this.adminACL.address
+      );
 
     // TBD - V3 DOES NOT CURRENTLY HAVE A WORKING MINTER
 

--- a/test/core/V3/GenArt721CoreV3_Events.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Events.test.ts
@@ -30,7 +30,7 @@ describe("GenArt721CoreV3 Events", async function () {
     );
     this.randomizer = await randomizerFactory.deploy();
     const adminACLFactory = await ethers.getContractFactory(
-      "MockAdminACLV0EventsTrue"
+      "MockAdminACLV0Events"
     );
     this.adminACL = await adminACLFactory.deploy();
     const artblocksFactory = await ethers.getContractFactory("GenArt721CoreV3");

--- a/test/core/V3/GenArt721CoreV3_Integration.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Integration.test.ts
@@ -34,7 +34,7 @@ describe("GenArt721CoreV3 Integration", async function () {
     );
     this.randomizer = await randomizerFactory.deploy();
     const adminACLFactory = await ethers.getContractFactory(
-      "MockAdminACLV0EventsTrue"
+      "MockAdminACLV0Events"
     );
     this.adminACL = await adminACLFactory.deploy();
     const artblocksFactory = await ethers.getContractFactory("GenArt721CoreV3");
@@ -66,23 +66,27 @@ describe("GenArt721CoreV3 Integration", async function () {
       .updateProjectMaxInvocations(this.projectZero, this.maxInvocations);
   });
 
-  describe("has whitelisted owner", function () {
-    it("has an artblocksAddress", async function () {
+  describe("artblocksAddress", function () {
+    it("returns expected artblocksAddress", async function () {
       expect(await this.genArt721Core.artblocksAddress()).to.be.equal(
         this.accounts.deployer.address
       );
     });
+  });
 
-    it("has an admin", async function () {
-      expect(await this.genArt721Core.admin()).to.be.equal(
+  describe("owner", function () {
+    it("returns expected owner", async function () {
+      expect(await this.genArt721Core.owner()).to.be.equal(
         this.adminACL.address
       );
     });
+  });
 
-    it("has a whitelisted account", async function () {
-      expect(
-        await this.genArt721Core.isWhitelisted(this.accounts.deployer.address)
-      ).to.be.equal(true);
+  describe("admin", function () {
+    it("returns expected backwards-compatible admin (owner)", async function () {
+      expect(await this.genArt721Core.admin()).to.be.equal(
+        this.adminACL.address
+      );
     });
   });
 
@@ -116,24 +120,6 @@ describe("GenArt721CoreV3 Integration", async function () {
         .connect(this.accounts.deployer)
         .coreType();
       expect(coreType).to.be.equal("GenArt721CoreV3");
-    });
-  });
-
-  describe("owner", function () {
-    it("returns expected owner", async function () {
-      const ownerAddress = await this.genArt721Core
-        .connect(this.accounts.deployer)
-        .owner();
-      expect(ownerAddress).to.be.equal(this.accounts.deployer.address);
-    });
-  });
-
-  describe("admin", function () {
-    it("returns expected backwards-compatible admin (owner)", async function () {
-      const adminAddress = await this.genArt721Core
-        .connect(this.accounts.deployer)
-        .owner();
-      expect(adminAddress).to.be.equal(this.accounts.deployer.address);
     });
   });
 });

--- a/test/core/V3/GenArt721CoreV3_Integration.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Integration.test.ts
@@ -33,10 +33,17 @@ describe("GenArt721CoreV3 Integration", async function () {
       "BasicRandomizer"
     );
     this.randomizer = await randomizerFactory.deploy();
+    const adminACLFactory = await ethers.getContractFactory("MockAdminACLV0");
+    this.adminACL = await adminACLFactory.deploy();
     const artblocksFactory = await ethers.getContractFactory("GenArt721CoreV3");
     this.genArt721Core = await artblocksFactory
       .connect(this.accounts.deployer)
-      .deploy(this.name, this.symbol, this.randomizer.address);
+      .deploy(
+        this.name,
+        this.symbol,
+        this.randomizer.address,
+        this.adminACL.address
+      );
 
     // TBD - V3 DOES NOT CURRENTLY HAVE A WORKING MINTER
 

--- a/test/core/V3/GenArt721CoreV3_Integration.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Integration.test.ts
@@ -33,7 +33,9 @@ describe("GenArt721CoreV3 Integration", async function () {
       "BasicRandomizer"
     );
     this.randomizer = await randomizerFactory.deploy();
-    const adminACLFactory = await ethers.getContractFactory("MockAdminACLV0");
+    const adminACLFactory = await ethers.getContractFactory(
+      "MockAdminACLV0EventsTrue"
+    );
     this.adminACL = await adminACLFactory.deploy();
     const artblocksFactory = await ethers.getContractFactory("GenArt721CoreV3");
     this.genArt721Core = await artblocksFactory
@@ -65,7 +67,7 @@ describe("GenArt721CoreV3 Integration", async function () {
   });
 
   describe("has whitelisted owner", function () {
-    it("has an admin", async function () {
+    it("has an artblocksAddress", async function () {
       expect(await this.genArt721Core.artblocksAddress()).to.be.equal(
         this.accounts.deployer.address
       );
@@ -73,7 +75,7 @@ describe("GenArt721CoreV3 Integration", async function () {
 
     it("has an admin", async function () {
       expect(await this.genArt721Core.admin()).to.be.equal(
-        this.accounts.deployer.address
+        this.adminACL.address
       );
     });
 

--- a/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
+++ b/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
@@ -33,7 +33,7 @@ describe("GenArt721CoreV3 Project Configure", async function () {
     );
     this.randomizer = await randomizerFactory.deploy();
     const adminACLFactory = await ethers.getContractFactory(
-      "MockAdminACLV0EventsTrue"
+      "MockAdminACLV0Events"
     );
     this.adminACL = await adminACLFactory.deploy();
     const artblocksFactory = await ethers.getContractFactory("GenArt721CoreV3");

--- a/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
+++ b/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
@@ -32,7 +32,9 @@ describe("GenArt721CoreV3 Project Configure", async function () {
       "BasicRandomizer"
     );
     this.randomizer = await randomizerFactory.deploy();
-    const adminACLFactory = await ethers.getContractFactory("MockAdminACLV0");
+    const adminACLFactory = await ethers.getContractFactory(
+      "MockAdminACLV0EventsTrue"
+    );
     this.adminACL = await adminACLFactory.deploy();
     const artblocksFactory = await ethers.getContractFactory("GenArt721CoreV3");
     this.genArt721Core = await artblocksFactory

--- a/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
+++ b/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
@@ -32,10 +32,17 @@ describe("GenArt721CoreV3 Project Configure", async function () {
       "BasicRandomizer"
     );
     this.randomizer = await randomizerFactory.deploy();
+    const adminACLFactory = await ethers.getContractFactory("MockAdminACLV0");
+    this.adminACL = await adminACLFactory.deploy();
     const artblocksFactory = await ethers.getContractFactory("GenArt721CoreV3");
     this.genArt721Core = await artblocksFactory
       .connect(this.accounts.deployer)
-      .deploy(this.name, this.symbol, this.randomizer.address);
+      .deploy(
+        this.name,
+        this.symbol,
+        this.randomizer.address,
+        this.adminACL.address
+      );
 
     // TBD - V3 DOES NOT CURRENTLY HAVE A WORKING MINTER
 

--- a/test/core/V3/GenArt721CoreV3_Views.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Views.test.ts
@@ -29,10 +29,17 @@ describe("GenArt721CoreV3 Views", async function () {
       "BasicRandomizer"
     );
     this.randomizer = await randomizerFactory.deploy();
+    const adminACLFactory = await ethers.getContractFactory("MockAdminACLV0");
+    this.adminACL = await adminACLFactory.deploy();
     const artblocksFactory = await ethers.getContractFactory("GenArt721CoreV3");
     this.genArt721Core = await artblocksFactory
       .connect(this.accounts.deployer)
-      .deploy(this.name, this.symbol, this.randomizer.address);
+      .deploy(
+        this.name,
+        this.symbol,
+        this.randomizer.address,
+        this.adminACL.address
+      );
 
     // TBD - V3 DOES NOT CURRENTLY HAVE A WORKING MINTER
 

--- a/test/core/V3/GenArt721CoreV3_Views.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Views.test.ts
@@ -30,7 +30,7 @@ describe("GenArt721CoreV3 Views", async function () {
     );
     this.randomizer = await randomizerFactory.deploy();
     const adminACLFactory = await ethers.getContractFactory(
-      "MockAdminACLV0EventsTrue"
+      "MockAdminACLV0Events"
     );
     this.adminACL = await adminACLFactory.deploy();
     const artblocksFactory = await ethers.getContractFactory("GenArt721CoreV3");

--- a/test/core/V3/GenArt721CoreV3_Views.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Views.test.ts
@@ -29,7 +29,9 @@ describe("GenArt721CoreV3 Views", async function () {
       "BasicRandomizer"
     );
     this.randomizer = await randomizerFactory.deploy();
-    const adminACLFactory = await ethers.getContractFactory("MockAdminACLV0");
+    const adminACLFactory = await ethers.getContractFactory(
+      "MockAdminACLV0EventsTrue"
+    );
     this.adminACL = await adminACLFactory.deploy();
     const artblocksFactory = await ethers.getContractFactory("GenArt721CoreV3");
     this.genArt721Core = await artblocksFactory

--- a/test/core/gas-tests/GenArt721CoreV3_GasOptimization.test.ts
+++ b/test/core/gas-tests/GenArt721CoreV3_GasOptimization.test.ts
@@ -31,10 +31,17 @@ describe("GenArt721CoreV3 Gas Tests", async function () {
       "BasicRandomizer"
     );
     this.randomizer = await randomizerFactory.deploy();
+    const adminACLFactory = await ethers.getContractFactory("MockAdminACLV0");
+    this.adminACL = await adminACLFactory.deploy();
     const artblocksFactory = await ethers.getContractFactory("GenArt721CoreV3");
     this.genArt721Core = await artblocksFactory
       .connect(this.accounts.deployer)
-      .deploy(this.name, this.symbol, this.randomizer.address);
+      .deploy(
+        this.name,
+        this.symbol,
+        this.randomizer.address,
+        this.adminACL.address
+      );
 
     // allow user to mint on contract to remove any minter gas noise
     await this.genArt721Core

--- a/test/core/gas-tests/GenArt721CoreV3_GasOptimization.test.ts
+++ b/test/core/gas-tests/GenArt721CoreV3_GasOptimization.test.ts
@@ -32,7 +32,7 @@ describe("GenArt721CoreV3 Gas Tests", async function () {
     );
     this.randomizer = await randomizerFactory.deploy();
     const adminACLFactory = await ethers.getContractFactory(
-      "MockAdminACLV0EventsTrue"
+      "MockAdminACLV0Events"
     );
     this.adminACL = await adminACLFactory.deploy();
     const artblocksFactory = await ethers.getContractFactory("GenArt721CoreV3");

--- a/test/core/gas-tests/GenArt721CoreV3_GasOptimization.test.ts
+++ b/test/core/gas-tests/GenArt721CoreV3_GasOptimization.test.ts
@@ -31,7 +31,9 @@ describe("GenArt721CoreV3 Gas Tests", async function () {
       "BasicRandomizer"
     );
     this.randomizer = await randomizerFactory.deploy();
-    const adminACLFactory = await ethers.getContractFactory("MockAdminACLV0");
+    const adminACLFactory = await ethers.getContractFactory(
+      "MockAdminACLV0EventsTrue"
+    );
     this.adminACL = await adminACLFactory.deploy();
     const artblocksFactory = await ethers.getContractFactory("GenArt721CoreV3");
     this.genArt721Core = await artblocksFactory

--- a/test/minter-suite-minters/Minter.common.ts
+++ b/test/minter-suite-minters/Minter.common.ts
@@ -11,7 +11,7 @@ export const Minter_Common = async () => {
   describe("constructor", async function () {
     it("reverts when given incorrect minter filter and core addresses", async function () {
       const artblocksFactory = await ethers.getContractFactory(
-        "GenArt721CoreV3"
+        "GenArt721CoreV1"
       );
       const token2 = await artblocksFactory
         .connect(this.accounts.deployer)


### PR DESCRIPTION
Delegate all V3 admin authentication to a generalized Admin ACL contract, and assume Admin ACL is core contract owner.

This implementation is based on discussions between @ryley-o, @jakerockland, and @laureli(https://github.com/laureli).

In general, whenever admin may have authority to call some external function on the core contract, the core contract asks its owning ACL "is `msg.sender` allowed to call the external function being called on `address(this)`?". The ACL responds with true or false, and the core contract either rejects or accepts the call based on the response.

It is expected that eventually there will be some AdminACL contract designed that utilizes groups and sets of addresses/multisigs to determine which groups may call which functions on the core contract.

The details of this implementation are somewhat elegant in that function interfaces are relatively easy to generate in solidity, resulting in fairly readable code. This is also true in ethers, making tests fairly straightforward.

## Design Alternatives
Delegating all calls to an AdminACL (i.e. requiring all admin calls have `msg.sender == owner()`) was considered, specifically because it would be backwards compatible with V0 and V1 Art Blocks core contracts. However, if generalized, that pattern would require admin EOAs and/or multisigs to generate raw calldata in some way, and interact with the AdminACL contract directly.

Perhaps the most competitive and still relatively user-friendly alternative AdminACL contract that could be designed would have external functions that correspond 1:1 with all core contract admin-callable functions. For example, `updateProjectDescription` could be a function on the AdminACL that forwards the call to the core contract's `updateProjectDescription` function, if `msg.sender` was allowed to call the function. This AdminACL would have the drawback of having a bunch of boilerplate forwarding code for every function, and it would not be able to add support for new functions (e.g. on new minters) without making the ACL upgradeable (or reverting back to the generalized "call with this raw calldata" function, making it not user-friendly). After some discussion with the team, this was not considered a better option than the implementation in the PR.