### PR TITLE
Reduce V3 mint gas costs

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -231,12 +231,19 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         uint256 _projectId,
         address _by
     ) external returns (uint256 _tokenId) {
+        // CHECKS
         require(
             msg.sender == minterContract,
             "Must mint from the allowed minter contract."
         );
+
+        // load invocations into memory
+        uint256 invocationsBefore = projects[_projectId].invocations;
+        uint256 invocationsAfter = invocationsBefore + 1;
+        uint256 maxInvocations = projects[_projectId].maxInvocations;
+
         require(
-            projects[_projectId].completedTimestamp == 0,
+            invocationsBefore < maxInvocations,
             "Must not exceed max invocations"
         );
         require(
@@ -250,24 +257,17 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
             "Purchases are paused."
         );
 
-        return _mintToken(_to, _projectId);
-    }
-
-    function _mintToken(address _to, uint256 _projectId)
-        internal
-        returns (uint256 _tokenId)
-    {
-        // checks & effects
-        // increment project's invocations, then move to memory to avoid SLOAD
-        uint256 _invocationsAfter = ++projects[_projectId].invocations;
-        uint256 _invocationsBefore = _invocationsAfter - 1;
-        uint256 thisTokenId = (_projectId * ONE_MILLION) + _invocationsBefore;
+        // EFFECTS
+        // increment project's invocations
+        projects[_projectId].invocations = invocationsAfter;
+        uint256 thisTokenId = (_projectId * ONE_MILLION) + invocationsBefore;
 
         // mark project as completed if hit max invocations
-        if (_invocationsAfter == projects[_projectId].maxInvocations) {
+        if (invocationsAfter == maxInvocations) {
             _completeProject(_projectId);
         }
 
+        // (includes an interaction with randomizer)
         bytes32 tokenHash = keccak256(
             abi.encodePacked(
                 thisTokenId,
@@ -278,7 +278,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
 
         tokenIdToHash[thisTokenId] = tokenHash;
 
-        // interactions
+        // INTERACTIONS
         _mint(_to, thisTokenId);
 
         // Do not need to also log `projectId` in event, as the `projectId` for

--- a/contracts/V3_CHANGELOG.md
+++ b/contracts/V3_CHANGELOG.md
@@ -50,3 +50,5 @@ _This document is intended to document and explain the Art Blocks Core V3 change
   - Placing splitter logic on core is preferred over creating something like a "common mint functions" external contract, because it avoids extra gas costs associated with EIP-2929 and calling cold addresses.
 - Update minters in minter suite to integrate with V3 core contract
   - A couple breaking changes were made on the V3 core contract that required changes to the minter suite contracts.
+- Improve gas efficiency of minting on the V3 core contract
+  - Minimize costly SLOAD operations & re-organize logic to minimize gas usage

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
@@ -131,7 +131,7 @@ describe("MinterDAExpV2_V3Core", async function () {
         "ETH"
       );
 
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0191971")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0189742")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
@@ -131,7 +131,7 @@ describe("MinterDALinV2_V3Core", async function () {
         "ETH"
       );
 
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.019191")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0189681")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/MinterHolder/MinterHolderV1.test.ts
+++ b/test/minter-suite-minters/MinterHolder/MinterHolderV1.test.ts
@@ -25,7 +25,7 @@ import { MinterHolder_Common } from "./MinterHolder.common";
  * These tests intended to ensure Filtered Minter integrates properly with V3
  * core contract.
  */
-describe("MinterHolderV0", async function () {
+describe("MinterHolderV1", async function () {
   beforeEach(async function () {
     // standard accounts and constants
     this.accounts = await getAccounts();
@@ -177,7 +177,7 @@ describe("MinterHolderV0", async function () {
         ethers.utils.formatUnits(txCost.toString(), "ether").toString(),
         "ETH"
       );
-      expect(compareBN(txCost, ethers.utils.parseEther("0.0151593"), 1)).to.be
+      expect(compareBN(txCost, ethers.utils.parseEther("0.0145"), 1)).to.be
         .true;
     });
   });

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
@@ -159,7 +159,7 @@ describe("MinterSetPriceV2_V3Core", async function () {
         "ETH"
       );
 
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0180247")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0178018")); // assuming a cost of 100 GWEI
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
@@ -142,7 +142,7 @@ describe("MinterSetPriceERC20V2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0182463"));
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0180234"));
     });
   });
 


### PR DESCRIPTION
## Only merge after #225 

Reduce V3 mint gas costs by better managing SLOAD operations during mint.

This reduces V3 core contract mint gas costs by better managing SLOAD operations on the core contract during mint. This change is very straightforward and likely doesn't affect readability of the contract in a significant way.

## Gas impacts
Mint costs are slightly reduced, as shown in the table below.

_(All gas costs assume project 1 mint 501 of 1000)_
| Gas Test | Previous gas used to purchase | New gas used to purchase | % change |
| --- | --- | --- | --- |
| MinterSetPriceV2_V3Core | 146059 | 143814 | -1.5% (cheaper) |
| MinterDAExpV2_V3Core | 157783 | 155538 | -1.4% (cheaper) |