### PR TITLE
Propose/Accept pattern for V3 updated Artist payment addresses

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -18,6 +18,17 @@ pragma solidity 0.8.9;
 contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     event ProjectCompleted(uint256 indexed _projectId);
 
+    event ProposedArtistAddressesAndSplits(
+        uint256 indexed _projectId,
+        address _artistAddress,
+        address _additionalPayeePrimarySales,
+        uint256 _additionalPayeePrimarySalesPercentage,
+        address _additionalPayeeSecondarySales,
+        uint256 _additionalPayeeSecondarySalesPercentage
+    );
+
+    event AcceptedArtistAddressesAndSplits(uint256 indexed _projectId);
+
     uint256 constant ONE_MILLION = 1_000_000;
     uint256 constant FOUR_WEEKS_IN_SECONDS = 2_419_200;
 
@@ -58,6 +69,9 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         public projectIdToAdditionalPayeeSecondarySalesPercentage;
     mapping(uint256 => uint256)
         public projectIdToSecondaryMarketRoyaltyPercentage;
+
+    /// hash of artist's proposed payment updates to be approved by admin
+    mapping(uint256 => bytes32) public proposedArtistAddressesAndSplitsHash;
 
     address payable public artblocksAddress;
     /// Percentage of mint revenue allocated to Art Blocks
@@ -289,18 +303,130 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     }
 
     /**
+     * @notice Artist proposes updated set of artist address, additional payee
+     * addresses, and percentage splits for project `_projectId`. Addresses and
+     * percentages do not have to all be changed, but they must all be defined
+     * as a complete set.
+     * @param _projectId Project ID.
+     * @param _artistAddress Artist address that controls the project, and may
+     * receive payments.
+     * @param _additionalPayeePrimarySales Address that may receive a
+     * percentage split of the artit's primary sales revenue.
+     * @param _additionalPayeePrimarySalesPercentage Percent of artist's
+     * portion of primary sale revenue that will be split to address
+     * `_additionalPayeePrimarySales`.
+     * @param _additionalPayeeSecondarySales Address that may receive a percentage
+     * split of the secondary sales royalties.
+     * @param _additionalPayeeSecondarySalesPercentage Percent of artist's portion
+     * of secondary sale royalties that will be split to address
+     * `_additionalPayeeSecondarySales`.
+     */
+    function artistProposePaymentAddressesAndSplits(
+        uint256 _projectId,
+        address payable _artistAddress,
+        address payable _additionalPayeePrimarySales,
+        uint256 _additionalPayeePrimarySalesPercentage,
+        address payable _additionalPayeeSecondarySales,
+        uint256 _additionalPayeeSecondarySalesPercentage
+    ) external onlyArtist(_projectId) {
+        // checks
+        require(
+            _additionalPayeePrimarySalesPercentage <= 100 &&
+                _additionalPayeeSecondarySalesPercentage <= 100,
+            "Max of 100%"
+        );
+        // effects
+        proposedArtistAddressesAndSplitsHash[_projectId] = keccak256(
+            abi.encodePacked(
+                _artistAddress,
+                _additionalPayeePrimarySales,
+                _additionalPayeePrimarySalesPercentage,
+                _additionalPayeeSecondarySales,
+                _additionalPayeeSecondarySalesPercentage
+            )
+        );
+        // emit event for off-chain indexing
+        emit ProposedArtistAddressesAndSplits(
+            _projectId,
+            _artistAddress,
+            _additionalPayeePrimarySales,
+            _additionalPayeePrimarySalesPercentage,
+            _additionalPayeeSecondarySales,
+            _additionalPayeeSecondarySalesPercentage
+        );
+    }
+
+    /**
+     * @notice Admin accepts a proposed set of updated artist address,
+     * additional payee addresses, and percentage splits for project
+     * `_projectId`. Addresses and percentages do not have to all be changed,
+     * but they must all be defined as a complete set.
+     * @param _projectId Project ID.
+     * @param _artistAddress Artist address that controls the project, and may
+     * receive payments.
+     * @param _additionalPayeePrimarySales Address that may receive a
+     * percentage split of the artit's primary sales revenue.
+     * @param _additionalPayeePrimarySalesPercentage Percent of artist's
+     * portion of primary sale revenue that will be split to address
+     * `_additionalPayeePrimarySales`.
+     * @param _additionalPayeeSecondarySales Address that may receive a percentage
+     * split of the secondary sales royalties.
+     * @param _additionalPayeeSecondarySalesPercentage Percent of artist's portion
+     * of secondary sale royalties that will be split to address
+     * `_additionalPayeeSecondarySales`.
+     * @dev this must be called by the Admin ACL contract, and must only accept
+     * the most recent proposed values for a given project (validated on-chain
+     * by comparing the hash of the proposed and accepted values).
+     */
+    function adminAcceptArtistAddressesAndSplits(
+        uint256 _projectId,
+        address payable _artistAddress,
+        address payable _additionalPayeePrimarySales,
+        uint256 _additionalPayeePrimarySalesPercentage,
+        address payable _additionalPayeeSecondarySales,
+        uint256 _additionalPayeeSecondarySalesPercentage
+    ) external onlyAdminACL(this.adminAcceptArtistAddressesAndSplits.selector) {
+        // checks
+        require(
+            proposedArtistAddressesAndSplitsHash[_projectId] ==
+                keccak256(
+                    abi.encodePacked(
+                        _artistAddress,
+                        _additionalPayeePrimarySales,
+                        _additionalPayeePrimarySalesPercentage,
+                        _additionalPayeeSecondarySales,
+                        _additionalPayeeSecondarySalesPercentage
+                    )
+                ),
+            "Must match proposal"
+        );
+        // effects
+        projectIdToArtistAddress[_projectId] = _artistAddress;
+        projectIdToAdditionalPayeePrimarySales[
+            _projectId
+        ] = _additionalPayeePrimarySales;
+        projectIdToAdditionalPayeePrimarySalesPercentage[
+            _projectId
+        ] = _additionalPayeePrimarySalesPercentage;
+        projectIdToAdditionalPayeeSecondarySales[
+            _projectId
+        ] = _additionalPayeeSecondarySales;
+        projectIdToAdditionalPayeeSecondarySalesPercentage[
+            _projectId
+        ] = _additionalPayeeSecondarySalesPercentage;
+        // emit event for off-chain indexing
+        emit AcceptedArtistAddressesAndSplits(_projectId);
+    }
+
+    /**
      * @notice Updates artist of project `_projectId` to `_artistAddress`.
+     * This is to only be used in the event that the artist address is
+     * compromised or illegal.
      */
     function updateProjectArtistAddress(
         uint256 _projectId,
         address payable _artistAddress
-    )
-        public
-        onlyArtistOrAdminACL(
-            _projectId,
-            this.updateProjectArtistAddress.selector
-        )
-    {
+    ) public onlyAdminACL(this.updateProjectArtistAddress.selector) {
         projectIdToArtistAddress[_projectId] = _artistAddress;
     }
 
