### PR TITLE
Add history of randomizers to V3 core

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -63,11 +63,9 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     /// current randomizer contract
     IRandomizerV2 public randomizerContract;
 
-    /// mapping of all randomizer contract addresses ever used by this contract
-    /// @dev index of first randomizer begins at zero, incrementing by one each
-    /// time a randomizer change occurs.
-    mapping(uint256 => address) private _indexToRandomizerContracts;
-    uint256 private _nextRandomizerIndex;
+    /// append-only array of all randomizer contract addresses ever used by
+    /// this contract
+    address[] private _historicalRandomizerAddresses;
 
     /// admin ACL contract
     IAdminACLV0 public adminACLContract;
@@ -953,17 +951,18 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
 
     /**
      * @notice Gets qty of randomizers in history of all randomizers used by
-     * this core contract.
+     * this core contract. If a randomizer is switched away from then back to,
+     * it will show up in the history twice.
      */
     function numHistoricalRandomizers() external view returns (uint256) {
-        return _nextRandomizerIndex;
+        return _historicalRandomizerAddresses.length;
     }
 
     /**
      * @notice Gets address of randomizer at index `_index` in history of all
      * randomizers used by this core contract. Index is zero-based.
      * @param _index Historical index of randomizer to be queried.
-     * @dev If a randomizer is switched away from and then switch back to, it
+     * @dev If a randomizer is switched away from and then switched back to, it
      * will show up in the history twice.
      */
     function getHistoricalRandomizerAt(uint256 _index)
@@ -971,8 +970,11 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         view
         returns (address)
     {
-        require(_index < _nextRandomizerIndex, "Index out of bounds");
-        return _indexToRandomizerContracts[_index];
+        require(
+            _index < _historicalRandomizerAddresses.length,
+            "Index out of bounds"
+        );
+        return _historicalRandomizerAddresses[_index];
     }
 
     /**
@@ -1166,10 +1168,8 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
      */
     function _updateRandomizerAddress(address _randomizerAddress) internal {
         randomizerContract = IRandomizerV2(_randomizerAddress);
-        // populate historical randomizer mapping, then increment index
-        _indexToRandomizerContracts[
-            _nextRandomizerIndex++
-        ] = _randomizerAddress;
+        // populate historical randomizer array
+        _historicalRandomizerAddresses.push(_randomizerAddress);
         emit PlatformUpdated(FIELD_RANDOMIZER_ADDRESS);
     }
 

--- a/test/core/V3/GenArt721CoreV3_Views.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Views.test.ts
@@ -495,4 +495,61 @@ describe("GenArt721CoreV3 Views", async function () {
       );
     });
   });
+
+  describe("numHistoricalRandomizers", function () {
+    it("returns value of one upon initial configuration", async function () {
+      const numHistoricalRandomizers = await this.genArt721Core
+        .connect(this.accounts.user)
+        .numHistoricalRandomizers();
+      expect(numHistoricalRandomizers).to.be.equal(1);
+    });
+
+    it("increments value when more randomizers are added", async function () {
+      // update to dummy randomizer address
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .updateRandomizerAddress(this.accounts.deployer.address);
+      // expect incremented number of randomizers
+      const numHistoricalRandomizers = await this.genArt721Core
+        .connect(this.accounts.user)
+        .numHistoricalRandomizers();
+      expect(numHistoricalRandomizers).to.be.equal(2);
+    });
+  });
+
+  describe("getHistoricalRandomizerAt", function () {
+    it("returns initial randomizer at index of zero upon initial configuration", async function () {
+      const randomizerAddress = await this.genArt721Core
+        .connect(this.accounts.user)
+        .getHistoricalRandomizerAt(0);
+      expect(randomizerAddress).to.be.equal(this.randomizer.address);
+    });
+
+    it("returns initial and next randomizer at expected indices when >1 randomizer in history", async function () {
+      // update to dummy randomizer address
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .updateRandomizerAddress(this.accounts.deployer.address);
+      // expect initial randomizer at index zero
+      const initialRandomizer = await this.genArt721Core
+        .connect(this.accounts.user)
+        .getHistoricalRandomizerAt(0);
+      expect(initialRandomizer).to.be.equal(this.randomizer.address);
+      // expect next randomizer at index one
+      const nextRandomizer = await this.genArt721Core
+        .connect(this.accounts.user)
+        .getHistoricalRandomizerAt(1);
+      expect(nextRandomizer).to.be.equal(this.accounts.deployer.address);
+    });
+
+    it("reverts when invalid index is queried", async function () {
+      // expect revert when query out of bounds index
+      await expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.user)
+          .getHistoricalRandomizerAt(2),
+        "Index out of bounds"
+      );
+    });
+  });
 });

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
@@ -130,7 +130,7 @@ describe("MinterDAExpV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0192677")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0192655")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
@@ -131,7 +131,7 @@ describe("MinterDAExpV2_V3Core", async function () {
         "ETH"
       );
 
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0192672")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.019265")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
@@ -130,7 +130,7 @@ describe("MinterDALinV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0192616")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0192594")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
@@ -131,7 +131,7 @@ describe("MinterDALinV2_V3Core", async function () {
         "ETH"
       );
 
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0192611")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0192589")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
@@ -158,7 +158,7 @@ describe("MinterSetPriceV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0180953")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0180931")); // assuming a cost of 100 GWEI
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
@@ -159,7 +159,7 @@ describe("MinterSetPriceV2_V3Core", async function () {
         "ETH"
       );
 
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0180948")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0180926")); // assuming a cost of 100 GWEI
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
@@ -142,7 +142,7 @@ describe("MinterSetPriceERC20V2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0183169"));
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0183147"));
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
@@ -142,7 +142,7 @@ describe("MinterSetPriceERC20V2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0183164"));
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0183142"));
     });
   });
 


### PR DESCRIPTION
## Only merge after #234

Add queryable history of randomizer to V3 core.

This adds an append-only historical array of all randomizer addresses ever used by the V3 core. This helps with documenting on-chain history of the contract for our users.

Under the hood, opted to use a private array of historical randomizer addresses. From a user's perspective, there are two new functions that enable enumeration of all historical randomizers, in the order they were used by the contract. Chose to give views for qty and query at a given index because it is our typical pattern, and guarantees return values fit within block limits. It also minimizes the cost associated with return value size if a contract wants to query our contract at a specific index.

Note that this could have been implemented with a private mapping and index counter, but a dynamic storage array is a bit more more intuitive for this use case.

## Alternatives
If we care about surfacing which randomizer was being used at a given block, this could be implemented via a Checkpoints data structure instead: https://docs.openzeppelin.com/contracts/4.x/api/utils#Checkpoints
(I don't think we care enough about supporting that query to import the lib, but wanted to point it out as an option).