### PR TITLE
Update randomizer interface for V3 core

### DIFF
--- a/contracts/BasicRandomizerV2.sol
+++ b/contracts/BasicRandomizerV2.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Creatd By: Art Blocks Inc.
+
+pragma solidity 0.8.9;
+
+import "./interfaces/0.8.x/IRandomizerV2.sol";
+import "./interfaces/0.8.x/IGenArt721CoreContractV3.sol";
+
+import "@openzeppelin-4.7/contracts/access/Ownable.sol";
+
+contract BasicRandomizerV2 is IRandomizerV2, Ownable {
+    // The core contract that may interact with this randomizer contract.
+    IGenArt721CoreContractV3 public genArt721Core;
+
+    function assignCoreAndRenounce(address _genArt721Core) external onlyOwner {
+        renounceOwnership();
+        genArt721Core = IGenArt721CoreContractV3(_genArt721Core);
+    }
+
+    // When `genArt721Core` calls this, it can be assured that the randomizer
+    // will set a bytes32 hash for tokenId `_tokenId` on the core contract.
+    function assignTokenHash(uint256 _tokenId) external {
+        uint256 time = block.timestamp;
+        bytes32 hash = keccak256(
+            abi.encodePacked(
+                _tokenId,
+                block.number,
+                blockhash(block.number - 1),
+                time,
+                (time % 200) + 1
+            )
+        );
+        genArt721Core.setTokenHash_8PT(_tokenId, hash);
+    }
+}