@@ -357,49 +483,6 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         onlyArtistOrAdminACL(_projectId, this.updateProjectArtistName.selector)
     {
         projects[_projectId].artist = _projectArtistName;
-    }
-
-    /**
-     * @notice Updates additional payees and percentage splits for project
-     * `_projectId`.
-     * @param _projectId Project ID.
-     * @param _additionalPayeePrimarySales Address that may receive a
-     * percentage split of the artit's primary sales revenue.
-     * @param _additionalPayeePrimarySalesPercentage Percent of artist's
-     * portion of primary sale revenue that will be split to address
-     * `_additionalPayeePrimarySales`.
-     * @param _additionalPayeeSecondarySales Address that may receive a percentage
-     * split of the secondary sales royalties.
-     * @param _additionalPayeeSecondarySalesPercentage Percent of artist's portion
-     * of secondary sale royalties that will be split to address
-     * `_additionalPayeeRoyalties`.
-     */
-    function updateProjectAdditionalPayees(
-        uint256 _projectId,
-        address payable _additionalPayeePrimarySales,
-        uint256 _additionalPayeePrimarySalesPercentage,
-        address payable _additionalPayeeSecondarySales,
-        uint256 _additionalPayeeSecondarySalesPercentage
-    ) external onlyArtist(_projectId) {
-        // checks
-        require(
-            _additionalPayeePrimarySalesPercentage <= 100 &&
-                _additionalPayeeSecondarySalesPercentage <= 100,
-            "Max of 100%"
-        );
-        // effects
-        projectIdToAdditionalPayeePrimarySales[
-            _projectId
-        ] = _additionalPayeePrimarySales;
-        projectIdToAdditionalPayeePrimarySalesPercentage[
-            _projectId
-        ] = _additionalPayeePrimarySalesPercentage;
-        projectIdToAdditionalPayeeSecondarySales[
-            _projectId
-        ] = _additionalPayeeSecondarySales;
-        projectIdToAdditionalPayeeSecondarySalesPercentage[
-            _projectId
-        ] = _additionalPayeeSecondarySalesPercentage;
     }
 
     /**

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -356,7 +356,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
      * of secondary sale royalties that will be split to address
      * `_additionalPayeeSecondarySales`.
      */
