### PR TITLE
V3-compatible minters use V3 core revenue splitting logic

### DIFF
--- a/contracts/minter-suite/Minters/MinterDALin/MinterDALinV2.sol
+++ b/contracts/minter-suite/Minters/MinterDALin/MinterDALinV2.sol
@@ -299,47 +299,36 @@ contract MinterDALinV2 is ReentrancyGuard, IFilteredMinterV0 {
         uint256 _currentPriceInWei
     ) internal {
         if (msg.value > 0) {
+            bool success_;
+            // send refund to sender
             uint256 refund = msg.value - _currentPriceInWei;
             if (refund > 0) {
-                (bool success_, ) = msg.sender.call{value: refund}("");
+                (success_, ) = msg.sender.call{value: refund}("");
                 require(success_, "Refund failed");
             }
-            uint256 foundationAmount = (_currentPriceInWei *
-                genArtCoreContract.artblocksPercentage()) / 100;
-            if (foundationAmount > 0) {
-                (bool success_, ) = genArtCoreContract.artblocksAddress().call{
-                    value: foundationAmount
-                }("");
-                require(success_, "Foundation payment failed");
-            }
-            uint256 projectFunds = _currentPriceInWei - foundationAmount;
-            uint256 additionalPayeeAmount;
-            if (
-                genArtCoreContract
-                    .projectIdToAdditionalPayeePrimarySalesPercentage(
-                        _projectId
-                    ) > 0
-            ) {
-                additionalPayeeAmount =
-                    (projectFunds *
-                        genArtCoreContract
-                            .projectIdToAdditionalPayeePrimarySalesPercentage(
-                                _projectId
-                            )) /
-                    100;
-                if (additionalPayeeAmount > 0) {
-                    (bool success_, ) = genArtCoreContract
-                        .projectIdToAdditionalPayeePrimarySales(_projectId)
-                        .call{value: additionalPayeeAmount}("");
-                    require(success_, "Additional payment failed");
-                }
-            }
-            uint256 creatorFunds = projectFunds - additionalPayeeAmount;
-            if (creatorFunds > 0) {
-                (bool success_, ) = genArtCoreContract
-                    .projectIdToArtistAddress(_projectId)
-                    .call{value: creatorFunds}("");
+            // split remaining funds between foundation, artist, and artist's
+            // additional payee
+            (
+                address payable[] memory recipients_,
+                uint256[] memory revenues_
+            ) = genArtCoreContract.getPrimaryRevenueSplits(
+                    _projectId,
+                    _currentPriceInWei
+                );
+            // artist payment
+            if (revenues_[0] > 0) {
+                (success_, ) = recipients_[0].call{value: revenues_[0]}("");
                 require(success_, "Artist payment failed");
+            }
+            // additional payee payment
+            if (revenues_[1] > 0) {
+                (success_, ) = recipients_[1].call{value: revenues_[1]}("");
+                require(success_, "Additional Payee payment failed");
+            }
+            // Art Blocks payment
+            if (revenues_[2] > 0) {
+                (success_, ) = recipients_[2].call{value: revenues_[2]}("");
+                require(success_, "Art Blocks payment failed");
             }
         }
     }

--- a/contracts/minter-suite/Minters/MinterHolder/MinterHolderV1.sol
+++ b/contracts/minter-suite/Minters/MinterHolder/MinterHolderV1.sol
@@ -486,50 +486,39 @@ contract MinterHolderV1 is ReentrancyGuard, IFilteredMinterHolderV0 {
      */
     function _splitFundsETH(uint256 _projectId) internal {
         if (msg.value > 0) {
+            bool success_;
+            // send refund to sender
             uint256 pricePerTokenInWei = projectIdToPricePerTokenInWei[
                 _projectId
             ];
             uint256 refund = msg.value - pricePerTokenInWei;
             if (refund > 0) {
-                (bool success_, ) = msg.sender.call{value: refund}("");
+                (success_, ) = msg.sender.call{value: refund}("");
                 require(success_, "Refund failed");
             }
-            uint256 foundationAmount = (pricePerTokenInWei *
-                genArtCoreContract.artblocksPercentage()) / 100;
-            if (foundationAmount > 0) {
-                (bool success_, ) = genArtCoreContract.artblocksAddress().call{
-                    value: foundationAmount
-                }("");
-                require(success_, "Foundation payment failed");
-            }
-            uint256 projectFunds = pricePerTokenInWei - foundationAmount;
-            uint256 additionalPayeeAmount;
-            if (
-                genArtCoreContract
-                    .projectIdToAdditionalPayeePrimarySalesPercentage(
-                        _projectId
-                    ) > 0
-            ) {
-                additionalPayeeAmount =
-                    (projectFunds *
-                        genArtCoreContract
-                            .projectIdToAdditionalPayeePrimarySalesPercentage(
-                                _projectId
-                            )) /
-                    100;
-                if (additionalPayeeAmount > 0) {
-                    (bool success_, ) = genArtCoreContract
-                        .projectIdToAdditionalPayeePrimarySales(_projectId)
-                        .call{value: additionalPayeeAmount}("");
-                    require(success_, "Additional payment failed");
-                }
-            }
-            uint256 creatorFunds = projectFunds - additionalPayeeAmount;
-            if (creatorFunds > 0) {
-                (bool success_, ) = genArtCoreContract
-                    .projectIdToArtistAddress(_projectId)
-                    .call{value: creatorFunds}("");
+            // split remaining funds between foundation, artist, and artist's
+            // additional payee
+            (
+                address payable[] memory recipients_,
+                uint256[] memory revenues_
+            ) = genArtCoreContract.getPrimaryRevenueSplits(
+                    _projectId,
+                    pricePerTokenInWei
+                );
+            // artist payment
+            if (revenues_[0] > 0) {
+                (success_, ) = recipients_[0].call{value: revenues_[0]}("");
                 require(success_, "Artist payment failed");
+            }
+            // additional payee payment
+            if (revenues_[1] > 0) {
+                (success_, ) = recipients_[1].call{value: revenues_[1]}("");
+                require(success_, "Additional Payee payment failed");
+            }
+            // Art Blocks payment
+            if (revenues_[2] > 0) {
+                (success_, ) = recipients_[2].call{value: revenues_[2]}("");
+                require(success_, "Art Blocks payment failed");
             }
         }
     }

--- a/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
+++ b/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
@@ -319,50 +319,39 @@ contract MinterMerkleV1 is ReentrancyGuard, IFilteredMinterMerkleV0 {
      */
     function _splitFundsETH(uint256 _projectId) internal {
         if (msg.value > 0) {
+            bool success_;
+            // send refund to sender
             uint256 pricePerTokenInWei = projectIdToPricePerTokenInWei[
                 _projectId
             ];
             uint256 refund = msg.value - pricePerTokenInWei;
             if (refund > 0) {
-                (bool success_, ) = msg.sender.call{value: refund}("");
+                (success_, ) = msg.sender.call{value: refund}("");
                 require(success_, "Refund failed");
             }
-            uint256 foundationAmount = (pricePerTokenInWei *
-                genArtCoreContract.artblocksPercentage()) / 100;
-            if (foundationAmount > 0) {
-                (bool success_, ) = genArtCoreContract.artblocksAddress().call{
-                    value: foundationAmount
-                }("");
-                require(success_, "Foundation payment failed");
-            }
-            uint256 projectFunds = pricePerTokenInWei - foundationAmount;
-            uint256 additionalPayeeAmount;
-            if (
-                genArtCoreContract
-                    .projectIdToAdditionalPayeePrimarySalesPercentage(
-                        _projectId
-                    ) > 0
-            ) {
-                additionalPayeeAmount =
-                    (projectFunds *
-                        genArtCoreContract
-                            .projectIdToAdditionalPayeePrimarySalesPercentage(
-                                _projectId
-                            )) /
-                    100;
-                if (additionalPayeeAmount > 0) {
-                    (bool success_, ) = genArtCoreContract
-                        .projectIdToAdditionalPayeePrimarySales(_projectId)
-                        .call{value: additionalPayeeAmount}("");
-                    require(success_, "Additional payment failed");
-                }
-            }
-            uint256 creatorFunds = projectFunds - additionalPayeeAmount;
-            if (creatorFunds > 0) {
-                (bool success_, ) = genArtCoreContract
-                    .projectIdToArtistAddress(_projectId)
-                    .call{value: creatorFunds}("");
+            // split remaining funds between foundation, artist, and artist's
+            // additional payee
+            (
+                address payable[] memory recipients_,
+                uint256[] memory revenues_
+            ) = genArtCoreContract.getPrimaryRevenueSplits(
+                    _projectId,
+                    pricePerTokenInWei
+                );
+            // artist payment
+            if (revenues_[0] > 0) {
+                (success_, ) = recipients_[0].call{value: revenues_[0]}("");
                 require(success_, "Artist payment failed");
+            }
+            // additional payee payment
+            if (revenues_[1] > 0) {
+                (success_, ) = recipients_[1].call{value: revenues_[1]}("");
+                require(success_, "Additional Payee payment failed");
+            }
+            // Art Blocks payment
+            if (revenues_[2] > 0) {
+                (success_, ) = recipients_[2].call{value: revenues_[2]}("");
+                require(success_, "Art Blocks payment failed");
             }
         }
     }

--- a/contracts/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
+++ b/contracts/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
@@ -205,50 +205,39 @@ contract MinterSetPriceV2 is ReentrancyGuard, IFilteredMinterV0 {
      */
     function _splitFundsETH(uint256 _projectId) internal {
         if (msg.value > 0) {
+            bool success_;
+            // send refund to sender
             uint256 pricePerTokenInWei = projectIdToPricePerTokenInWei[
                 _projectId
             ];
             uint256 refund = msg.value - pricePerTokenInWei;
             if (refund > 0) {
-                (bool success_, ) = msg.sender.call{value: refund}("");
+                (success_, ) = msg.sender.call{value: refund}("");
                 require(success_, "Refund failed");
             }
-            uint256 foundationAmount = (pricePerTokenInWei *
-                genArtCoreContract.artblocksPercentage()) / 100;
-            if (foundationAmount > 0) {
-                (bool success_, ) = genArtCoreContract.artblocksAddress().call{
-                    value: foundationAmount
-                }("");
-                require(success_, "Foundation payment failed");
-            }
-            uint256 projectFunds = pricePerTokenInWei - foundationAmount;
-            uint256 additionalPayeeAmount;
-            if (
-                genArtCoreContract
-                    .projectIdToAdditionalPayeePrimarySalesPercentage(
-                        _projectId
-                    ) > 0
-            ) {
-                additionalPayeeAmount =
-                    (projectFunds *
-                        genArtCoreContract
-                            .projectIdToAdditionalPayeePrimarySalesPercentage(
-                                _projectId
-                            )) /
-                    100;
-                if (additionalPayeeAmount > 0) {
-                    (bool success_, ) = genArtCoreContract
-                        .projectIdToAdditionalPayeePrimarySales(_projectId)
-                        .call{value: additionalPayeeAmount}("");
-                    require(success_, "Additional payment failed");
-                }
-            }
-            uint256 creatorFunds = projectFunds - additionalPayeeAmount;
-            if (creatorFunds > 0) {
-                (bool success_, ) = genArtCoreContract
-                    .projectIdToArtistAddress(_projectId)
-                    .call{value: creatorFunds}("");
+            // split remaining funds between foundation, artist, and artist's
+            // additional payee
+            (
+                address payable[] memory recipients_,
+                uint256[] memory revenues_
+            ) = genArtCoreContract.getPrimaryRevenueSplits(
+                    _projectId,
+                    pricePerTokenInWei
+                );
+            // artist payment
+            if (revenues_[0] > 0) {
+                (success_, ) = recipients_[0].call{value: revenues_[0]}("");
                 require(success_, "Artist payment failed");
+            }
+            // additional payee payment
+            if (revenues_[1] > 0) {
+                (success_, ) = recipients_[1].call{value: revenues_[1]}("");
+                require(success_, "Additional Payee payment failed");
+            }
+            // Art Blocks payment
+            if (revenues_[2] > 0) {
+                (success_, ) = recipients_[2].call{value: revenues_[2]}("");
+                require(success_, "Art Blocks payment failed");
             }
         }
     }


### PR DESCRIPTION
## only merge after #223 

Update all V3-compatible minters to use the V3 core's revenue splitting logic, exposed on new external function `getPrimaryRevenueSplits` function.

Placing a common primary revenue split logic in a single place on the V3 core removes some redundant code on minters. It also avoids adding another contract to the purchase flow, since the core contract has already been called during a purchase, avoiding gas costs associated with loading cold addresses.

## Gas Impacts
Gas tests indicate expected gas costs of minting are impacted as indicated in the table below:

_(All gas costs assume gas price of 100 gwei)_
_(note: This is cost of purchasing token zero, which is artificially lower than most tokens, but percent changes are ~valid)_
| Minter | Previous gas cost to purchase | New gas cost to purchase | % change |
| --- | --- | --- | --- |
| MinterSetPriceV2_V3Core | 0.0182068 | 0.0185271 | +1.75 % |
| MinterDAExpV2_V3Core | 0.0193763 | 0.0196995 | +1.67 % |

⚠️  These gas impacts are relatively high, and are probably due to the use of arrays as return values in the core contract's function. A different PR will likely be opened that finds a more gas-efficient solution.