--- a/contracts/BasicRandomizerV2.sol
+++ b/contracts/BasicRandomizerV2.sol
@@ -20,6 +20,7 @@ contract BasicRandomizerV2 is IRandomizerV2, Ownable {
     // When `genArt721Core` calls this, it can be assured that the randomizer
     // will set a bytes32 hash for tokenId `_tokenId` on the core contract.
     function assignTokenHash(uint256 _tokenId) external {
+        require(msg.sender == address(genArt721Core), "only core");
         uint256 time = block.timestamp;
         bytes32 hash = keccak256(
             abi.encodePacked(

--- a/contracts/BasicRandomizerV2.sol
+++ b/contracts/BasicRandomizerV2.sol
@@ -20,7 +20,7 @@ contract BasicRandomizerV2 is IRandomizerV2, Ownable {
     // When `genArt721Core` calls this, it can be assured that the randomizer
     // will set a bytes32 hash for tokenId `_tokenId` on the core contract.
     function assignTokenHash(uint256 _tokenId) external {
-        require(msg.sender == address(genArt721Core), "only core");
+        require(msg.sender == address(genArt721Core), "Only core may call");
         uint256 time = block.timestamp;
         bytes32 hash = keccak256(
             abi.encodePacked(

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -255,10 +255,11 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
             _completeProject(_projectId);
         }
 
+        // INTERACTIONS
+
         // token hash is updated by the randomizer contract on V3
         randomizerContract.assignTokenHash(thisTokenId);
 
-        // INTERACTIONS
         _mint(_to, thisTokenId);
 
         // Do not need to also log `projectId` in event, as the `projectId` for
@@ -276,9 +277,13 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
      * non-zero hash.
      * @param _tokenId Token ID to set the hash for.
      * @param _hash Hash to set for the token ID.
+     * @dev gas-optimized function name because called during mint sequence
      */
     function setTokenHash_8PT(uint256 _tokenId, bytes32 _hash) external {
-        require(msg.sender == address(randomizerContract), "Only randomizer.");
+        require(
+            msg.sender == address(randomizerContract),
+            "Only randomizer may set"
+        );
         require(
             tokenIdToHash[_tokenId] == bytes32(0),
             "Token hash already set."

--- a/contracts/V3_CHANGELOG.md
+++ b/contracts/V3_CHANGELOG.md
@@ -53,3 +53,4 @@ _This document is intended to document and explain the Art Blocks Core V3 change
 - Improve gas efficiency of minting on the V3 core contract
   - Minimize costly SLOAD operations & re-organize logic to minimize gas usage
   - Optimize mint function signature to reduce gas usage
+- Update randomizer interface for V3 core contract

--- a/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
+++ b/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
@@ -112,6 +112,9 @@ interface IGenArt721CoreContractV3 {
 
     function artblocksPercentage() external view returns (uint256);
 
+    // function to set a token's hash (must be guarded)
+    function setTokenHash_8PT(uint256 _tokenId, bytes32 _hash) external;
+
     // @dev gas-optimized signature in V3 for `mint`
     function mint_Ecf(
         address _to,

--- a/contracts/interfaces/0.8.x/IRandomizerV2.sol
+++ b/contracts/interfaces/0.8.x/IRandomizerV2.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Creatd By: Art Blocks Inc.
+
+pragma solidity ^0.8.0;
+
+import "./IGenArt721CoreContractV3.sol";
+
+interface IRandomizerV2 {
+    // The core contract that may interact with this randomizer contract.
+    function genArt721Core() external view returns (IGenArt721CoreContractV3);
+
+    // When `genArt721Core` calls this, it can be assured that the randomizer
+    // will set a bytes32 hash for tokenId `_tokenId` on the core contract.
+    function assignTokenHash(uint256 _tokenId) external;
+}

--- a/contracts/interfaces/0.8.x/IRandomizerV2.sol
+++ b/contracts/interfaces/0.8.x/IRandomizerV2.sol
@@ -9,7 +9,7 @@ interface IRandomizerV2 {
     // The core contract that may interact with this randomizer contract.
     function genArt721Core() external view returns (IGenArt721CoreContractV3);
 
-    // When `genArt721Core` calls this, it can be assured that the randomizer
+    // When a core contract calls this, it can be assured that the randomizer
     // will set a bytes32 hash for tokenId `_tokenId` on the core contract.
     function assignTokenHash(uint256 _tokenId) external;
 }

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
@@ -131,7 +131,7 @@ describe("MinterDAExpV2_V3Core", async function () {
         "ETH"
       );
 
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0189599")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0192435")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
@@ -131,7 +131,7 @@ describe("MinterDALinV2_V3Core", async function () {
         "ETH"
       );
 
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0189538")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0192374")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/MinterHolder/MinterHolderV1.test.ts
+++ b/test/minter-suite-minters/MinterHolder/MinterHolderV1.test.ts
@@ -177,7 +177,7 @@ describe("MinterHolderV1", async function () {
         ethers.utils.formatUnits(txCost.toString(), "ether").toString(),
         "ETH"
       );
-      expect(compareBN(txCost, ethers.utils.parseEther("0.0145"), 1)).to.be
+      expect(compareBN(txCost, ethers.utils.parseEther("0.0150254"), 1)).to.be
         .true;
     });
   });

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
@@ -159,7 +159,7 @@ describe("MinterSetPriceV2_V3Core", async function () {
         "ETH"
       );
 
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0177875")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0180711")); // assuming a cost of 100 GWEI
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
@@ -142,7 +142,7 @@ describe("MinterSetPriceERC20V2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0180091"));
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0182927"));
     });
   });
 

--- a/test/randomizer/basicRandomizerV2/basicRandomizerV2.test.ts
+++ b/test/randomizer/basicRandomizerV2/basicRandomizerV2.test.ts
@@ -1,0 +1,155 @@
+import {
+  BN,
+  constants,
+  expectEvent,
+  expectRevert,
+  balance,
+  ether,
+} from "@openzeppelin/test-helpers";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+
+import {
+  getAccounts,
+  assignDefaultConstants,
+  deployAndGet,
+  deployCoreWithMinterFilter,
+  mintProjectUntilRemaining,
+  advanceEVMByTime,
+} from "../../util/common";
+import { FOUR_WEEKS } from "../../util/constants";
+
+/**
+ * General Integration tests for Basic Randomizer V2 with V3 core.
+ */
+describe("BasicRandomizerV2 w/V3 core", async function () {
+  beforeEach(async function () {
+    // standard accounts and constants
+    this.accounts = await getAccounts();
+    await assignDefaultConstants.call(this);
+
+    // deploy and configure minter filter and minter
+    ({
+      genArt721Core: this.genArt721Core,
+      minterFilter: this.minterFilter,
+      randomizer: this.randomizer,
+      adminACL: this.adminACL,
+    } = await deployCoreWithMinterFilter.call(
+      this,
+      "GenArt721CoreV3",
+      "MinterFilterV1"
+    ));
+
+    this.minter = await deployAndGet.call(this, "MinterSetPriceV2", [
+      this.genArt721Core.address,
+      this.minterFilter.address,
+    ]);
+
+    // add project
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .addProject("name", this.accounts.artist.address);
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .toggleProjectIsActive(this.projectZero);
+    await this.genArt721Core
+      .connect(this.accounts.artist)
+      .updateProjectMaxInvocations(this.projectZero, this.maxInvocations);
+
+    // configure minter for project zero
+    await this.minterFilter
+      .connect(this.accounts.deployer)
+      .addApprovedMinter(this.minter.address);
+    await this.minterFilter
+      .connect(this.accounts.deployer)
+      .setMinterForProject(this.projectZero, this.minter.address);
+    await this.minter
+      .connect(this.accounts.artist)
+      .updatePricePerTokenInWei(this.projectZero, 0);
+  });
+
+  describe("assignCoreAndRenounce", function () {
+    it("does not allow non-owner to call", async function () {
+      // deploy new randomizer
+      const randomizer = await deployAndGet.call(this, "BasicRandomizerV2", []);
+      // expect failure when non-owner calls renounce and assign core
+      await expectRevert(
+        randomizer
+          .connect(this.accounts.user)
+          .assignCoreAndRenounce(this.genArt721Core.address),
+        "Ownable: caller is not the owner"
+      );
+    });
+
+    it("allows owner to call", async function () {
+      // deploy new randomizer
+      const randomizer = await deployAndGet.call(this, "BasicRandomizerV2", []);
+      // expect success when owner calls renounce and assign core
+      await randomizer
+        .connect(this.accounts.deployer)
+        .assignCoreAndRenounce(this.genArt721Core.address);
+    });
+
+    it("does not allow owner to call twice", async function () {
+      // deploy new randomizer
+      const randomizer = await deployAndGet.call(this, "BasicRandomizerV2", []);
+      // expect failure when owner calls renounce and assign core twice
+      await randomizer
+        .connect(this.accounts.deployer)
+        .assignCoreAndRenounce(this.genArt721Core.address);
+      await expectRevert(
+        randomizer
+          .connect(this.accounts.deployer)
+          .assignCoreAndRenounce(this.genArt721Core.address),
+        "Ownable: caller is not the owner"
+      );
+    });
+  });
+
+  describe("assignTokenHash", function () {
+    it("does not allow address that is not the assigned core to assign hash", async function () {
+      // expect revert when non-core calls assignTokenHash
+      await expectRevert(
+        this.randomizer
+          .connect(this.accounts.deployer)
+          .assignTokenHash(this.projectZeroTokenZero.toNumber()),
+        "Only core may call"
+      );
+      // expect token hash of unminted token to be unassigned (0x0)
+      expect(
+        await this.genArt721Core.tokenIdToHash(
+          this.projectZeroTokenZero.toNumber()
+        )
+      ).to.be.equal(ethers.constants.HashZero);
+    });
+
+    it("does allow address that is the assigned core to assign hash", async function () {
+      // expect successful mint
+      await this.minter
+        .connect(this.accounts.artist)
+        .purchase(this.projectZero);
+      // expect token hash to be assigned
+      expect(
+        await this.genArt721Core.tokenIdToHash(
+          this.projectZeroTokenZero.toNumber()
+        )
+      ).to.not.be.equal(ethers.constants.HashZero);
+    });
+  });
+
+  describe("owner", function () {
+    it("returns null owner after being configured and renounced", async function () {
+      expect(await this.randomizer.owner()).to.be.equal(constants.ZERO_ADDRESS);
+    });
+
+    it("returns deployer prior to being configured and renounced", async function () {
+      // deploy new randomizer
+      const randomizer = await deployAndGet.call(this, "BasicRandomizerV2", []);
+      // expect owner to be deployer prior to being configured and renounced
+      expect(await randomizer.owner()).to.be.equal(
+        this.accounts.deployer.address
+      );
+    });
+  });
+});

--- a/test/util/common.ts
+++ b/test/util/common.ts
@@ -81,20 +81,20 @@ export async function deployAndGet(
     .deploy(...deployArgs);
 }
 
-// utility function to deploy randomizer, core, and MinterFilter
+// utility function to deploy basic randomizer, core, and MinterFilter
 // works for core versions V0, V1, V2, V3
 export async function deployCoreWithMinterFilter(
   coreContractName: string,
   minterFilterName: string
 ): Promise<CoreWithMinterSuite> {
-  const randomizer = await deployAndGet.call(this, "BasicRandomizer", []);
-  let genArt721Core, minterFilter, adminACL;
+  let randomizer, genArt721Core, minterFilter, adminACL;
   if (
     coreContractName.endsWith("V0") ||
     coreContractName.endsWith("V1") ||
     coreContractName.endsWith("V2") ||
     coreContractName.endsWith("V2_PRTNR")
   ) {
+    randomizer = await deployAndGet.call(this, "BasicRandomizer", []);
     genArt721Core = await deployAndGet.call(this, coreContractName, [
       this.name,
       this.symbol,
@@ -108,6 +108,7 @@ export async function deployCoreWithMinterFilter(
       .connect(this.accounts.deployer)
       .addMintWhitelisted(minterFilter.address);
   } else if (coreContractName.endsWith("V3")) {
+    randomizer = await deployAndGet.call(this, "BasicRandomizerV2", []);
     adminACL = await deployAndGet.call(this, "MockAdminACLV0Events", []);
     genArt721Core = await deployAndGet.call(this, coreContractName, [
       this.name,
@@ -115,6 +116,11 @@ export async function deployCoreWithMinterFilter(
       randomizer.address,
       adminACL.address,
     ]);
+    // assign core contract for randomizer to use
+    randomizer
+      .connect(this.accounts.deployer)
+      .assignCoreAndRenounce(genArt721Core.address);
+    // deploy minter filter
     minterFilter = await deployAndGet.call(this, minterFilterName, [
       genArt721Core.address,
     ]);

--- a/test/util/common.ts
+++ b/test/util/common.ts
@@ -199,11 +199,13 @@ type T_PBAB = {
 };
 
 export async function deployAndGetPBAB(): Promise<T_PBAB> {
+  const randomizer = await deployAndGet.call(this, "BasicRandomizer", []);
+
   const PBABFactory = await ethers.getContractFactory("GenArt721CoreV2_PBAB");
   const pbabToken = await PBABFactory.connect(this.accounts.deployer).deploy(
     this.name,
     this.symbol,
-    this.randomizer.address
+    randomizer.address
   );
   const minterFactory = await ethers.getContractFactory("GenArt721Minter_PBAB");
   const pbabMinter = await minterFactory.deploy(pbabToken.address);


### PR DESCRIPTION
## Only merge after #230 

Update randomizer interface for V3 core contract.

This frees some constraints on our randomizer contract at the cost of some additional gas during mints.

## Gas impacts
Mint costs are increased, as shown in the table below.

_(All gas costs assume project 3 mint 501 of 1000)_
| Gas Test | Previous gas used to purchase | New gas used to purchase | % change |
| --- | --- | --- | --- |
| MinterSetPriceV2_V3Core | 143687 | 146523 | +2.0% |
| MinterDAExpV2_V3Core | 155411 | 158247 | +1.8% |

## Tests

- [x] Update existing tests 
- [x] Add new tests for new functionality