### PR TITLE
Get revenue splits view on v3 core

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -1067,19 +1067,20 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     {
         recipients_ = new address payable[](3);
         revenues_ = new uint256[](3);
-        // Art Blocks
-        recipients_[2] = artblocksAddress;
+        // calculate revenues
         uint256 _artblocksRevenue = (_price * artblocksPercentage) / 100;
-        revenues_[2] = (_price * artblocksPercentage) / 100;
-        // additional payee
-        recipients_[1] = projectIdToAdditionalPayeePrimarySales[_projectId];
         uint256 _projectFunds = _price - _artblocksRevenue;
         uint256 _additionalPayeeRevenue = (_projectFunds *
             projectIdToAdditionalPayeePrimarySalesPercentage[_projectId]) / 100;
-        revenues_[1] = _additionalPayeeRevenue;
-        // artist
+        // Artist
         recipients_[0] = projectIdToArtistAddress[_projectId];
         revenues_[0] = _projectFunds - _additionalPayeeRevenue;
+        // Additional Payee for primary sales
+        recipients_[1] = projectIdToAdditionalPayeePrimarySales[_projectId];
+        revenues_[1] = _additionalPayeeRevenue;
+        // Art Blocks
+        recipients_[2] = artblocksAddress;
+        revenues_[2] = _artblocksRevenue;
     }
 
     /**

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -1040,6 +1040,49 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     }
 
     /**
+     * @notice View function that returns appropriate revenue splits between
+     * different parties given a sale price of `_price` on project
+     * `_projectId`. Prescribes a split between project artist, additional
+     * primary payee, and Art Blocks. Does not account for refund if user
+     * overpays for a token (minter should refund the difference).
+     * Some minters may have alternative methods of splitting payments, in
+     * which case they should implement their own payment splitting logic.
+     * @param _projectId Project ID to be queried.
+     * @param _price Sale price of token.
+     * @return recipients_ Array of recipient addresses, always in the order
+     * [artist, additionalPayeePrimarySales, artblocksAddress]
+     * @return revenues_ Array of recipient addresses, always in the order
+     * [artistRevenue, additionalPayeePrimarySalesRevenue, artblocksRevenue]
+     * @dev this always returns three addresses and three revenues, but the
+     * revenue could be zero for one or more of the addresses. It is up to the
+     * contract performing the revenue split to handle this appropriately.
+     */
+    function getPrimaryRevenueSplits(uint256 _projectId, uint256 _price)
+        external
+        view
+        returns (
+            address payable[] memory recipients_,
+            uint256[] memory revenues_
+        )
+    {
+        recipients_ = new address payable[](3);
+        revenues_ = new uint256[](3);
+        // Art Blocks
+        recipients_[2] = artblocksAddress;
+        uint256 _artblocksRevenue = (_price * artblocksPercentage) / 100;
+        revenues_[2] = (_price * artblocksPercentage) / 100;
+        // additional payee
+        recipients_[1] = projectIdToAdditionalPayeePrimarySales[_projectId];
+        uint256 _projectFunds = _price - _artblocksRevenue;
+        uint256 _additionalPayeeRevenue = (_projectFunds *
+            projectIdToAdditionalPayeePrimarySalesPercentage[_projectId]) / 100;
+        revenues_[1] = _additionalPayeeRevenue;
+        // artist
+        recipients_[0] = projectIdToArtistAddress[_projectId];
+        revenues_[0] = _projectFunds - _additionalPayeeRevenue;
+    }
+
+    /**
      * @notice Returns contract owner. Set to deployer's address by default on
      * contract deployment.
      * @dev ref: https://docs.openzeppelin.com/contracts/4.x/api/access#Ownable

--- a/contracts/V3_CHANGELOG.md
+++ b/contracts/V3_CHANGELOG.md
@@ -45,3 +45,6 @@ _This document is intended to document and explain the Art Blocks Core V3 change
 - Add events for all indexed platform and project state changes
   - This is to improve the ability for clients to track changes to the platform and projects
   - Specifically, this enables our subgraph indexing layer to avoid using less performant call handlers when tracking the state of the V3 core contract. Event handlers may now be used to fully define all state changes.
+- Add split revenues view function on core for primary sales
+  - This offloads often-repeated primary sale payment splitting logic from V3's minter contracts onto the V3 core contract.
+  - Placing splitter logic on core is preferred over creating something like a "common mint functions" external contract, because it avoids extra gas costs associated with EIP-2929 and calling cold addresses.

--- a/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
+++ b/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
@@ -72,6 +72,15 @@ interface IGenArt721CoreContractV3 {
     ) external view returns (uint256);
 
     // @dev new function in V3
+    function getPrimaryRevenueSplits(uint256 _projectId, uint256 _price)
+        external
+        view
+        returns (
+            address payable[] memory recipients_,
+            uint256[] memory revenues_
+        );
+
+    // @dev new function in V3
     function projectStateData(uint256 _projectId)
         external
         view

--- a/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
+++ b/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
@@ -85,11 +85,11 @@ interface IGenArt721CoreContractV3 {
         external
         view
         returns (
-            uint256,
-            uint256,
-            bool,
-            bool,
-            bool
+            uint256 invocations,
+            uint256 maxInvocations,
+            bool active,
+            bool paused,
+            bool locked
         );
 
     function artblocksAddress() external view returns (address payable);

--- a/test/core/V3/GenArt721CoreV3_Views.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Views.test.ts
@@ -345,4 +345,101 @@ describe("GenArt721CoreV3 Views", async function () {
       ).to.be.equal(valuesToUpdateTo[5]);
     });
   });
+
+  describe("getPrimaryRevenueSplits", function () {
+    it("returns expected values for projectZero", async function () {
+      const revenueSplits = await this.genArt721Core
+        .connect(this.accounts.user)
+        .getPrimaryRevenueSplits(
+          this.projectZero,
+          ethers.utils.parseEther("1")
+        );
+      // expect revenue splits to be properly calculated
+      // Art Blocks
+      const artblocksAddress = await this.genArt721Core.artblocksAddress();
+      expect(revenueSplits.recipients_[2]).to.be.equal(artblocksAddress);
+      expect(revenueSplits.revenues_[2]).to.be.equal(
+        ethers.utils.parseEther("0.10")
+      );
+      // Additional Payee
+      const additionalPayeePrimarySalesAddress =
+        await this.genArt721Core.projectIdToAdditionalPayeePrimarySales(
+          this.projectZero
+        );
+      expect(revenueSplits.recipients_[1]).to.be.equal(
+        additionalPayeePrimarySalesAddress
+      );
+      expect(revenueSplits.revenues_[1]).to.be.equal(
+        ethers.utils.parseEther("0")
+      );
+      // Artist
+      const artistAddress = await this.genArt721Core.projectIdToArtistAddress(
+        this.projectZero
+      );
+      expect(revenueSplits.recipients_[0]).to.be.equal(artistAddress);
+      expect(revenueSplits.revenues_[0]).to.be.equal(
+        ethers.utils.parseEther("0.90")
+      );
+    });
+
+    it("returns expected values for projectOne, with updated payment addresses and percentages", async function () {
+      // add project
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .addProject("name", this.accounts.artist2.address);
+      // artist2 populates an addditional payee
+      const proposeArtistPaymentAddressesAndSplitsArgs = [
+        this.projectOne,
+        this.accounts.artist2.address,
+        this.accounts.additional2.address,
+        51,
+        this.accounts.user2.address,
+        0,
+      ];
+      await this.genArt721Core
+        .connect(this.accounts.artist2)
+        .proposeArtistPaymentAddressesAndSplits(
+          ...proposeArtistPaymentAddressesAndSplitsArgs
+        );
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .adminAcceptArtistAddressesAndSplits(
+          ...proposeArtistPaymentAddressesAndSplitsArgs
+        );
+      // update Art Blocks percentage to 20%
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .updateArtblocksPercentage(20);
+      // change Art Blocks payment address to random address
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .updateArtblocksAddress(this.accounts.user.address);
+      // check for expected values
+      const revenueSplits = await this.genArt721Core
+        .connect(this.accounts.user)
+        .getPrimaryRevenueSplits(this.projectOne, ethers.utils.parseEther("1"));
+      // expect revenue splits to be properly calculated
+      // Art Blocks
+      expect(revenueSplits.recipients_[2]).to.be.equal(
+        this.accounts.user.address
+      );
+      expect(revenueSplits.revenues_[2]).to.be.equal(
+        ethers.utils.parseEther("0.20")
+      );
+      // Additional Payee (0.8 * 0.51 = 0.408)
+      expect(revenueSplits.recipients_[1]).to.be.equal(
+        proposeArtistPaymentAddressesAndSplitsArgs[2]
+      );
+      expect(revenueSplits.revenues_[1]).to.be.equal(
+        ethers.utils.parseEther("0.408")
+      );
+      // Artist (0.8 * 0.51 = 0.392)
+      expect(revenueSplits.recipients_[0]).to.be.equal(
+        proposeArtistPaymentAddressesAndSplitsArgs[1]
+      );
+      expect(revenueSplits.revenues_[0]).to.be.equal(
+        ethers.utils.parseEther("0.392")
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Only merge after #220 

Add an external view function on V3 core that minters may query while splitting primary sales revenues.

This offloads the often-repeated primary sale payment splitting logic from V3's minter contracts onto the V3 core itself. Placing the payment splitting logic on the core makes sense because the core contract has already been called during a purchase (see costs associated with cold (initial) contract call in [EIP-2929](https://eips.ethereum.org/EIPS/eip-2929)). _(note: this update may very slightly increase or decrease gas costs to split a token's payment, can quantify when minters are updated to work with V3)_

Tests are added for this new payment splitting logic.