### PR TITLE
Add Art Blocks secondary royalty data to V3 core

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -20,10 +20,10 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     uint256 constant FOUR_WEEKS_IN_SECONDS = 2_419_200;
 
     // generic platform event fields
-    bytes32 constant FIELD_ARTBLOCKS_ADDRESS_PRIMARY_SALES =
-        "artblocksAddressPrimarySales";
-    bytes32 constant FIELD_ARTBLOCKS_ADDRESS_SECONDARY_SALES =
-        "artblocksAddressSecondarySales";
+    bytes32 constant FIELD_ARTBLOCKS_PRIMARY_SALES_ADDRESS =
+        "artblocksPrimarySalesAddress";
+    bytes32 constant FIELD_ARTBLOCKS_SECONDARY_SALES_ADDRESS =
+        "artblocksSecondarySalesAddress";
     bytes32 constant FIELD_RANDOMIZER_ADDRESS = "randomizerAddress";
     bytes32 constant FIELD_ARTBLOCKS_CURATION_REGISTRY_ADDRESS =
         "curationRegistryAddress";
@@ -115,11 +115,11 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     mapping(uint256 => bytes32) public proposedArtistAddressesAndSplitsHash;
 
     /// Art Blocks payment address for all primary sales revenues
-    address payable public artblocksAddressPrimarySales;
+    address payable public artblocksPrimarySalesAddress;
     /// Percentage of primary sales revenue allocated to Art Blocks
     uint256 public artblocksPrimarySalesPercentage = 10;
     /// Art Blocks payment address for all secondary sales royalty revenues
-    address payable public artblocksAddressSecondarySales;
+    address payable public artblocksSecondarySalesAddress;
     /// Basis Points of secondary sales royalties allocated to Art Blocks
     uint256 public artblocksSecondarySalesBPS = 250;
 
@@ -214,8 +214,8 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         address _randomizerContract,
         address _adminACLContract
     ) ERC721(_tokenName, _tokenSymbol) {
-        _updateArtblocksAddressPrimarySales(msg.sender);
-        _updateArtblocksAddressSecondarySales(msg.sender);
+        _updateArtblocksPrimarySalesAddress(msg.sender);
+        _updateArtblocksSecondarySalesAddress(msg.sender);
         _updateRandomizerAddress(_randomizerContract);
         // set AdminACL management contract as owner
         _transferOwnership(_adminACLContract);
@@ -336,25 +336,25 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     }
 
     /**
-     * @notice Updates artblocksAddressPrimarySales to `_artblocksAddressPrimarySales`.
+     * @notice Updates artblocksPrimarySalesAddress to `_artblocksPrimarySalesAddress`.
      */
