### PR TITLE
Emit events on V3 to eliminate subgraph call handlers

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -47,7 +47,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     bytes32 constant FIELD_PROJECT_NAME = "name";
     bytes32 constant FIELD_ARTIST_NAME = "artistName";
     bytes32 constant FIELD_SECONDARY_MARKET_ROYALTY_PERCENTAGE =
-        "secondaryMarketRoyaltyPercentage";
+        "royaltyPercentage";
     bytes32 constant FIELD_PROJECT_DESCRIPTION = "description";
     bytes32 constant FIELD_PROJECT_WEBSITE = "website";
     bytes32 constant FIELD_PROJECT_LICENSE = "license";

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -16,8 +16,6 @@ pragma solidity 0.8.9;
  * @author Art Blocks Inc.
  */
 contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
-    event ProjectCompleted(uint256 indexed _projectId);
-
     event ProposedArtistAddressesAndSplits(
         uint256 indexed _projectId,
         address _artistAddress,
@@ -31,6 +29,34 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
 
     uint256 constant ONE_MILLION = 1_000_000;
     uint256 constant FOUR_WEEKS_IN_SECONDS = 2_419_200;
+
+    // generic platform event fields
+    bytes32 constant FIELD_ARTBLOCKS_ADDRESS = "artblocksAddress";
+    bytes32 constant FIELD_RANDOMIZER_ADDRESS = "randomizerAddress";
+    bytes32 constant FIELD_ARTBLOCKS_CURATION_REGISTRY_ADDRESS =
+        "curationRegistryAddress";
+    bytes32 constant FIELD_ARTBLOCKS_DEPENDENCY_REGISTRY_ADDRESS =
+        "dependencyRegistryAddress";
+    bytes32 constant FIELD_ARTBLOCKS_PERCENTAGE = "artblocksPercentage";
+    // generic project event fields
+    bytes32 constant FIELD_PROJECT_COMPLETED = "projectCompleted";
+    bytes32 constant FIELD_PROJECT_ACTIVE = "active";
+    bytes32 constant FIELD_ARTIST_ADDRESS = "artistAddress";
+    bytes32 constant FIELD_PROJECT_PAUSED = "paused";
+    bytes32 constant FIELD_PROJECT_CREATED = "created";
+    bytes32 constant FIELD_PROJECT_NAME = "projectName";
+    bytes32 constant FIELD_ARTIST_NAME = "artistName";
+    bytes32 constant FIELD_SECONDARY_MARKET_ROYALTY_PERCENTAGE =
+        "secondaryMarketRoyaltyPercentage";
+    bytes32 constant FIELD_PROJECT_DESCRIPTION = "projectDescription";
+    bytes32 constant FIELD_PROJECT_WEBSITE = "projectWebsite";
+    bytes32 constant FIELD_PROJECT_LICENSE = "projectLicense";
+    bytes32 constant FIELD_MAX_INVOCATIONS = "projectMaxInvocations";
+    bytes32 constant FIELD_PROJECT_SCRIPT_TOUCHED = "projectScriptTouched";
+    bytes32 constant FIELD_PROJECT_SCRIPT_TYPE = "projectScriptType";
+    bytes32 constant FIELD_PROJECT_ASPECT_RATIO = "projectAspectRatio";
+    bytes32 constant FIELD_PROJECT_IPFS_HASH = "projectIpfsHash";
+    bytes32 constant FIELD_PROJECT_BASE_URI = "projectBaseURI";
 
     /// Art Blocks previous flagship token addresses (for reference)
     address public constant ART_BLOCKS_TOKEN_ADDRESS_0 =
@@ -169,7 +195,9 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         address _adminACLContract
     ) ERC721(_tokenName, _tokenSymbol) {
         artblocksAddress = payable(msg.sender);
+        emit PlatformUpdated(FIELD_ARTBLOCKS_ADDRESS);
         randomizerContract = IRandomizer(_randomizerContract);
+        emit PlatformUpdated(FIELD_RANDOMIZER_ADDRESS);
         // set AdminACL management contract as owner
         _transferOwnership(_adminACLContract);
     }