-    function artistProposePaymentAddressesAndSplits(
+    function proposeArtistPaymentAddressesAndSplits(
         uint256 _projectId,
         address payable _artistAddress,
         address payable _additionalPayeePrimarySales,

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -439,7 +439,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
                         _additionalPayeeSecondarySalesPercentage
                     )
                 ),
-            "Must match proposal"
+            "Must match artist proposal"
         );
         // effects
         projectIdToArtistAddress[_projectId] = _artistAddress;

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -465,7 +465,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     /**
      * @notice Updates artist of project `_projectId` to `_artistAddress`.
      * This is to only be used in the event that the artist address is
-     * compromised or illegal.
+     * compromised or sanctioned.
      */
     function updateProjectArtistAddress(
         uint256 _projectId,

--- a/contracts/V3_CHANGELOG.md
+++ b/contracts/V3_CHANGELOG.md
@@ -25,6 +25,10 @@ _This document is intended to document and explain the Art Blocks Core V3 change
   - IMPORTANT for artists to understand the impact of the change. Internal artist communication plan required for this type of change.
 - Automatically lock projects four weeks after they are fully minted
   - IMPORTANT for artists to understand the impact of the change. Internal artist communication plan required for this type of change.
+- Follow propose/execute pattern for updates to artist payment accounts
+  - Artists may propose updates to their artist, additional primary, and additional secondary payment accounts. These updates must be executed by the contract admin.
+  - This is to ensure that artists remain in control of their payment accounts, but that the contract admin can step in to prevent non-compliant payment accounts from being used.
+  - If admin renounces ownership, artists can directly update their payment accounts.
 - Only allow artist to update project description when project is unlocked; only allow admin to update project description when project is locked.
 - Add artist additionalPrimary and additionalSecondary payment accounts
   - This is to allow artists to have different additional payee accounts for primary sales vs. secondary royalty sales. This supports the use case where an artist has a charity as a payee in primary sales, but not in secondary sales.

--- a/contracts/V3_CHANGELOG.md
+++ b/contracts/V3_CHANGELOG.md
@@ -29,7 +29,7 @@ _This document is intended to document and explain the Art Blocks Core V3 change
   - Artists may propose updates to their artist, additional primary, and additional secondary payment accounts. These updates must be executed by the contract admin.
   - This is to ensure that artists remain in control of their payment accounts, but that the contract admin can step in to prevent non-compliant payment accounts from being used.
   - If admin renounces ownership, artists can directly update their payment accounts.
-  - If admin has not renounced ownership, admin can directly update artist payment accounts in the event of a compromized or illegal artist account.
+  - If admin has not renounced ownership, admin can directly update artist payment accounts in the event of a compromised or sanctioned artist account.
 - Only allow artist to update project description when project is unlocked; only allow admin to update project description when project is locked.
 - Add artist additionalPrimary and additionalSecondary payment accounts
   - This is to allow artists to have different additional payee accounts for primary sales vs. secondary royalty sales. This supports the use case where an artist has a charity as a payee in primary sales, but not in secondary sales.

--- a/contracts/V3_CHANGELOG.md
+++ b/contracts/V3_CHANGELOG.md
@@ -29,6 +29,7 @@ _This document is intended to document and explain the Art Blocks Core V3 change
   - Artists may propose updates to their artist, additional primary, and additional secondary payment accounts. These updates must be executed by the contract admin.
   - This is to ensure that artists remain in control of their payment accounts, but that the contract admin can step in to prevent non-compliant payment accounts from being used.
   - If admin renounces ownership, artists can directly update their payment accounts.
+  - If admin has not renounced ownership, admin can directly update artist payment accounts in the event of a compromized or illegal artist account.
 - Only allow artist to update project description when project is unlocked; only allow admin to update project description when project is locked.
 - Add artist additionalPrimary and additionalSecondary payment accounts
   - This is to allow artists to have different additional payee accounts for primary sales vs. secondary royalty sales. This supports the use case where an artist has a charity as a payee in primary sales, but not in secondary sales.

--- a/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
+++ b/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
@@ -385,7 +385,7 @@ describe("GenArt721CoreV3 Project Configure", async function () {
             this.valuesToUpdateTo[4],
             this.valuesToUpdateTo[5] + 1
           ),
-        "Must match proposal"
+        "Must match artist proposal"
       );
       await expectRevert(
         this.genArt721Core
@@ -398,7 +398,7 @@ describe("GenArt721CoreV3 Project Configure", async function () {
             this.valuesToUpdateTo[2],
             this.valuesToUpdateTo[5]
           ),
-        "Must match proposal"
+        "Must match artist proposal"
       );
       await expectRevert(
         this.genArt721Core
@@ -411,7 +411,7 @@ describe("GenArt721CoreV3 Project Configure", async function () {
             this.valuesToUpdateTo[4],
             this.valuesToUpdateTo[5]
           ),
-        "Must match proposal"
+        "Must match artist proposal"
       );
       await expectRevert(
         this.genArt721Core
@@ -424,7 +424,7 @@ describe("GenArt721CoreV3 Project Configure", async function () {
             this.valuesToUpdateTo[4],
             this.valuesToUpdateTo[5]
           ),
-        "Must match proposal"
+        "Must match artist proposal"
       );
       await expectRevert(
         this.genArt721Core
@@ -437,7 +437,7 @@ describe("GenArt721CoreV3 Project Configure", async function () {
             this.valuesToUpdateTo[4],
             this.valuesToUpdateTo[5]
           ),
-        "Must match proposal"
+        "Must match artist proposal"
       );
       await expectRevert(
         this.genArt721Core
@@ -450,7 +450,7 @@ describe("GenArt721CoreV3 Project Configure", async function () {
             this.valuesToUpdateTo[4],
             this.valuesToUpdateTo[5]
           ),
-        "Must match proposal"
+        "Must match artist proposal"
       );
     });
   });

--- a/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
+++ b/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
@@ -281,6 +281,42 @@ describe("GenArt721CoreV3 Project Configure", async function () {
     });
   });
 