-    function updateArtblocksAddressPrimarySales(
-        address payable _artblocksAddressPrimarySales
-    ) external onlyAdminACL(this.updateArtblocksAddressPrimarySales.selector) {
-        _updateArtblocksAddressPrimarySales(_artblocksAddressPrimarySales);
+    function updateArtblocksPrimarySalesAddress(
+        address payable _artblocksPrimarySalesAddress
+    ) external onlyAdminACL(this.updateArtblocksPrimarySalesAddress.selector) {
+        _updateArtblocksPrimarySalesAddress(_artblocksPrimarySalesAddress);
     }
 
     /**
      * @notice Updates Art Blocks secondary sales royalty payment address to
-     * `_artblocksAddressSecondarySales`.
+     * `_artblocksSecondarySalesAddress`.
      */
-    function updateArtblocksAddressSecondarySales(
-        address payable _artblocksAddressSecondarySales
+    function updateArtblocksSecondarySalesAddress(
+        address payable _artblocksSecondarySalesAddress
     )
         external
-        onlyAdminACL(this.updateArtblocksAddressSecondarySales.selector)
+        onlyAdminACL(this.updateArtblocksSecondarySalesAddress.selector)
     {
-        _updateArtblocksAddressSecondarySales(_artblocksAddressSecondarySales);
+        _updateArtblocksSecondarySalesAddress(_artblocksSecondarySalesAddress);
     }
 
     /**
@@ -1095,7 +1095,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
             100;
         artistRevenue_ = projectFunds - additionalPayeePrimaryRevenue_;
         // set addresses from storage
-        artblocksAddress_ = artblocksAddressPrimarySales;
+        artblocksAddress_ = artblocksPrimarySalesAddress;
         artistAddress_ = artistRevenue_ > 0
             ? projectIdToArtistAddress[_projectId]
             : payable(address(0));
@@ -1198,24 +1198,24 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     /**
      * @notice Updates Art Blocks payment address to `_artblocksAddress`.
      */
-    function _updateArtblocksAddressPrimarySales(
-        address _artblocksAddressPrimarySales
+    function _updateArtblocksPrimarySalesAddress(
+        address _artblocksPrimarySalesAddress
     ) internal {
-        artblocksAddressPrimarySales = payable(_artblocksAddressPrimarySales);
-        emit PlatformUpdated(FIELD_ARTBLOCKS_ADDRESS_PRIMARY_SALES);
+        artblocksPrimarySalesAddress = payable(_artblocksPrimarySalesAddress);
+        emit PlatformUpdated(FIELD_ARTBLOCKS_PRIMARY_SALES_ADDRESS);
     }
 
     /**
      * @notice Updates Art Blocks secondary sales royalty payment address to
-     * `_artblocksAddressSecondarySales`.
+     * `_artblocksSecondarySalesAddress`.
      */
-    function _updateArtblocksAddressSecondarySales(
-        address _artblocksAddressSecondarySales
+    function _updateArtblocksSecondarySalesAddress(
+        address _artblocksSecondarySalesAddress
     ) internal {
-        artblocksAddressSecondarySales = payable(
-            _artblocksAddressSecondarySales
+        artblocksSecondarySalesAddress = payable(
+            _artblocksSecondarySalesAddress
         );
-        emit PlatformUpdated(FIELD_ARTBLOCKS_ADDRESS_SECONDARY_SALES);
+        emit PlatformUpdated(FIELD_ARTBLOCKS_SECONDARY_SALES_ADDRESS);
     }
 
     /**

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -375,11 +375,16 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     /**
      * @notice Updates Art Blocks secondary sales royalty Basis Points to
      * `_artblocksSecondarySalesBPS`.
+     * @dev Due to seocndary royalties being ultimately enforced via social
+     * consensus, no hard upper limit is imposed on the BPS value, other than
+     * <= 100% royalty, which would not make mathematical sense. Realistically,
+     * changing this value is expected to either never occur, or be a rare
+     * occurrence.
      */
     function updateArtblocksSecondarySalesBPS(
         uint256 _artblocksSecondarySalesBPS
     ) external onlyAdminACL(this.updateArtblocksSecondarySalesBPS.selector) {
-        require(_artblocksSecondarySalesBPS <= 250, "Max of 2.5%");
+        require(_artblocksSecondarySalesBPS <= 10000, "Max of 100%");
         artblocksSecondarySalesBPS = _artblocksSecondarySalesBPS;
         emit PlatformUpdated(FIELD_ARTBLOCKS_SECONDARY_SALES_BPS);
     }

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -359,7 +359,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
 
     /**
      * @notice Updates Art Blocks primary sales revenue percentage to
-     * `_artblocksPercentage`.
+     * `_artblocksPrimarySalesPercentage`.
      */
     function updateArtblocksPrimarySalesPercentage(
         uint256 _artblocksPrimarySalesPercentage
@@ -374,7 +374,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
 
     /**
      * @notice Updates Art Blocks secondary sales royalty Basis Points to
-     * `_artblocksBPSSecondary`.
+     * `_artblocksSecondarySalesBPS`.
      */
     function updateArtblocksSecondarySalesBPS(
         uint256 _artblocksSecondarySalesBPS
@@ -385,7 +385,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     }
 
     /**
-     * @notice updates minter to `_address`.
+     * @notice Updates minter to `_address`.
      */
     function updateMinterContract(address _address)
         external
@@ -1196,7 +1196,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     }
 
     /**
-     * @notice Updates Art Blocks payment address to `_artblocksAddress`.
+     * @notice Updates Art Blocks payment address to `_artblocksPrimarySalesAddress`.
      */
     function _updateArtblocksPrimarySalesAddress(
         address _artblocksPrimarySalesAddress

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -1023,6 +1023,22 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     }
 
     /**
+     * @notice Backwards-compatible (pre-V3) function returning Art Blocks
+     * primary sales payment address (now called artblocksPrimarySalesAddress).
+     */
+    function artblocksAddress() external view returns (address payable) {
+        return artblocksPrimarySalesAddress;
+    }
+
+    /**
+     * @notice Backwards-compatible (pre-V3) function returning Art Blocks
+     * primary sales percentage (now called artblocksPrimarySalesPercentage).
+     */
+    function artblocksPercentage() external view returns (uint256) {
+        return artblocksPrimarySalesPercentage;
+    }
+
+    /**
      * @notice Gets royalty data for token ID `_tokenId`.
      * @param _tokenId Token ID to be queried.
      * @return artistAddress Artist's payment address

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -21,12 +21,15 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
 
     // generic platform event fields
     bytes32 constant FIELD_ARTBLOCKS_ADDRESS = "artblocksAddress";
+    bytes32 constant FIELD_ARTBLOCKS_ADDRESS_SECONDARY =
+        "artblocksAddressSecondary";
     bytes32 constant FIELD_RANDOMIZER_ADDRESS = "randomizerAddress";
     bytes32 constant FIELD_ARTBLOCKS_CURATION_REGISTRY_ADDRESS =
         "curationRegistryAddress";
     bytes32 constant FIELD_ARTBLOCKS_DEPENDENCY_REGISTRY_ADDRESS =
         "dependencyRegistryAddress";
     bytes32 constant FIELD_ARTBLOCKS_PERCENTAGE = "artblocksPercentage";
+    bytes32 constant FIELD_ARTBLOCKS_BPS_SECONDARY = "artblocksBPSSecondary";
     // generic project event fields
     bytes32 constant FIELD_PROJECT_COMPLETED = "completed";
     bytes32 constant FIELD_PROJECT_ACTIVE = "active";
@@ -108,9 +111,14 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     /// hash of artist's proposed payment updates to be approved by admin
     mapping(uint256 => bytes32) public proposedArtistAddressesAndSplitsHash;
 
+    /// Art Blocks payment address for all primary sales revenues
     address payable public artblocksAddress;
     /// Percentage of mint revenue allocated to Art Blocks
     uint256 public artblocksPercentage = 10;
+    /// Art Blocks payment address for all secondary sales royalty reveneus
+    address payable public artblocksAddressSecondary;
+    /// Basis Points of secondary sales revenue allocated to Art Blocks
+    uint256 public artblocksBPSSecondary = 250;
 
     mapping(uint256 => bytes32) public tokenIdToHash;
 
@@ -204,6 +212,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         address _adminACLContract
     ) ERC721(_tokenName, _tokenSymbol) {
         _updateArtblocksAddress(msg.sender);
+        _updateArtblocksAddressSecondary(msg.sender);
         _updateRandomizerAddress(_randomizerContract);
         // set AdminACL management contract as owner
         _transferOwnership(_adminACLContract);
@@ -334,6 +343,16 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     }
 
     /**
+     * @notice Updates artblocksAddressSecondary to
+     * `_artblocksAddressSecondary`.
+     */
+    function updateArtblocksAddressSecondary(
+        address payable _artblocksAddressSecondary
+    ) external onlyAdminACL(this.updateArtblocksAddressSecondary.selector) {
+        _updateArtblocksAddressSecondary(_artblocksAddressSecondary);
+    }
+
+    /**
      * @notice Updates Art Blocks mint revenue percentage to
      * `_artblocksPercentage`.
      */
@@ -344,6 +363,19 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         require(_artblocksPercentage <= 25, "Max of 25%");
         artblocksPercentage = _artblocksPercentage;
         emit PlatformUpdated(FIELD_ARTBLOCKS_PERCENTAGE);
+    }
+
+    /**
+     * @notice Updates Art Blocks secondary sales revenue Basis Points to
+     * `_artblocksBPSSecondary`.
+     */
+    function updateArtblocksBPSSecondary(uint256 _artblocksBPSSecondary)
+        external
+        onlyAdminACL(this.updateArtblocksBPSSecondary.selector)
+    {
+        require(_artblocksBPSSecondary <= 250, "Max of 2.5%");
+        artblocksBPSSecondary = _artblocksBPSSecondary;
+        emit PlatformUpdated(FIELD_ARTBLOCKS_BPS_SECONDARY);
     }
 
     /**
@@ -1158,11 +1190,22 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     }
 
     /**
-     * @notice Updates Art Blocks payment address to `_renderProviderAddress`.
+     * @notice Updates Art Blocks payment address to `_artblocksAddress`.
      */
     function _updateArtblocksAddress(address _artblocksAddress) internal {
         artblocksAddress = payable(_artblocksAddress);
         emit PlatformUpdated(FIELD_ARTBLOCKS_ADDRESS);
+    }
+
+    /**
+     * @notice Updates Art Blocks secondary sales payment address to
+     * `_artblocksAddressSecondary`.
+     */
+    function _updateArtblocksAddressSecondary(
+        address _artblocksAddressSecondary
+    ) internal {
+        artblocksAddressSecondary = payable(_artblocksAddressSecondary);
+        emit PlatformUpdated(FIELD_ARTBLOCKS_ADDRESS_SECONDARY);
     }
 
     /**

--- a/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
+++ b/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
@@ -109,7 +109,7 @@ interface IGenArt721CoreContractV3 {
         );
 
     // @dev Art Blocks primary sales payment address
-    function artblocksAddressPrimarySales()
+    function artblocksPrimarySalesAddress()
         external
         view
         returns (address payable);
@@ -118,7 +118,7 @@ interface IGenArt721CoreContractV3 {
     function artblocksPrimarySalesPercentage() external view returns (uint256);
 
     // @dev Art Blocks secondary sales royalties payment address
-    function artblocksAddressSecondarySales()
+    function artblocksSecondarySalesAddress()
         external
         view
         returns (address payable);

--- a/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
+++ b/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
@@ -42,7 +42,7 @@ interface IGenArt721CoreContractV3 {
     // Admin ACL contract for V3, will be at the address owner()
     function adminACLContract() external returns (IAdminACLV0);
 
-    // backwards-compatible admin - equal to owner()
+    // backwards-compatible (pre-V3) admin - equal to owner()
     function admin() external view returns (address);
 
     /**
@@ -114,8 +114,20 @@ interface IGenArt721CoreContractV3 {
         view
         returns (address payable);
 
+    /**
+     * @notice Backwards-compatible (pre-V3) function returning Art Blocks
+     * primary sales payment address (now called artblocksPrimarySalesAddress).
+     */
+    function artblocksAddress() external view returns (address payable);
+
     // @dev Percentage of primary sales allocated to Art Blocks
     function artblocksPrimarySalesPercentage() external view returns (uint256);
+
+    /**
+     * @notice Backwards-compatible (pre-V3) function returning Art Blocks
+     * primary sales percentage (now called artblocksPrimarySalesPercentage).
+     */
+    function artblocksPercentage() external view returns (uint256);
 
     // @dev Art Blocks secondary sales royalties payment address
     function artblocksSecondarySalesAddress()

--- a/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
+++ b/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
@@ -108,9 +108,23 @@ interface IGenArt721CoreContractV3 {
             bool locked
         );
 
-    function artblocksAddress() external view returns (address payable);
+    // @dev Art Blocks primary sales payment address
+    function artblocksAddressPrimarySales()
+        external
+        view
+        returns (address payable);
 
-    function artblocksPercentage() external view returns (uint256);
+    // @dev Percentage of primary sales allocated to Art Blocks
+    function artblocksPrimarySalesPercentage() external view returns (uint256);
+
+    // @dev Art Blocks secondary sales royalties payment address
+    function artblocksAddressSecondarySales()
+        external
+        view
+        returns (address payable);
+
+    // @dev Basis points of secondary sales allocated to Art Blocks
+    function artblocksSecondarySalesBPS() external view returns (uint256);
 
     // function to set a token's hash (must be guarded)
     function setTokenHash_8PT(uint256 _tokenId, bytes32 _hash) external;

--- a/test/core/V3/GenArt721CoreV3_AdminACLRequests.test.ts
+++ b/test/core/V3/GenArt721CoreV3_AdminACLRequests.test.ts
@@ -94,16 +94,20 @@ describe("GenArt721CoreV3 AminACL Requests", async function () {
   });
 
   describe("requests appropriate selectors from AdminACL", function () {
-    it("updateArtblocksAddress", async function () {
-      await validateAdminACLRequest.call(this, "updateArtblocksAddress", [
-        this.accounts.user.address,
-      ]);
+    it("updateArtblocksPrimarySalesAddress", async function () {
+      await validateAdminACLRequest.call(
+        this,
+        "updateArtblocksPrimarySalesAddress",
+        [this.accounts.user.address]
+      );
     });
 
-    it("updateArtblocksPercentage", async function () {
-      await validateAdminACLRequest.call(this, "updateArtblocksPercentage", [
-        11,
-      ]);
+    it("updateArtblocksPrimarySalesPercentage", async function () {
+      await validateAdminACLRequest.call(
+        this,
+        "updateArtblocksPrimarySalesPercentage",
+        [11]
+      );
     });
 
     it("updateMinterContract", async function () {

--- a/test/core/V3/GenArt721CoreV3_AdminACLRequests.test.ts
+++ b/test/core/V3/GenArt721CoreV3_AdminACLRequests.test.ts
@@ -102,11 +102,27 @@ describe("GenArt721CoreV3 AminACL Requests", async function () {
       );
     });
 
+    it("updateArtblocksSecondarySalesAddress", async function () {
+      await validateAdminACLRequest.call(
+        this,
+        "updateArtblocksSecondarySalesAddress",
+        [this.accounts.user.address]
+      );
+    });
+
     it("updateArtblocksPrimarySalesPercentage", async function () {
       await validateAdminACLRequest.call(
         this,
         "updateArtblocksPrimarySalesPercentage",
         [11]
+      );
+    });
+
+    it("updateArtblocksSecondarySalesBPS", async function () {
+      await validateAdminACLRequest.call(
+        this,
+        "updateArtblocksSecondarySalesBPS",
+        [240]
       );
     });
 

--- a/test/core/V3/GenArt721CoreV3_ContractConfigure.test.ts
+++ b/test/core/V3/GenArt721CoreV3_ContractConfigure.test.ts
@@ -97,12 +97,12 @@ describe("GenArt721CoreV3 Contract Configure", async function () {
   });
 
   describe("updateArtblocksSecondarySalesBPS", function () {
-    it("does not allow a value > 2.5%", async function () {
+    it("does not allow a value > 100%", async function () {
       await expectRevert(
         this.genArt721Core
           .connect(this.accounts.deployer)
-          .updateArtblocksSecondarySalesBPS(260),
-        "Max of 2.5%"
+          .updateArtblocksSecondarySalesBPS(10001),
+        "Max of 100%"
       );
     });
 

--- a/test/core/V3/GenArt721CoreV3_ContractConfigure.test.ts
+++ b/test/core/V3/GenArt721CoreV3_ContractConfigure.test.ts
@@ -1,0 +1,121 @@
+import {
+  BN,
+  constants,
+  expectEvent,
+  expectRevert,
+  balance,
+  ether,
+} from "@openzeppelin/test-helpers";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import {
+  getAccounts,
+  assignDefaultConstants,
+  deployAndGet,
+  deployCoreWithMinterFilter,
+  mintProjectUntilRemaining,
+  advanceEVMByTime,
+} from "../../util/common";
+import { FOUR_WEEKS } from "../../util/constants";
+
+/**
+ * Tests for V3 core dealing with configuring the core contract.
+ */
+describe("GenArt721CoreV3 Contract Configure", async function () {
+  beforeEach(async function () {
+    // standard accounts and constants
+    this.accounts = await getAccounts();
+    await assignDefaultConstants.call(this);
+
+    // deploy and configure minter filter and minter
+    ({
+      genArt721Core: this.genArt721Core,
+      minterFilter: this.minterFilter,
+      randomizer: this.randomizer,
+      adminACL: this.adminACL,
+    } = await deployCoreWithMinterFilter.call(
+      this,
+      "GenArt721CoreV3",
+      "MinterFilterV1"
+    ));
+
+    this.minter = await deployAndGet.call(this, "MinterSetPriceV2", [
+      this.genArt721Core.address,
+      this.minterFilter.address,
+    ]);
+
+    // add project zero
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .addProject("name", this.accounts.artist.address);
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .toggleProjectIsActive(this.projectZero);
+    await this.genArt721Core
+      .connect(this.accounts.artist)
+      .updateProjectMaxInvocations(this.projectZero, this.maxInvocations);
+
+    // add project one without setting it to active or setting max invocations
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .addProject("name", this.accounts.artist2.address);
+
+    // configure minter for project zero
+    await this.minterFilter
+      .connect(this.accounts.deployer)
+      .addApprovedMinter(this.minter.address);
+    await this.minterFilter
+      .connect(this.accounts.deployer)
+      .setMinterForProject(this.projectZero, this.minter.address);
+    await this.minter
+      .connect(this.accounts.artist)
+      .updatePricePerTokenInWei(this.projectZero, 0);
+  });
+
+  describe("updateArtblocksPrimarySalesPercentage", function () {
+    it("does not allow a value > 25%", async function () {
+      await expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.deployer)
+          .updateArtblocksPrimarySalesPercentage(26),
+        "Max of 25%"
+      );
+    });
+
+    it("does allow a value of 25%", async function () {
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .updateArtblocksPrimarySalesPercentage(25);
+    });
+
+    it("does allow a value of < 25%", async function () {
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .updateArtblocksPrimarySalesPercentage(0);
+    });
+  });
+
+  describe("updateArtblocksSecondarySalesBPS", function () {
+    it("does not allow a value > 2.5%", async function () {
+      await expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.deployer)
+          .updateArtblocksSecondarySalesBPS(260),
+        "Max of 2.5%"
+      );
+    });
+
+    it("does allow a value of 2.5%", async function () {
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .updateArtblocksSecondarySalesBPS(250);
+    });
+
+    it("does allow a value of < 2.5%", async function () {
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .updateArtblocksSecondarySalesBPS(0);
+    });
+  });
+});

--- a/test/core/V3/GenArt721CoreV3_Events.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Events.test.ts
@@ -93,6 +93,19 @@ describe("GenArt721CoreV3 Events", async function () {
         );
     });
 
+    it("emits artblocksSecondarySalesAddress", async function () {
+      // emits expected event arg(s)
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.deployer)
+          .updateArtblocksSecondarySalesAddress(this.accounts.artist.address)
+      )
+        .to.emit(this.genArt721Core, "PlatformUpdated")
+        .withArgs(
+          ethers.utils.formatBytes32String("artblocksSecondarySalesAddress")
+        );
+    });
+
     it("emits 'randomizerAddress'", async function () {
       // emits expected event arg(s)
       expect(
@@ -141,6 +154,17 @@ describe("GenArt721CoreV3 Events", async function () {
         .withArgs(
           ethers.utils.formatBytes32String("artblocksPrimaryPercentage")
         );
+    });
+
+    it("emits 'artblocksSecondaryBPS'", async function () {
+      // emits expected event arg(s)
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.deployer)
+          .updateArtblocksSecondarySalesBPS(240)
+      )
+        .to.emit(this.genArt721Core, "PlatformUpdated")
+        .withArgs(ethers.utils.formatBytes32String("artblocksSecondaryBPS"));
     });
   });
 

--- a/test/core/V3/GenArt721CoreV3_Events.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Events.test.ts
@@ -80,15 +80,17 @@ describe("GenArt721CoreV3 Events", async function () {
   });
 
   describe("PlatformUpdated", function () {
-    it("emits artblocksAddress", async function () {
+    it("emits artblocksPrimarySalesAddress", async function () {
       // emits expected event arg(s)
       expect(
         await this.genArt721Core
           .connect(this.accounts.deployer)
-          .updateArtblocksAddress(this.accounts.artist.address)
+          .updateArtblocksPrimarySalesAddress(this.accounts.artist.address)
       )
         .to.emit(this.genArt721Core, "PlatformUpdated")
-        .withArgs(ethers.utils.formatBytes32String("artblocksAddress"));
+        .withArgs(
+          ethers.utils.formatBytes32String("artblocksPrimarySalesAddress")
+        );
     });
 
     it("emits 'randomizerAddress'", async function () {
@@ -128,15 +130,17 @@ describe("GenArt721CoreV3 Events", async function () {
         );
     });
 
-    it("emits 'artblocksPercentage'", async function () {
+    it("emits 'artblocksPrimaryPercentage'", async function () {
       // emits expected event arg(s)
       expect(
         await this.genArt721Core
           .connect(this.accounts.deployer)
-          .updateArtblocksPercentage(11)
+          .updateArtblocksPrimarySalesPercentage(11)
       )
         .to.emit(this.genArt721Core, "PlatformUpdated")
-        .withArgs(ethers.utils.formatBytes32String("artblocksPercentage"));
+        .withArgs(
+          ethers.utils.formatBytes32String("artblocksPrimaryPercentage")
+        );
     });
   });
 

--- a/test/core/V3/GenArt721CoreV3_Integration.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Integration.test.ts
@@ -69,11 +69,11 @@ describe("GenArt721CoreV3 Integration", async function () {
       .updatePricePerTokenInWei(this.projectZero, 0);
   });
 
-  describe("artblocksAddress", function () {
-    it("returns expected artblocksAddress", async function () {
-      expect(await this.genArt721Core.artblocksAddress()).to.be.equal(
-        this.accounts.deployer.address
-      );
+  describe("artblocksPrimarySalesAddress", function () {
+    it("returns expected artblocksPrimarySalesAddress", async function () {
+      expect(
+        await this.genArt721Core.artblocksPrimarySalesAddress()
+      ).to.be.equal(this.accounts.deployer.address);
     });
   });
 

--- a/test/core/V3/GenArt721CoreV3_Integration.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Integration.test.ts
@@ -77,11 +77,25 @@ describe("GenArt721CoreV3 Integration", async function () {
     });
   });
 
+  describe("artblocksAddress", function () {
+    it("returns expected artblocksAddress", async function () {
+      expect(await this.genArt721Core.artblocksAddress()).to.be.equal(
+        this.accounts.deployer.address
+      );
+    });
+  });
+
   describe("artblocksSecondarySalesAddress", function () {
     it("returns expected artblocksSecondarySalesAddress", async function () {
       expect(
         await this.genArt721Core.artblocksSecondarySalesAddress()
       ).to.be.equal(this.accounts.deployer.address);
+    });
+  });
+
+  describe("artblocksPercentage", function () {
+    it("returns expected artblocksPercentage", async function () {
+      expect(await this.genArt721Core.artblocksPercentage()).to.be.equal(10);
     });
   });
 

--- a/test/core/V3/GenArt721CoreV3_Integration.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Integration.test.ts
@@ -77,6 +77,14 @@ describe("GenArt721CoreV3 Integration", async function () {
     });
   });
 
+  describe("artblocksSecondarySalesAddress", function () {
+    it("returns expected artblocksSecondarySalesAddress", async function () {
+      expect(
+        await this.genArt721Core.artblocksSecondarySalesAddress()
+      ).to.be.equal(this.accounts.deployer.address);
+    });
+  });
+
   describe("owner", function () {
     it("returns expected owner", async function () {
       expect(await this.genArt721Core.owner()).to.be.equal(

--- a/test/core/V3/GenArt721CoreV3_Views.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Views.test.ts
@@ -353,7 +353,8 @@ describe("GenArt721CoreV3 Views", async function () {
         );
       // expect revenue splits to be properly calculated
       // Art Blocks
-      const artblocksAddress = await this.genArt721Core.artblocksAddress();
+      const artblocksAddress =
+        await this.genArt721Core.artblocksPrimarySalesAddress();
       expect(revenueSplits.artblocksAddress_).to.be.equal(artblocksAddress);
       expect(revenueSplits.artblocksRevenue_).to.be.equal(
         ethers.utils.parseEther("0.10")
@@ -404,11 +405,11 @@ describe("GenArt721CoreV3 Views", async function () {
       // update Art Blocks percentage to 20%
       await this.genArt721Core
         .connect(this.accounts.deployer)
-        .updateArtblocksPercentage(20);
+        .updateArtblocksPrimarySalesPercentage(20);
       // change Art Blocks payment address to random address
       await this.genArt721Core
         .connect(this.accounts.deployer)
-        .updateArtblocksAddress(this.accounts.user.address);
+        .updateArtblocksPrimarySalesAddress(this.accounts.user.address);
       // check for expected values
       const revenueSplits = await this.genArt721Core
         .connect(this.accounts.user)
@@ -461,14 +462,14 @@ describe("GenArt721CoreV3 Views", async function () {
         .adminAcceptArtistAddressesAndSplits(
           ...proposeArtistPaymentAddressesAndSplitsArgs
         );
-      // update Art Blocks percentage to 20%
+      // update Art Blocks primary sales percentage to 20%
       await this.genArt721Core
         .connect(this.accounts.deployer)
-        .updateArtblocksPercentage(20);
-      // change Art Blocks payment address to random address
+        .updateArtblocksPrimarySalesPercentage(20);
+      // change Art Blocks primary sales payment address to random address
       await this.genArt721Core
         .connect(this.accounts.deployer)
-        .updateArtblocksAddress(this.accounts.user.address);
+        .updateArtblocksPrimarySalesAddress(this.accounts.user.address);
       // check for expected values
       const revenueSplits = await this.genArt721Core
         .connect(this.accounts.user)

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
@@ -130,7 +130,7 @@ describe("MinterDAExpV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.019268")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0192702")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
@@ -130,7 +130,7 @@ describe("MinterDAExpV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0192655")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.019268")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
@@ -130,7 +130,7 @@ describe("MinterDALinV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0192594")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0192619")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
@@ -130,7 +130,7 @@ describe("MinterDALinV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0192619")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0192641")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
@@ -158,7 +158,7 @@ describe("MinterSetPriceV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0180956")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0180978")); // assuming a cost of 100 GWEI
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
@@ -158,7 +158,7 @@ describe("MinterSetPriceV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0180931")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0180956")); // assuming a cost of 100 GWEI
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
@@ -142,7 +142,7 @@ describe("MinterSetPriceERC20V2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0183172"));
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0183194"));
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
@@ -142,7 +142,7 @@ describe("MinterSetPriceERC20V2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0183147"));
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0183172"));
     });
   });
 


### PR DESCRIPTION
## Only merge after #235 

Add Art Blocks secondary royalty data to the V3 core.

Specifically, this adds an `artblocksSecondarySalesAddress` and `artblocksSecondarySalesBPS` public, configurable (by admin) field. The values are applied across the entire contract (i.e. no specific values per-project).

Chose to also update legacy names `artblocksAddress` -> `artblocksPrimarySalesAddress` and `artblocksPercentage` -> `artblocksPrimarySalesPercentage`, to make variable names more intuitive. The impact of breaking this portion of the legacy interface is minimized thanks to the new primary payment splitter function on the V3 core contract, as well as a follow-on PR where we will support Manifold's Royalty Registry directly (i.e. we won't need to deploy a new shim layer for breaking the legacy interface).

Also, I put a constraint for admin to never increase our basis points above 250 (2.5%). Input from @jakerockland would be much appreciated on that constraint!

## Follow-on work
A follow-on PR will be added to support Manifold's Royalty Registry directly