@@ -292,7 +320,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
      */
     function _completeProject(uint256 _projectId) internal {
         projects[_projectId].completedTimestamp = block.timestamp;
-        emit ProjectCompleted(_projectId);
+        emit ProjectUpdated(_projectId, FIELD_PROJECT_COMPLETED);
     }
 
     /**
@@ -305,6 +333,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         onlyAdminACL(this.updateArtblocksCurationRegistryAddress.selector)
     {
         artblocksCurationRegistryAddress = _artblocksCurationRegistryAddress;
+        emit PlatformUpdated(FIELD_ARTBLOCKS_CURATION_REGISTRY_ADDRESS);
     }
 
     /**
@@ -317,6 +346,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         onlyAdminACL(this.updateArtblocksDependencyRegistryAddress.selector)
     {
         artblocksDependencyRegistryAddress = _artblocksDependencyRegistryAddress;
+        emit PlatformUpdated(FIELD_ARTBLOCKS_DEPENDENCY_REGISTRY_ADDRESS);
     }
 
     /**
@@ -327,6 +357,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         onlyAdminACL(this.updateArtblocksAddress.selector)
     {
         artblocksAddress = _artblocksAddress;
+        emit PlatformUpdated(FIELD_ARTBLOCKS_ADDRESS);
     }
 
     /**
@@ -339,6 +370,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     {
         require(_artblocksPercentage <= 25, "Max of 25%");
         artblocksPercentage = _artblocksPercentage;
+        emit PlatformUpdated(FIELD_ARTBLOCKS_PERCENTAGE);
     }
 
     /**
@@ -360,6 +392,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         onlyAdminACL(this.updateRandomizerAddress.selector)
     {
         randomizerContract = IRandomizer(_randomizerAddress);
+        emit PlatformUpdated(FIELD_RANDOMIZER_ADDRESS);
     }
 
     /**
@@ -370,6 +403,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         onlyAdminACL(this.toggleProjectIsActive.selector)
     {
         projects[_projectId].active = !projects[_projectId].active;
+        emit ProjectUpdated(_projectId, FIELD_PROJECT_ACTIVE);
     }
 
     /**
@@ -504,6 +538,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         address payable _artistAddress
     ) public onlyAdminACL(this.updateProjectArtistAddress.selector) {
         projectIdToArtistAddress[_projectId] = _artistAddress;
+        emit ProjectUpdated(_projectId, FIELD_ARTIST_ADDRESS);
     }
 
     /**
@@ -514,6 +549,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         onlyArtist(_projectId)
     {
         projects[_projectId].paused = !projects[_projectId].paused;
+        emit ProjectUpdated(_projectId, FIELD_PROJECT_PAUSED);
     }
 
     /**
@@ -533,6 +569,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         projects[projectId].maxInvocations = ONE_MILLION;
 
         nextProjectId = nextProjectId + 1;
+        emit ProjectUpdated(projectId, FIELD_PROJECT_CREATED);
     }
 
     /**
@@ -544,6 +581,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         onlyArtistOrAdminACL(_projectId, this.updateProjectName.selector)
     {
         projects[_projectId].name = _projectName;
+        emit ProjectUpdated(_projectId, FIELD_PROJECT_NAME);
     }
 
     /**
@@ -559,6 +597,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         onlyArtistOrAdminACL(_projectId, this.updateProjectArtistName.selector)
     {
         projects[_projectId].artist = _projectArtistName;
+        emit ProjectUpdated(_projectId, FIELD_ARTIST_NAME);
     }
 
     /**
@@ -580,6 +619,10 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         projectIdToSecondaryMarketRoyaltyPercentage[
             _projectId
         ] = _secondMarketRoyalty;
+        emit ProjectUpdated(
+            _projectId,
+            FIELD_SECONDARY_MARKET_ROYALTY_PERCENTAGE
+        );
     }
 
     /**
@@ -599,6 +642,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         );
         // effects
         projects[_projectId].description = _projectDescription;
+        emit ProjectUpdated(_projectId, FIELD_PROJECT_DESCRIPTION);
     }
 
     /**
@@ -609,6 +653,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         string memory _projectWebsite
     ) public onlyArtist(_projectId) {
         projects[_projectId].website = _projectWebsite;
+        emit ProjectUpdated(_projectId, FIELD_PROJECT_WEBSITE);
     }
 
     /**
@@ -623,6 +668,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         onlyArtistOrAdminACL(_projectId, this.updateProjectLicense.selector)
     {
         projects[_projectId].license = _projectLicense;
+        emit ProjectUpdated(_projectId, FIELD_PROJECT_LICENSE);
     }
 
     /**
@@ -647,6 +693,8 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         );
         // effects
         projects[_projectId].maxInvocations = _maxInvocations;
+        emit ProjectUpdated(_projectId, FIELD_MAX_INVOCATIONS);
+
         // register completed timestamp if action completed the project
         if (_maxInvocations == projects[_projectId].invocations) {
             _completeProject(_projectId);
@@ -667,6 +715,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
             projects[_projectId].scriptCount
         ] = _script;
         projects[_projectId].scriptCount = projects[_projectId].scriptCount + 1;
+        emit ProjectUpdated(_projectId, FIELD_PROJECT_SCRIPT_TOUCHED);
     }
 
     /**
@@ -689,6 +738,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
             "scriptId out of range"
         );
         projects[_projectId].scripts[_scriptId] = _script;
+        emit ProjectUpdated(_projectId, FIELD_PROJECT_SCRIPT_TOUCHED);
     }
 
     /**
@@ -707,6 +757,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
             projects[_projectId].scriptCount - 1
         ];
         projects[_projectId].scriptCount = projects[_projectId].scriptCount - 1;
+        emit ProjectUpdated(_projectId, FIELD_PROJECT_SCRIPT_TOUCHED);
     }
 
     /**
@@ -726,6 +777,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     {
         projects[_projectId].scriptType = _scriptType;
         projects[_projectId].scriptTypeVersion = _scriptTypeVersion;
+        emit ProjectUpdated(_projectId, FIELD_PROJECT_SCRIPT_TYPE);
     }
 
     /**
@@ -743,6 +795,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         onlyArtistOrAdminACL(_projectId, this.updateProjectAspectRatio.selector)
     {
         projects[_projectId].aspectRatio = _aspectRatio;
+        emit ProjectUpdated(_projectId, FIELD_PROJECT_ASPECT_RATIO);
     }
 
     /**
@@ -754,6 +807,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         onlyArtistOrAdminACL(_projectId, this.updateProjectIpfsHash.selector)
     {
         projects[_projectId].ipfsHash = _ipfsHash;
+        emit ProjectUpdated(_projectId, FIELD_PROJECT_IPFS_HASH);
     }
 
     /**
@@ -764,6 +818,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         onlyArtist(_projectId)
     {
         projects[_projectId].projectBaseURI = _newBaseURI;
+        emit ProjectUpdated(_projectId, FIELD_PROJECT_BASE_URI);
     }
 
     /**

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -39,24 +39,24 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         "dependencyRegistryAddress";
     bytes32 constant FIELD_ARTBLOCKS_PERCENTAGE = "artblocksPercentage";
     // generic project event fields
-    bytes32 constant FIELD_PROJECT_COMPLETED = "projectCompleted";
+    bytes32 constant FIELD_PROJECT_COMPLETED = "completed";
     bytes32 constant FIELD_PROJECT_ACTIVE = "active";
     bytes32 constant FIELD_ARTIST_ADDRESS = "artistAddress";
     bytes32 constant FIELD_PROJECT_PAUSED = "paused";
     bytes32 constant FIELD_PROJECT_CREATED = "created";
-    bytes32 constant FIELD_PROJECT_NAME = "projectName";
+    bytes32 constant FIELD_PROJECT_NAME = "name";
     bytes32 constant FIELD_ARTIST_NAME = "artistName";
     bytes32 constant FIELD_SECONDARY_MARKET_ROYALTY_PERCENTAGE =
         "secondaryMarketRoyaltyPercentage";
-    bytes32 constant FIELD_PROJECT_DESCRIPTION = "projectDescription";
-    bytes32 constant FIELD_PROJECT_WEBSITE = "projectWebsite";
-    bytes32 constant FIELD_PROJECT_LICENSE = "projectLicense";
-    bytes32 constant FIELD_MAX_INVOCATIONS = "projectMaxInvocations";
-    bytes32 constant FIELD_PROJECT_SCRIPT_TOUCHED = "projectScriptTouched";
-    bytes32 constant FIELD_PROJECT_SCRIPT_TYPE = "projectScriptType";
-    bytes32 constant FIELD_PROJECT_ASPECT_RATIO = "projectAspectRatio";
-    bytes32 constant FIELD_PROJECT_IPFS_HASH = "projectIpfsHash";
-    bytes32 constant FIELD_PROJECT_BASE_URI = "projectBaseURI";
+    bytes32 constant FIELD_PROJECT_DESCRIPTION = "description";
+    bytes32 constant FIELD_PROJECT_WEBSITE = "website";
+    bytes32 constant FIELD_PROJECT_LICENSE = "license";
+    bytes32 constant FIELD_MAX_INVOCATIONS = "maxInvocations";
+    bytes32 constant FIELD_PROJECT_SCRIPT = "script";
+    bytes32 constant FIELD_PROJECT_SCRIPT_TYPE = "scriptType";
+    bytes32 constant FIELD_PROJECT_ASPECT_RATIO = "aspectRatio";
+    bytes32 constant FIELD_PROJECT_IPFS_HASH = "ipfsHash";
+    bytes32 constant FIELD_PROJECT_BASE_URI = "baseURI";
 
     // Art Blocks previous flagship ERC721 token addresses (for reference)
     /// Art Blocks Project ID range: [0-2]
@@ -720,7 +720,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
             projects[_projectId].scriptCount
         ] = _script;
         projects[_projectId].scriptCount = projects[_projectId].scriptCount + 1;
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_SCRIPT_TOUCHED);
+        emit ProjectUpdated(_projectId, FIELD_PROJECT_SCRIPT);
     }
 
     /**
@@ -743,7 +743,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
             "scriptId out of range"
         );
         projects[_projectId].scripts[_scriptId] = _script;
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_SCRIPT_TOUCHED);
+        emit ProjectUpdated(_projectId, FIELD_PROJECT_SCRIPT);
     }
 
     /**
@@ -762,7 +762,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
             projects[_projectId].scriptCount - 1
         ];
         projects[_projectId].scriptCount = projects[_projectId].scriptCount - 1;
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_SCRIPT_TOUCHED);
+        emit ProjectUpdated(_projectId, FIELD_PROJECT_SCRIPT);
     }
 
     /**

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -196,10 +196,8 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         address _randomizerContract,
         address _adminACLContract
     ) ERC721(_tokenName, _tokenSymbol) {
-        artblocksAddress = payable(msg.sender);
-        emit PlatformUpdated(FIELD_ARTBLOCKS_ADDRESS);
-        randomizerContract = IRandomizer(_randomizerContract);
-        emit PlatformUpdated(FIELD_RANDOMIZER_ADDRESS);
+        _updateArtblocksAddress(msg.sender);
+        _updateRandomizerAddress(_randomizerContract);
         // set AdminACL management contract as owner
         _transferOwnership(_adminACLContract);
     }
@@ -213,6 +211,22 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     function _transferOwnership(address newOwner) internal override {
         Ownable._transferOwnership(newOwner);
         adminACLContract = IAdminACLV0(newOwner);
+    }
+
+    /**
+     * @notice Updates Art Blocks payment address to `_renderProviderAddress`.
+     */
+    function _updateArtblocksAddress(address _artblocksAddress) internal {
+        artblocksAddress = payable(_artblocksAddress);
+        emit PlatformUpdated(FIELD_ARTBLOCKS_ADDRESS);
+    }
+
+    /**
+     * @notice Updates randomizer address to `_randomizerAddress`.
+     */
+    function _updateRandomizerAddress(address _randomizerAddress) internal {
+        randomizerContract = IRandomizer(_randomizerAddress);
+        emit PlatformUpdated(FIELD_RANDOMIZER_ADDRESS);
     }
 
     /**
@@ -361,8 +375,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         public
         onlyAdminACL(this.updateArtblocksAddress.selector)
     {
-        artblocksAddress = _artblocksAddress;
-        emit PlatformUpdated(FIELD_ARTBLOCKS_ADDRESS);
+        _updateArtblocksAddress(_artblocksAddress);
     }
 
     /**
@@ -396,8 +409,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         public
         onlyAdminACL(this.updateRandomizerAddress.selector)
     {
-        randomizerContract = IRandomizer(_randomizerAddress);
-        emit PlatformUpdated(FIELD_RANDOMIZER_ADDRESS);
+        _updateRandomizerAddress(_randomizerAddress);
     }
 
     /**

--- a/contracts/V3_CHANGELOG.md
+++ b/contracts/V3_CHANGELOG.md
@@ -42,3 +42,6 @@ _This document is intended to document and explain the Art Blocks Core V3 change
   - This helps define the relationship between the V3 core contract and the V1 and V2 core contracts
 - Add public reference variables for the Art Blocks-managed Dependency and Curation registries
   - This helps more completely define, on-chain, the metadata and rendering dependencies of Art Blocks projects
+- Add events to all indexed platform and project state changes
+  - This is to improve the ability for clients to track changes to the platform and projects
+  - Specifically, this enables our subgraph indexing layer to avoid using less performant call handlers when tracking the state of the V3 core contract. Event handlers may now be used to fully define all state changes.

--- a/contracts/V3_CHANGELOG.md
+++ b/contracts/V3_CHANGELOG.md
@@ -42,6 +42,6 @@ _This document is intended to document and explain the Art Blocks Core V3 change
   - This helps define the relationship between the V3 core contract and the V1 and V2 core contracts
 - Add public reference variables for the Art Blocks-managed Dependency and Curation registries
   - This helps more completely define, on-chain, the metadata and rendering dependencies of Art Blocks projects
-- Add events to all indexed platform and project state changes
+- Add events for all indexed platform and project state changes
   - This is to improve the ability for clients to track changes to the platform and projects
   - Specifically, this enables our subgraph indexing layer to avoid using less performant call handlers when tracking the state of the V3 core contract. Event handlers may now be used to fully define all state changes.

--- a/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
+++ b/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
@@ -18,15 +18,15 @@ interface IGenArt721CoreContractV3 {
     event MinterUpdated(address indexed _currentMinter);
 
     /**
+     * @notice Platform updated on bytes32-encoded field `_field`.
+     */
+    event PlatformUpdated(bytes32 indexed _field);
+
+    /**
      * @notice Project ID `_projectId` updated on bytes32-encoded field
      * `_update`.
      */
     event ProjectUpdated(uint256 indexed _projectId, bytes32 indexed _update);