+  describe("updateProjectArtistAddress", function () {
+    it("only allows owner to update project artist address", async function () {
+      await expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.artist)
+          .updateProjectArtistAddress(
+            this.projectZero,
+            this.accounts.artist2.address
+          ),
+        "Only Admin ACL allowed"
+      );
+      this.genArt721Core
+        .connect(this.accounts.deployer)
+        .updateProjectArtistAddress(
+          this.projectZero,
+          this.accounts.artist2.address
+        );
+    });
+
+    it("reflects updated artist address", async function () {
+      this.genArt721Core
+        .connect(this.accounts.deployer)
+        .updateProjectArtistAddress(
+          this.projectZero,
+          this.accounts.artist2.address
+        );
+      // expect view to reflect update
+      const projectArtistPaymentInfo = await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .projectArtistPaymentInfo(this.projectZero);
+      expect(projectArtistPaymentInfo.artistAddress).to.equal(
+        this.accounts.artist2.address
+      );
+    });
+  });
+
   describe("update project payment addresses", function () {
     beforeEach(async function () {
       this.valuesToUpdateTo = [

--- a/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
+++ b/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
@@ -280,4 +280,178 @@ describe("GenArt721CoreV3 Project Configure", async function () {
       );
     });
   });
+
+  describe("update project payment addresses", function () {
+    beforeEach(async function () {
+      this.valuesToUpdateTo = [
+        this.projectZero,
+        this.accounts.artist2.address,
+        this.accounts.additional.address,
+        50,
+        this.accounts.additional2.address,
+        51,
+      ];
+    });
+
+    it("only allows artist to propose updates", async function () {
+      // rejects deployer as a proposer of updates
+      await expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.deployer)
+          .proposeArtistPaymentAddressesAndSplits(...this.valuesToUpdateTo),
+        "Only artist"
+      );
+      // rejects user as a proposer of updates
+      await expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.user)
+          .proposeArtistPaymentAddressesAndSplits(...this.valuesToUpdateTo),
+        "Only artist"
+      );
+      // allows artist to propose new values
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .proposeArtistPaymentAddressesAndSplits(...this.valuesToUpdateTo);
+    });
+
+    it("only allows adminACL-allowed account to accept updates if owner has not renounced ownership", async function () {
+      // artist proposes new values
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .proposeArtistPaymentAddressesAndSplits(...this.valuesToUpdateTo);
+      // rejects artist as an acceptor of updates
+      await expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.artist)
+          .adminAcceptArtistAddressesAndSplits(...this.valuesToUpdateTo),
+        "Only Admin ACL allowed"
+      );
+      // rejects user as an acceptor of updates
+      await expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.user)
+          .adminAcceptArtistAddressesAndSplits(...this.valuesToUpdateTo),
+        "Only Admin ACL allowed"
+      );
+      // allows deployer to accept new values
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .adminAcceptArtistAddressesAndSplits(...this.valuesToUpdateTo);
+    });
+
+    it("only allows artist account to accept proposed updates if owner has renounced ownership", async function () {
+      // artist proposes new values
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .proposeArtistPaymentAddressesAndSplits(...this.valuesToUpdateTo);
+      // admin renounces ownership
+      await this.adminACL
+        .connect(this.accounts.deployer)
+        .renounceOwnershipOn(this.genArt721Core.address);
+      // deployer may no longer accept proposed values
+      await expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.deployer)
+          .adminAcceptArtistAddressesAndSplits(...this.valuesToUpdateTo),
+        "Only Admin ACL allowed, or artist if owner has renounced"
+      );
+      // user may not accept proposed values
+      await expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.user)
+          .adminAcceptArtistAddressesAndSplits(...this.valuesToUpdateTo),
+        "Only Admin ACL allowed, or artist if owner has renounced"
+      );
+      // artist may accept proposed values
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .adminAcceptArtistAddressesAndSplits(...this.valuesToUpdateTo);
+    });
+
+    it("does not allow adminACL-allowed account to accept updates that don't match artist proposed values", async function () {
+      // artist proposes new values
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .proposeArtistPaymentAddressesAndSplits(...this.valuesToUpdateTo);
+      // rejects deployer's updates if they don't match artist's proposed values
+      await expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.deployer)
+          .adminAcceptArtistAddressesAndSplits(
+            this.valuesToUpdateTo[0],
+            this.valuesToUpdateTo[1],
+            this.valuesToUpdateTo[2],
+            this.valuesToUpdateTo[3],
+            this.valuesToUpdateTo[4],
+            this.valuesToUpdateTo[5] + 1
+          ),
+        "Must match proposal"
+      );
+      await expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.deployer)
+          .adminAcceptArtistAddressesAndSplits(
+            this.valuesToUpdateTo[0],
+            this.valuesToUpdateTo[1],
+            this.valuesToUpdateTo[2],
+            this.valuesToUpdateTo[3],
+            this.valuesToUpdateTo[2],
+            this.valuesToUpdateTo[5]
+          ),
+        "Must match proposal"
+      );
+      await expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.deployer)
+          .adminAcceptArtistAddressesAndSplits(
+            this.valuesToUpdateTo[0],
+            this.valuesToUpdateTo[1],
+            this.valuesToUpdateTo[2],
+            this.valuesToUpdateTo[3] - 1,
+            this.valuesToUpdateTo[4],
+            this.valuesToUpdateTo[5]
+          ),
+        "Must match proposal"
+      );
+      await expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.deployer)
+          .adminAcceptArtistAddressesAndSplits(
+            this.valuesToUpdateTo[0],
+            this.valuesToUpdateTo[1],
+            this.valuesToUpdateTo[4],
+            this.valuesToUpdateTo[3],
+            this.valuesToUpdateTo[4],
+            this.valuesToUpdateTo[5]
+          ),
+        "Must match proposal"
+      );
+      await expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.deployer)
+          .adminAcceptArtistAddressesAndSplits(
+            this.valuesToUpdateTo[0],
+            this.accounts.user.address,
+            this.valuesToUpdateTo[2],
+            this.valuesToUpdateTo[3],
+            this.valuesToUpdateTo[4],
+            this.valuesToUpdateTo[5]
+          ),
+        "Must match proposal"
+      );
+      await expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.deployer)
+          .adminAcceptArtistAddressesAndSplits(
+            this.projectOne,
+            this.valuesToUpdateTo[1],
+            this.valuesToUpdateTo[2],
+            this.valuesToUpdateTo[3],
+            this.valuesToUpdateTo[4],
+            this.valuesToUpdateTo[5]
+          ),
+        "Must match proposal"
+      );
+    });
+  });
 });

