### PR TITLE
Expose relevant contracts on core

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -36,7 +36,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     address public constant ART_BLOCKS_TOKEN_ADDRESS_0 =
         0x059EDD72Cd353dF5106D2B9cC5ab83a52287aC3a;
     address public constant ART_BLOCKS_TOKEN_ADDRESS_1 =
-        0x059EDD72Cd353dF5106D2B9cC5ab83a52287aC3a;
+        0xa7d8d9ef8D8Ce8992Df33D8b8CF4Aebabd5bD270;
 
     /// Curation registry managed by Art Blocks
     address public artblocksCurationRegistryAddress;

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -32,6 +32,17 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     uint256 constant ONE_MILLION = 1_000_000;
     uint256 constant FOUR_WEEKS_IN_SECONDS = 2_419_200;
 
+    /// Art Blocks previous flagship token addresses (for reference)
+    address public constant ART_BLOCKS_TOKEN_ADDRESS_0 =
+        0x059EDD72Cd353dF5106D2B9cC5ab83a52287aC3a;
+    address public constant ART_BLOCKS_TOKEN_ADDRESS_1 =
+        0x059EDD72Cd353dF5106D2B9cC5ab83a52287aC3a;
+
+    /// Curation registry managed by Art Blocks
+    address public artblocksCurationRegistryAddress;
+    /// Dependency registry managed by Art Blocks
+    address public artblocksDependencyRegistryAddress;
+
     /// randomizer contract
     IRandomizer public randomizerContract;
 
