### PR TITLE
 Move V3 core's events to interface.

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -135,17 +135,6 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     string public constant coreVersion = "v3.0.0";
     string public constant coreType = "GenArt721CoreV3";
 
-    event ProposedArtistAddressesAndSplits(
-        uint256 indexed _projectId,
-        address _artistAddress,
-        address _additionalPayeePrimarySales,
-        uint256 _additionalPayeePrimarySalesPercentage,
-        address _additionalPayeeSecondarySales,
-        uint256 _additionalPayeeSecondarySalesPercentage
-    );
-
-    event AcceptedArtistAddressesAndSplits(uint256 indexed _projectId);
-
     modifier onlyValidTokenId(uint256 _tokenId) {
         require(_exists(_tokenId), "Token ID does not exist");
         _;

--- a/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
+++ b/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
@@ -30,6 +30,17 @@ interface IGenArt721CoreContractV3 is IManifold {
      */
     event ProjectUpdated(uint256 indexed _projectId, bytes32 indexed _update);
 
+    event ProposedArtistAddressesAndSplits(
+        uint256 indexed _projectId,
+        address _artistAddress,
+        address _additionalPayeePrimarySales,
+        uint256 _additionalPayeePrimarySalesPercentage,
+        address _additionalPayeeSecondarySales,
+        uint256 _additionalPayeeSecondarySalesPercentage
+    );
+
+    event AcceptedArtistAddressesAndSplits(uint256 indexed _projectId);
+
     // version and type of the core contract
     // coreVersion is a string of the form "0.x.y"
     function coreVersion() external view returns (string memory);


### PR DESCRIPTION
## Only merge after #237 

Move V3 core's events to interface.

per [this discussion](https://github.com/ArtBlocks/artblocks-contracts/pull/204#discussion_r944847756) as part of #204 's review, having events in the interface is ideal if we think they will remain in future version updates.

This move the `ProposedArtistAddressesAndSplits` and `AcceptedArtistAddressesAndSplits` events to the V3 core's `IGenArt721CoreContractV3` interface.