-
-    /**
-     * @notice Platform updated on bytes32-encoded field `_field`.
-     */
-    event PlatformUpdated(bytes32 indexed _field);
 
     // version and type of the core contract
     // coreVersion is a string of the form "0.x.y"

--- a/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
+++ b/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
@@ -21,12 +21,12 @@ interface IGenArt721CoreContractV3 {
      * @notice Project ID `_projectId` updated on bytes32-encoded field
      * `_update`.
      */
-    event ProjectUpdated(uint256 indexed _projectId, bytes32 _update);
+    event ProjectUpdated(uint256 indexed _projectId, bytes32 indexed _update);
 
     /**
      * @notice Platform updated on bytes32-encoded field `_field`.
      */
-    event PlatformUpdated(bytes32 _field);
+    event PlatformUpdated(bytes32 indexed _field);
 
     // version and type of the core contract
     // coreVersion is a string of the form "0.x.y"

--- a/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
+++ b/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
@@ -17,6 +17,17 @@ interface IGenArt721CoreContractV3 {
      */
     event MinterUpdated(address indexed _currentMinter);
 
+    /**
+     * @notice Project ID `_projectId` updated on bytes32-encoded field
+     * `_update`.
+     */
+    event ProjectUpdated(uint256 indexed _projectId, bytes32 _update);
+
+    /**
+     * @notice Platform updated on bytes32-encoded field `_field`.
+     */
+    event PlatformUpdated(bytes32 _field);
+
     // version and type of the core contract
     // coreVersion is a string of the form "0.x.y"
     function coreVersion() external view returns (string memory);

--- a/test/core/V3/GenArt721CoreV3_AdminACLRequests.test.ts
+++ b/test/core/V3/GenArt721CoreV3_AdminACLRequests.test.ts
@@ -13,7 +13,7 @@ import {
   getAccounts,
   assignDefaultConstants,
   deployAndGet,
-  fullyMintProject,
+  mintProjectUntilRemaining,
   advanceEVMByTime,
   deployCoreWithMinterFilter,
 } from "../../util/common";
@@ -209,7 +209,12 @@ describe("GenArt721CoreV3 AminACL Requests", async function () {
 
     it("updateProjectDescription", async function () {
       // admin may only call when in a locked state
-      await fullyMintProject.call(this, this.projectZero, this.accounts.artist);
+      await mintProjectUntilRemaining.call(
+        this,
+        this.projectZero,
+        this.accounts.artist,
+        0
+      );
       await advanceEVMByTime(FOUR_WEEKS + 1);
       // ensure admin requests expected selector
       await validateAdminACLRequest.call(this, "updateProjectDescription", [

--- a/test/core/V3/GenArt721CoreV3_Events.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Events.test.ts
@@ -69,35 +69,6 @@ describe("GenArt721CoreV3 Events", async function () {
       .addProject("name", this.accounts.artist2.address);
   });
 
-  describe("ProjectCompleted", function () {
-    it("emits ProjectCompleted when being minted out", async function () {
-      for (let i = 0; i < this.maxInvocations - 1; i++) {
-        await this.genArt721Core
-          .connect(this.accounts.artist)
-          .mint(
-            this.accounts.artist.address,
-            this.projectZero,
-            this.accounts.artist.address
-          );
-      }
-      // emits event when being minted out
-      expect(
-        await this.genArt721Core
-          .connect(this.accounts.artist)
-          .mint(
-            this.accounts.artist.address,
-            this.projectZero,
-            this.accounts.artist.address
-          )
-      )
-        .to.emit(this.genArt721Core, "ProjectUpdated")
-        .withArgs(
-          this.projectZero,
-          ethers.utils.formatBytes32String("completed")
-        );
-    });
-  });
-
   describe("MinterUpdated", function () {
     it("emits MinterUpdated when being updated", async function () {
       // emits expected event arg(s)

--- a/test/core/V3/GenArt721CoreV3_Events.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Events.test.ts
@@ -69,31 +69,34 @@ describe("GenArt721CoreV3 Events", async function () {
       .addProject("name", this.accounts.artist2.address);
   });
 
-  // describe("ProjectCompleted", function () {
-  //   it("emits ProjectCompleted when being minted out", async function () {
-  //     for (let i = 0; i < this.maxInvocations - 1; i++) {
-  //       await this.genArt721Core
-  //         .connect(this.accounts.artist)
-  //         .mint(
-  //           this.accounts.artist.address,
-  //           this.projectZero,
-  //           this.accounts.artist.address
-  //         );
-  //     }
-  //     // emits event when being minted out
-  //     expect(
-  //       await this.genArt721Core
-  //         .connect(this.accounts.artist)
-  //         .mint(
-  //           this.accounts.artist.address,
-  //           this.projectZero,
-  //           this.accounts.artist.address
-  //         )
-  //     )
-  //       .to.emit(this.genArt721Core, "ProjectCompleted")
-  //       .withArgs(this.projectZero);
-  //   });
-  // });
+  describe("ProjectCompleted", function () {
+    it("emits ProjectCompleted when being minted out", async function () {
+      for (let i = 0; i < this.maxInvocations - 1; i++) {
+        await this.genArt721Core
+          .connect(this.accounts.artist)
+          .mint(
+            this.accounts.artist.address,
+            this.projectZero,
+            this.accounts.artist.address
+          );
+      }
+      // emits event when being minted out
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.artist)
+          .mint(
+            this.accounts.artist.address,
+            this.projectZero,
+            this.accounts.artist.address
+          )
+      )
+        .to.emit(this.genArt721Core, "ProjectUpdated")
+        .withArgs(
+          this.projectZero,
+          ethers.utils.formatBytes32String("completed")
+        );
+    });
+  });
 
   describe("MinterUpdated", function () {
     it("emits MinterUpdated when being updated", async function () {

--- a/test/core/V3/GenArt721CoreV3_Events.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Events.test.ts
@@ -67,29 +67,53 @@ describe("GenArt721CoreV3 Events", async function () {
       .addProject("name", this.accounts.artist2.address);
   });
 
-  describe("ProjectCompleted", function () {
-    it("emits ProjectCompleted when being minted out", async function () {
-      for (let i = 0; i < this.maxInvocations - 1; i++) {
-        await this.genArt721Core
-          .connect(this.accounts.artist)
-          .mint(
-            this.accounts.artist.address,
-            this.projectZero,
-            this.accounts.artist.address
-          );
-      }
-      // emits event when being minted out
+  // describe("ProjectCompleted", function () {
+  //   it("emits ProjectCompleted when being minted out", async function () {
+  //     for (let i = 0; i < this.maxInvocations - 1; i++) {
+  //       await this.genArt721Core
+  //         .connect(this.accounts.artist)
+  //         .mint(
+  //           this.accounts.artist.address,
+  //           this.projectZero,
+  //           this.accounts.artist.address
+  //         );
+  //     }
+  //     // emits event when being minted out
+  //     expect(
+  //       await this.genArt721Core
+  //         .connect(this.accounts.artist)
+  //         .mint(
+  //           this.accounts.artist.address,
+  //           this.projectZero,
+  //           this.accounts.artist.address
+  //         )
+  //     )
+  //       .to.emit(this.genArt721Core, "ProjectCompleted")
+  //       .withArgs(this.projectZero);
+  //   });
+  // });
+
+  describe("PlatformUpdated", function () {
+    it("emits artblocksAddress", async function () {
+      // emits expected event arg(s)
       expect(
         await this.genArt721Core
-          .connect(this.accounts.artist)
-          .mint(
-            this.accounts.artist.address,
-            this.projectZero,
-            this.accounts.artist.address
-          )
+          .connect(this.accounts.deployer)
+          .updateArtblocksAddress(this.accounts.artist.address)
       )
-        .to.emit(this.genArt721Core, "ProjectCompleted")
-        .withArgs(this.projectZero);
+        .to.emit(this.genArt721Core, "PlatformUpdated")
+        .withArgs(ethers.utils.formatBytes32String("artblocksAddress"));
+    });
+
+    it("emits 'randomizerAddress'", async function () {
+      // emits expected event arg(s)
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.deployer)
+          .updateRandomizerAddress(this.accounts.artist.address)
+      )
+        .to.emit(this.genArt721Core, "PlatformUpdated")
+        .withArgs(ethers.utils.formatBytes32String("randomizerAddress"));
     });
   });
 });

--- a/test/core/V3/GenArt721CoreV3_Events.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Events.test.ts
@@ -14,6 +14,8 @@ import {
   assignDefaultConstants,
   deployAndGet,
   deployCoreWithMinterFilter,
+  mintProjectUntilRemaining,
+  advanceEVMByTime,
 } from "../../util/common";
 
 /**
@@ -93,6 +95,19 @@ describe("GenArt721CoreV3 Events", async function () {
   //   });
   // });
 
+  describe("MinterUpdated", function () {
+    it("emits MinterUpdated when being updated", async function () {
+      // emits expected event arg(s)
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.deployer)
+          .updateMinterContract(this.accounts.deployer.address)
+      )
+        .to.emit(this.genArt721Core, "MinterUpdated")
+        .withArgs(this.accounts.deployer.address);
+    });
+  });
+
   describe("PlatformUpdated", function () {
     it("emits artblocksAddress", async function () {
       // emits expected event arg(s)
@@ -114,6 +129,313 @@ describe("GenArt721CoreV3 Events", async function () {
       )
         .to.emit(this.genArt721Core, "PlatformUpdated")
         .withArgs(ethers.utils.formatBytes32String("randomizerAddress"));
+    });
+
+    it("emits 'curationRegistryAddress'", async function () {
+      // emits expected event arg(s)
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.deployer)
+          .updateArtblocksCurationRegistryAddress(this.accounts.artist.address)
+      )
+        .to.emit(this.genArt721Core, "PlatformUpdated")
+        .withArgs(ethers.utils.formatBytes32String("curationRegistryAddress"));
+    });
+
+    it("emits 'dependencyRegistryAddress'", async function () {
+      // emits expected event arg(s)
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.deployer)
+          .updateArtblocksDependencyRegistryAddress(
+            this.accounts.artist.address
+          )
+      )
+        .to.emit(this.genArt721Core, "PlatformUpdated")
+        .withArgs(
+          ethers.utils.formatBytes32String("dependencyRegistryAddress")
+        );
+    });
+
+    it("emits 'artblocksPercentage'", async function () {
+      // emits expected event arg(s)
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.deployer)
+          .updateArtblocksPercentage(11)
+      )
+        .to.emit(this.genArt721Core, "PlatformUpdated")
+        .withArgs(ethers.utils.formatBytes32String("artblocksPercentage"));
+    });
+  });
+
+  describe("ProjectUpdated", function () {
+    it("emits completed", async function () {
+      await mintProjectUntilRemaining.call(
+        this,
+        this.projectZero,
+        this.accounts.artist,
+        1
+      );
+      // emits expected event arg(s) when completing project
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.artist)
+          .mint(
+            this.accounts.artist.address,
+            this.projectZero,
+            this.accounts.artist.address
+          )
+      )
+        .to.emit(this.genArt721Core, "ProjectUpdated")
+        .withArgs(
+          this.projectZero,
+          ethers.utils.formatBytes32String("completed")
+        );
+    });
+
+    it("emits active", async function () {
+      // emits expected event arg(s) when toggling project inactive
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.deployer)
+          .toggleProjectIsActive(this.projectZero)
+      )
+        .to.emit(this.genArt721Core, "ProjectUpdated")
+        .withArgs(this.projectZero, ethers.utils.formatBytes32String("active"));
+      // emits expected event arg(s) when toggling project active
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.deployer)
+          .toggleProjectIsActive(this.projectZero)
+      )
+        .to.emit(this.genArt721Core, "ProjectUpdated")
+        .withArgs(this.projectZero, ethers.utils.formatBytes32String("active"));
+    });
+
+    it("emits artistAddress", async function () {
+      // emits expected event arg(s)
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.deployer)
+          .updateProjectArtistAddress(
+            this.projectZero,
+            this.accounts.artist2.address
+          )
+      )
+        .to.emit(this.genArt721Core, "ProjectUpdated")
+        .withArgs(
+          this.projectZero,
+          ethers.utils.formatBytes32String("artistAddress")
+        );
+    });
+
+    it("emits paused", async function () {
+      // emits expected event arg(s)
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.artist)
+          .toggleProjectIsPaused(this.projectZero)
+      )
+        .to.emit(this.genArt721Core, "ProjectUpdated")
+        .withArgs(this.projectZero, ethers.utils.formatBytes32String("paused"));
+    });
+
+    it("emits created", async function () {
+      // emits expected event arg(s)
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.deployer)
+          .addProject("new project", this.accounts.artist.address)
+      )
+        .to.emit(this.genArt721Core, "ProjectUpdated")
+        .withArgs(this.projectTwo, ethers.utils.formatBytes32String("created"));
+    });
+
+    it("emits name", async function () {
+      // emits expected event arg(s)
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.deployer)
+          .updateProjectName(this.projectZero, "new project name")
+      )
+        .to.emit(this.genArt721Core, "ProjectUpdated")
+        .withArgs(this.projectZero, ethers.utils.formatBytes32String("name"));
+    });
+
+    it("emits artistName", async function () {
+      // emits expected event arg(s)
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.deployer)
+          .updateProjectArtistName(this.projectZero, "new artist name")
+      )
+        .to.emit(this.genArt721Core, "ProjectUpdated")
+        .withArgs(
+          this.projectZero,
+          ethers.utils.formatBytes32String("artistName")
+        );
+    });
+
+    it("emits secondaryMarketRoyaltyPercentage", async function () {
+      // emits expected event arg(s)
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.artist)
+          .updateProjectSecondaryMarketRoyaltyPercentage(this.projectZero, 10)
+      )
+        .to.emit(this.genArt721Core, "ProjectUpdated")
+        .withArgs(
+          this.projectZero,
+          ethers.utils.formatBytes32String("royaltyPercentage")
+        );
+    });
+
+    it("emits description", async function () {
+      // emits expected event arg(s)
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.artist)
+          .updateProjectDescription(this.projectZero, "new description")
+      )
+        .to.emit(this.genArt721Core, "ProjectUpdated")
+        .withArgs(
+          this.projectZero,
+          ethers.utils.formatBytes32String("description")
+        );
+    });
+
+    it("emits website", async function () {
+      // emits expected event arg(s)
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.artist)
+          .updateProjectWebsite(this.projectZero, "new website")
+      )
+        .to.emit(this.genArt721Core, "ProjectUpdated")
+        .withArgs(
+          this.projectZero,
+          ethers.utils.formatBytes32String("website")
+        );
+    });
+
+    it("emits license", async function () {
+      // emits expected event arg(s)
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.artist)
+          .updateProjectLicense(this.projectZero, "new license")
+      )
+        .to.emit(this.genArt721Core, "ProjectUpdated")
+        .withArgs(
+          this.projectZero,
+          ethers.utils.formatBytes32String("license")
+        );
+    });
+
+    it("emits maxInvocations", async function () {
+      // emits expected event arg(s)
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.artist)
+          .updateProjectMaxInvocations(this.projectZero, 10)
+      )
+        .to.emit(this.genArt721Core, "ProjectUpdated")
+        .withArgs(
+          this.projectZero,
+          ethers.utils.formatBytes32String("maxInvocations")
+        );
+    });
+
+    it("emits script when adding/editing/removing script", async function () {
+      // emits expected event arg(s)
+      // add script
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.artist)
+          .addProjectScript(this.projectZero, `console.log("hello world")`)
+      )
+        .to.emit(this.genArt721Core, "ProjectUpdated")
+        .withArgs(this.projectZero, ethers.utils.formatBytes32String("script"));
+      // edit script
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.artist)
+          .updateProjectScript(
+            this.projectZero,
+            0,
+            `console.log("hello world 2")`
+          )
+      )
+        .to.emit(this.genArt721Core, "ProjectUpdated")
+        .withArgs(this.projectZero, ethers.utils.formatBytes32String("script"));
+      // remove script
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.artist)
+          .removeProjectLastScript(this.projectZero)
+      )
+        .to.emit(this.genArt721Core, "ProjectUpdated")
+        .withArgs(this.projectZero, ethers.utils.formatBytes32String("script"));
+    });
+
+    it("emits scriptType", async function () {
+      // emits expected event arg(s)
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.artist)
+          .updateProjectScriptType(this.projectZero, "p5js", "v1.2.3")
+      )
+        .to.emit(this.genArt721Core, "ProjectUpdated")
+        .withArgs(
+          this.projectZero,
+          ethers.utils.formatBytes32String("scriptType")
+        );
+    });
+
+    it("emits aspectRatio", async function () {
+      // emits expected event arg(s)
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.artist)
+          .updateProjectAspectRatio(this.projectZero, "1.77777778")
+      )
+        .to.emit(this.genArt721Core, "ProjectUpdated")
+        .withArgs(
+          this.projectZero,
+          ethers.utils.formatBytes32String("aspectRatio")
+        );
+    });
+
+    it("emits ipfsHash", async function () {
+      // emits expected event arg(s)
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.artist)
+          .updateProjectIpfsHash(this.projectZero, "ipfsHash")
+      )
+        .to.emit(this.genArt721Core, "ProjectUpdated")
+        .withArgs(
+          this.projectZero,
+          ethers.utils.formatBytes32String("ipfsHash")
+        );
+    });
+
+    it("emits baseURI", async function () {
+      // emits expected event arg(s)
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.artist)
+          .updateProjectBaseURI(
+            this.projectZero,
+            "https://newbaseuri.com/token/"
+          )
+      )
+        .to.emit(this.genArt721Core, "ProjectUpdated")
+        .withArgs(
+          this.projectZero,
+          ethers.utils.formatBytes32String("baseURI")
+        );
     });
   });
 });

--- a/test/core/V3/GenArt721CoreV3_Integration.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Integration.test.ts
@@ -15,7 +15,7 @@ import {
   assignDefaultConstants,
   deployAndGet,
   deployCoreWithMinterFilter,
-  fullyMintProject,
+  mintProjectUntilRemaining,
   advanceEVMByTime,
 } from "../../util/common";
 import { FOUR_WEEKS } from "../../util/constants";
@@ -154,7 +154,12 @@ describe("GenArt721CoreV3 Integration", async function () {
 
   describe("reverts on project locked", async function () {
     it("reverts if try to add script", async function () {
-      await fullyMintProject.call(this, this.projectZero, this.accounts.artist);
+      await mintProjectUntilRemaining.call(
+        this,
+        this.projectZero,
+        this.accounts.artist,
+        0
+      );
       // wait until project is locked
       await advanceEVMByTime(FOUR_WEEKS + 1);
       // expect revert

--- a/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
+++ b/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
@@ -14,7 +14,7 @@ import {
   assignDefaultConstants,
   deployAndGet,
   deployCoreWithMinterFilter,
-  fullyMintProject,
+  mintProjectUntilRemaining,
   advanceEVMByTime,
 } from "../../util/common";
 import { FOUR_WEEKS } from "../../util/constants";
@@ -257,7 +257,12 @@ describe("GenArt721CoreV3 Project Configure", async function () {
     });
 
     it("owner can update when locked", async function () {
-      await fullyMintProject.call(this, this.projectZero, this.accounts.artist);
+      await mintProjectUntilRemaining.call(
+        this,
+        this.projectZero,
+        this.accounts.artist,
+        0
+      );
       await advanceEVMByTime(FOUR_WEEKS + 1);
       await this.genArt721Core
         .connect(this.accounts.deployer)
@@ -270,7 +275,12 @@ describe("GenArt721CoreV3 Project Configure", async function () {
     });
 
     it("artist cannot update when locked", async function () {
-      await fullyMintProject.call(this, this.projectZero, this.accounts.artist);
+      await mintProjectUntilRemaining.call(
+        this,
+        this.projectZero,
+        this.accounts.artist,
+        0
+      );
       await advanceEVMByTime(FOUR_WEEKS + 1);
       await expectRevert(
         this.genArt721Core

--- a/test/core/V3/GenArt721CoreV3_Views.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Views.test.ts
@@ -75,22 +75,22 @@ describe("GenArt721CoreV3 Views", async function () {
     });
   });
 
-  describe("ART_BLOCKS_TOKEN_ADDRESS_0", function () {
+  describe("ART_BLOCKS_ERC721TOKEN_ADDRESS_V0", function () {
     it("returns expected value", async function () {
       const reference = await this.genArt721Core
         .connect(this.accounts.deployer)
-        .ART_BLOCKS_TOKEN_ADDRESS_0();
+        .ART_BLOCKS_ERC721TOKEN_ADDRESS_V0();
       expect(reference).to.be.equal(
         "0x059EDD72Cd353dF5106D2B9cC5ab83a52287aC3a"
       );
     });
   });
 
-  describe("ART_BLOCKS_TOKEN_ADDRESS_1", function () {
+  describe("ART_BLOCKS_ERC721TOKEN_ADDRESS_V1", function () {
     it("returns expected value", async function () {
       const reference = await this.genArt721Core
         .connect(this.accounts.deployer)
-        .ART_BLOCKS_TOKEN_ADDRESS_1();
+        .ART_BLOCKS_ERC721TOKEN_ADDRESS_V1();
       expect(reference).to.be.equal(
         "0xa7d8d9ef8D8Ce8992Df33D8b8CF4Aebabd5bD270"
       );

--- a/test/util/common.ts
+++ b/test/util/common.ts
@@ -114,11 +114,12 @@ export async function safeAddProject(
   }
 }
 
-export async function fullyMintProject(
+export async function mintProjectUntilRemaining(
   _projectId: BN,
-  _minterAccount: SignerWithAddress
+  _minterAccount: SignerWithAddress,
+  _leaveRemainingInvocations: number = 0
 ) {
-  for (let i = 0; i < this.maxInvocations; i++) {
+  for (let i = 0; i < this.maxInvocations - _leaveRemainingInvocations; i++) {
     await this.genArt721Core
       .connect(_minterAccount)
       .mint(_minterAccount.address, _projectId, _minterAccount.address);


### PR DESCRIPTION
_(update - #213 will not be merged) Commonality was retained as much as possible with respect to a similar update on our V2 contract in PR #213 (Cc @lyaunzbe )._

Emit events for all indexed platform and project state changes on V3 core contract.

This change enables our subgraph indexing layer to completely avoid using less performant call handlers when tracking state of the V3 core contract.

In general, bytes32-encoded strings are used to flag which field has been updated. This is more gas performant than strings (thanks to a pre-defined upper-limit on length of bytes instead of an arbitrary length of bytes that must be reported for strings). Plenty of library support for converting bytes32-encoded strings to strings (see https://docs.ethers.io/v5/api/utils/strings/#utils-parseBytes32)

We have opted to only include the field name that was updated instead of also including the field value to both reduce the number of events that must be included on the contract, and reduce the quantity of bytes being emitted. We expose all data that is being updated via public view functions, so our subgraph indexers may query our contract directly for the updated state information.

Note that if an array field is updated, such as the project script, it must be entirely re-synced in our subgraph. This is because the subgraph can only query for the updated contract at the end of a given block, and many updates may occur in separate transactions in a single block. Because a full re-sync is required in the subgraph whenever a script is added, removed, or deleted, a single "projectScriptTouched" field flag is emitted for any of the three actions to indicate that a full re-sync is required (i.e. the required subgraph action is the same for any of the three operations).

## Design Alternatives
The event `MinterUpdated` could be an operation included in the `PlatformUpdated` event. However, because Minters being updated are a very important event that has a lot of downstream impacts, keeping it as its own event that defines the new minter address event seemed prudent. Additionally, a very-unexpected edge case where the minter is updated twice in the same block with some operations in-between the transactions could lead to state errors in our subgraph if we don't include the minter address in the event (this is due to the limitation of the subgraph only being able to query the contract state at the end of the block instead of understanding the intermediate state). That is never expected to happen, and is probably not reason enough to give `MinterUpdated` and event on its own - this is more to enable users and integrators to more-easily understand the state when our minter is updated, which is an important and rare event.