--- a/test/core/V3/GenArt721CoreV3_Views.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Views.test.ts
@@ -200,43 +200,41 @@ describe("GenArt721CoreV3 Views", async function () {
       ).to.be.equal(0);
     });
 
-    it("returns expected values after populating", async function () {
-      // artist populates values
+    it("returns expected values after updating artist payment addresses and splits", async function () {
+      const valuesToUpdateTo = [
+        this.projectZero,
+        this.accounts.artist2.address,
+        this.accounts.additional.address,
+        50,
+        this.accounts.additional2.address,
+        51,
+      ];
+      // artist proposes new values
       await this.genArt721Core
         .connect(this.accounts.artist)
-        .updateProjectArtistAddress(
-          this.projectZero,
-          this.accounts.artist2.address
-        );
+        .proposeArtistPaymentAddressesAndSplits(...valuesToUpdateTo);
       await this.genArt721Core
-        .connect(this.accounts.artist2)
-        .updateProjectAdditionalPayees(
-          this.projectZero,
-          this.accounts.additional.address,
-          50,
-          this.accounts.additional2.address,
-          51
-        );
-
+        .connect(this.accounts.deployer)
+        .adminAcceptArtistAddressesAndSplits(...valuesToUpdateTo);
       // check for expected values
       const projectArtistPaymentInfo = await this.genArt721Core
         .connect(this.accounts.deployer)
         .projectArtistPaymentInfo(this.projectZero);
       expect(projectArtistPaymentInfo.artistAddress).to.be.equal(
-        this.accounts.artist2.address
+        valuesToUpdateTo[1]
       );
       expect(projectArtistPaymentInfo.additionalPayeePrimarySales).to.be.equal(
-        this.accounts.additional.address
+        valuesToUpdateTo[2]
       );
       expect(
         projectArtistPaymentInfo.additionalPayeePrimarySalesPercentage
-      ).to.be.equal(50);
+      ).to.be.equal(valuesToUpdateTo[3]);
       expect(
         projectArtistPaymentInfo.additionalPayeeSecondarySales
-      ).to.be.equal(this.accounts.additional2.address);
+      ).to.be.equal(valuesToUpdateTo[4]);
       expect(
         projectArtistPaymentInfo.additionalPayeeSecondarySalesPercentage
-      ).to.be.equal(51);
+      ).to.be.equal(valuesToUpdateTo[5]);
     });
   });
 });