@@ -282,6 +293,30 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     function _completeProject(uint256 _projectId) internal {
         projects[_projectId].completedTimestamp = block.timestamp;
         emit ProjectCompleted(_projectId);
+    }
+
+    /**
+     * @notice Updates reference to Art Blocks Curation Registry contract.
+     */
+    function updateArtblocksCurationRegistryAddress(
+        address _artblocksCurationRegistryAddress
+    )
+        external
+        onlyAdminACL(this.updateArtblocksCurationRegistryAddress.selector)
+    {
+        artblocksCurationRegistryAddress = _artblocksCurationRegistryAddress;
+    }
+
+    /**
+     * @notice Updates reference to Art Blocks Dependency Registry contract.
+     */
+    function updateArtblocksDependencyRegistryAddress(
+        address _artblocksDependencyRegistryAddress
+    )
+        external
+        onlyAdminACL(this.updateArtblocksDependencyRegistryAddress.selector)
+    {
+        artblocksDependencyRegistryAddress = _artblocksDependencyRegistryAddress;
     }
 
     /**

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -32,10 +32,12 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     uint256 constant ONE_MILLION = 1_000_000;
     uint256 constant FOUR_WEEKS_IN_SECONDS = 2_419_200;
 
-    /// Art Blocks previous flagship token addresses (for reference)
-    address public constant ART_BLOCKS_TOKEN_ADDRESS_0 =
+    // Art Blocks previous flagship ERC721 token addresses (for reference)
+    /// Art Blocks Project ID range: [0-2]
+    address public constant ART_BLOCKS_ERC721TOKEN_ADDRESS_V0 =
         0x059EDD72Cd353dF5106D2B9cC5ab83a52287aC3a;
-    address public constant ART_BLOCKS_TOKEN_ADDRESS_1 =
+    /// Art Blocks Project ID range: [3-TODO: add V1 final project ID before deploying]
+    address public constant ART_BLOCKS_ERC721TOKEN_ADDRESS_V1 =
         0xa7d8d9ef8D8Ce8992Df33D8b8CF4Aebabd5bD270;
 
     /// Curation registry managed by Art Blocks

--- a/contracts/V3_CHANGELOG.md
+++ b/contracts/V3_CHANGELOG.md
@@ -38,3 +38,7 @@ _This document is intended to document and explain the Art Blocks Core V3 change
 - Delegate all admin access checks to new AdminACL contract
   - This is to allow for more flexible admin access control, and to allow for future admin access control changes without having to redeploy the core contract.
   - The core contract now does not distinguish between admin and whitelisted addresses. All admin access checks are delegated to the AdminACL contract.
+- Add public reference variables for prior Art Blocks flagship token addresses
+  - This helps define the relationship between the V3 core contract and the V1 and V2 core contracts
+- Add public reference variables for the Art Blocks-managed Dependency and Curation registries
+  - This helps more completely define, on-chain, the metadata and rendering dependencies of Art Blocks projects

--- a/test/core/V3/GenArt721CoreV3_Views.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Views.test.ts
@@ -75,22 +75,22 @@ describe("GenArt721CoreV3 Views", async function () {
     });
   });
 
-  describe("ART_BLOCKS_TOKEN_ADDRESS_0", function () {
+  describe("ART_BLOCKS_ERC721TOKEN_ADDRESS_V0", function () {
     it("returns expected value", async function () {
       const reference = await this.genArt721Core
         .connect(this.accounts.deployer)
-        .ART_BLOCKS_TOKEN_ADDRESS_0();
+        .ART_BLOCKS_ERC721TOKEN_ADDRESS_V0();
       expect(reference).to.be.equal(
         "0x059EDD72Cd353dF5106D2B9cC5ab83a52287aC3a"
       );
     });
   });
 
-  describe("ART_BLOCKS_TOKEN_ADDRESS_1", function () {
+  describe("ART_BLOCKS_ERC721TOKEN_ADDRESS_V1", function () {
     it("returns expected value", async function () {
       const reference = await this.genArt721Core
         .connect(this.accounts.deployer)
-        .ART_BLOCKS_TOKEN_ADDRESS_1();
+        .ART_BLOCKS_ERC721TOKEN_ADDRESS_V1();
       expect(reference).to.be.equal(
         "0xa7d8d9ef8D8Ce8992Df33D8b8CF4Aebabd5bD270"
       );

--- a/test/core/V3/GenArt721CoreV3_Views.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Views.test.ts
@@ -75,6 +75,114 @@ describe("GenArt721CoreV3 Views", async function () {
     });
   });
 
+  describe("ART_BLOCKS_TOKEN_ADDRESS_0", function () {
+    it("returns expected value", async function () {
+      const reference = await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .ART_BLOCKS_TOKEN_ADDRESS_0();
+      expect(reference).to.be.equal(
+        "0x059EDD72Cd353dF5106D2B9cC5ab83a52287aC3a"
+      );
+    });
+  });
+
+  describe("ART_BLOCKS_TOKEN_ADDRESS_1", function () {
+    it("returns expected value", async function () {
+      const reference = await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .ART_BLOCKS_TOKEN_ADDRESS_1();
+      expect(reference).to.be.equal(
+        "0xa7d8d9ef8D8Ce8992Df33D8b8CF4Aebabd5bD270"
+      );
+    });
+  });
+
+  describe("artblocksCurationRegistryAddress", function () {
+    it("returns expected default value", async function () {
+      const reference = await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .artblocksCurationRegistryAddress();
+      expect(reference).to.be.equal(constants.ZERO_ADDRESS);
+    });
+
+    it("returns expected populated value", async function () {
+      // admin set to dummy address
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .updateArtblocksCurationRegistryAddress(
+          this.accounts.additional.address
+        );
+      // expect value to be updated
+      const reference = await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .artblocksCurationRegistryAddress();
+      expect(reference).to.be.equal(this.accounts.additional.address);
+    });
+
+    it("only allows admin to update value", async function () {
+      // expect revert when non-admin attempts to update
+      for (const account of [this.accounts.artist, this.accounts.additional]) {
+        await expectRevert(
+          this.genArt721Core
+            .connect(account)
+            .updateArtblocksCurationRegistryAddress(
+              this.accounts.additional.address
+            ),
+          "Only Admin ACL allowed"
+        );
+      }
+      // admin allowed to update
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .updateArtblocksCurationRegistryAddress(
+          this.accounts.additional.address
+        );
+    });
+  });
+
+  describe("artblocksDependencyRegistryAddress", function () {
+    it("returns expected default value", async function () {
+      const reference = await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .artblocksDependencyRegistryAddress();
+      expect(reference).to.be.equal(constants.ZERO_ADDRESS);
+    });
+
+    it("returns expected populated value", async function () {
+      // admin set to dummy address
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .updateArtblocksDependencyRegistryAddress(
+          this.accounts.additional.address
+        );
+      // expect value to be updated
+      const reference = await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .artblocksDependencyRegistryAddress();
+      expect(reference).to.be.equal(this.accounts.additional.address);
+    });
+
+    it("only allows admin to update value", async function () {
+      // expect revert when non-admin attempts to update
+      for (const account of [this.accounts.artist, this.accounts.additional]) {
+        await expectRevert(
+          this.genArt721Core
+            .connect(account)
+            .updateArtblocksDependencyRegistryAddress(
+              this.accounts.additional.address
+            ),
+          "Only Admin ACL allowed"
+        );
+      }
+      // admin allowed to update
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .updateArtblocksDependencyRegistryAddress(
+          this.accounts.additional.address
+        );
+    });
+  });
+
   describe("projectScriptDetails", function () {
     it("returns expected default values", async function () {
       const projectScriptDetails = await this.genArt721Core


### PR DESCRIPTION
Expose public addresses for prior Art Blocks flagship token addresses, as well as the new dependency and curation registries.

As opposed to a generalized key-value enumerable mapping, opted to concretely define the four references added in this PR. The dependency and curation registry references are updatable by Admin-ACL-allowed addresses only.

References for dependency and curation registries are intentionally left out of constructor because these addresses may not be known at the time of V3 core deployment.

Note that events will need to be emitted when curation and dependency addresses are updated, but those events will be added in a subsequent PR (when removing all required call handlers on V3 core).