### PR DESCRIPTION
Use a propose/accept pattern when artist addresses are to be updated.

This allows Art Blocks to verify all artist + additional addresses meet regulatory and tax requirements prior to them being changed by an artist. The pattern still allows artists to propose updates publicly, on-chain, instead of through private communication channels.

## Design Decisions
While admin only cares about updated addresses, it is expected that artists would most often prefer to atomically update their additional payee address(es) at the same time as updating split percentages. Thus, all payment addresses and split percentages are proposed and accepted as a complete set. The exception is the secondary market royalty percentage, which remains completely in the control of a project's artist.

When an artist proposes an updated set of addresses and payment splits, and event is emitted with the requested values, and only the hash of the set of proposed values is stored on chain. This is to significantly reduce gas of the artist's transaction by avoiding writing every proposed value to storage. The emitted event allows our subgraph to retain the proposed values. admin may accept the values, and a hash of the values is verified on-chain to ensure admin did not modify any of the proposed values.

If admin [renounces ownership](https://docs.openzeppelin.com/contracts/4.x/api/access#Ownable-renounceOwnership--), artists may propose **and** accept updates on their own, to ensure the contract continues to be operational for artists. 

## Alternate Solutions
The artist's proposed values could be written to storage and we could avoid using our subgraph to retain proposed values. This would non-negligibly increase the cost of the artist's proposal transaction, and would require a more complex frontend to query each on-chain value when an admin wants to inspect a set of proposed values (as opposed to a graphql query in the current implementation).

## Tests
Tests are updated to provide coverage of the new functionality.