### PR TITLE
configure and update solidity-coverage hardhat plugin

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,0 +1,28 @@
+module.exports = {
+  skipFiles: [
+    "interfaces/",
+    "legacy/",
+    "libs/",
+    "mock/",
+    "PBAB+Collabs/art-blocks-x-pace/",
+    "PBAB+Collabs/artcode/",
+    "PBAB+Collabs/bright-moments/",
+    "PBAB+Collabs/colors-and-shapes/",
+    "PBAB+Collabs/crypto-citizens/",
+    "PBAB+Collabs/doodle-labs/",
+    "PBAB+Collabs/fireworks/",
+    "PBAB+Collabs/flutter/",
+    "PBAB+Collabs/legends-of-metaterra/",
+    "PBAB+Collabs/mechsuit/",
+    "PBAB+Collabs/plottables/",
+    "PBAB+Collabs/tboa/",
+    "BasicRandomizer.sol",
+    "BasicRandomizerV2.sol",
+  ],
+  mocha: {
+    // coverage distorts gas tests, so disable it
+    // ref: https://github.com/sc-forks/solidity-coverage/blob/master/docs/advanced.md#skipping-tests
+    grep: "@skip-on-coverage", // Find everything with this tag
+    invert: true, // Run the grep's inverse set.
+  },
+};

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "docgen": "hardhat docgen",
     "generate:typechain": "typechain --target ethers-v5 --outDir ./scripts/contracts './artifacts/contracts/**/!(*.dbg)*.json'",
     "test": "hardhat test",
+    "coverage": "hardhat coverage",
     "format": "prettier --write 'contracts/**/*.sol' && prettier --write 'scripts/**/*.ts' && prettier --write 'test/**/*.ts'",
     "lint": "prettier --check 'contracts/**/*.sol' && prettier --check 'scripts/**/*.ts' && prettier --check 'test/**/*.ts'",
     "remix": "remixd -s ./ --remix-ide https://remix.ethereum.org"
@@ -56,7 +57,7 @@
     "prettier": "^2.3.2",
     "prettier-plugin-solidity": "^1.0.0-beta.19",
     "prompt-sync": "^4.2.0",
-    "solidity-coverage": "^0.7.10",
+    "solidity-coverage": "^0.7.21",
     "ts-node": "^9.1.1",
     "typechain": "^4.0.3",
     "typescript": "^4.2.3"

--- a/test/Legacy/GenArt721LegacyMinter.test.ts
+++ b/test/Legacy/GenArt721LegacyMinter.test.ts
@@ -80,7 +80,7 @@ describe("GenArt721Minter", async function () {
   });
 
   describe("(LEGACY MINTER) purchase method", async function () {
-    it("mints and calculates gas values", async function () {
+    it("mints and calculates gas values [ @skip-on-coverage ]", async function () {
       await this.minter.connect(this.accounts.user).purchase(this.projectZero, {
         value: this.pricePerTokenInWei,
       });

--- a/test/core/GenArt721CoreV1_Integration.tests.ts
+++ b/test/core/GenArt721CoreV1_Integration.tests.ts
@@ -70,7 +70,7 @@ describe("GenArt721CoreV1 Integration", async function () {
   });
 
   describe("purchase payments and gas", async function () {
-    it("can create a token then funds distributed (no additional payee)", async function () {
+    it("can create a token then funds distributed (no additional payee) [ @skip-on-coverage ]", async function () {
       const artistBalance = await this.accounts.artist.getBalance();
       const ownerBalance = await this.accounts.user.getBalance();
       const deployerBalance = await this.accounts.deployer.getBalance();
@@ -107,7 +107,7 @@ describe("GenArt721CoreV1 Integration", async function () {
       ).to.equal(ethers.utils.parseEther("1.0361817").mul("-1")); // spent 1 ETH
     });
 
-    it("can create a token then funds distributed (with additional payee)", async function () {
+    it("can create a token then funds distributed (with additional payee) [ @skip-on-coverage ]", async function () {
       const additionalBalance = await this.accounts.additional.getBalance();
       const artistBalance = await this.accounts.artist.getBalance();
       const ownerBalance = await this.accounts.user.getBalance();
@@ -157,7 +157,7 @@ describe("GenArt721CoreV1 Integration", async function () {
       ).to.equal(ethers.utils.parseEther("0.8002491"));
     });
 
-    it("can create a token then funds distributed (with additional payee getting 100%)", async function () {
+    it("can create a token then funds distributed (with additional payee getting 100%) [ @skip-on-coverage ]", async function () {
       const additionalBalance = await this.accounts.additional.getBalance();
       const artistBalance = await this.accounts.artist.getBalance();
       const ownerBalance = await this.accounts.user.getBalance();

--- a/test/core/GenArt721CoreV2_PRTNR_Integration.tests.ts
+++ b/test/core/GenArt721CoreV2_PRTNR_Integration.tests.ts
@@ -71,7 +71,7 @@ describe("GenArt721CoreV2_PRTNR_Integration", async function () {
   });
 
   describe("purchase payments and gas", async function () {
-    it("can create a token then funds distributed (no additional payee)", async function () {
+    it("can create a token then funds distributed (no additional payee) [ @skip-on-coverage ]", async function () {
       const artistBalance = await this.accounts.artist.getBalance();
       const ownerBalance = await this.accounts.user.getBalance();
       const deployerBalance = await this.accounts.deployer.getBalance();
@@ -108,7 +108,7 @@ describe("GenArt721CoreV2_PRTNR_Integration", async function () {
       ).to.equal(ethers.utils.parseEther("1.0216789").mul("-1")); // spent 1 ETH
     });
 
-    it("can create a token then funds distributed (with additional payee)", async function () {
+    it("can create a token then funds distributed (with additional payee) [ @skip-on-coverage ]", async function () {
       const additionalBalance = await this.accounts.additional.getBalance();
       const artistBalance = await this.accounts.artist.getBalance();
       const ownerBalance = await this.accounts.user.getBalance();
@@ -158,7 +158,7 @@ describe("GenArt721CoreV2_PRTNR_Integration", async function () {
       ).to.equal(ethers.utils.parseEther("0.8002442"));
     });
 
-    it("can create a token then funds distributed (with additional payee getting 100%)", async function () {
+    it("can create a token then funds distributed (with additional payee getting 100%) [ @skip-on-coverage ]", async function () {
       const additionalBalance = await this.accounts.additional.getBalance();
       const artistBalance = await this.accounts.artist.getBalance();
       const ownerBalance = await this.accounts.user.getBalance();

--- a/test/core/gas-tests/GenArt721CoreV1_GasTests.test.ts
+++ b/test/core/gas-tests/GenArt721CoreV1_GasTests.test.ts
@@ -91,7 +91,7 @@ describe("GenArt721CoreV1 Gas Tests", async function () {
   });
 
   describe("mint gas optimization", function () {
-    it("test gas cost of mint on MinterSetPrice", async function () {
+    it("test gas cost of mint on MinterSetPrice [ @skip-on-coverage ]", async function () {
       // mint
       const tx = await this.minter
         .connect(this.accounts.user)
@@ -110,7 +110,7 @@ describe("GenArt721CoreV1 Gas Tests", async function () {
       );
     });
 
-    it("test gas cost of mint on MinterDAExp", async function () {
+    it("test gas cost of mint on MinterDAExp [ @skip-on-coverage ]", async function () {
       this.startingPrice = ethers.utils.parseEther("10");
       this.higherPricePerTokenInWei = this.startingPrice.add(
         ethers.utils.parseEther("0.1")

--- a/test/core/gas-tests/GenArt721CoreV3_GasTests.test.ts
+++ b/test/core/gas-tests/GenArt721CoreV3_GasTests.test.ts
@@ -103,7 +103,7 @@ describe("GenArt721CoreV3 Gas Tests", async function () {
   });
 
   describe("mint gas optimization", function () {
-    it("test gas cost of mint on MinterSetPrice", async function () {
+    it("test gas cost of mint on MinterSetPrice [ @skip-on-coverage ]", async function () {
       // mint
       const tx = await this.minter
         .connect(this.accounts.user)
@@ -122,7 +122,7 @@ describe("GenArt721CoreV3 Gas Tests", async function () {
       );
     });
 
-    it("test gas cost of mint on MinterDAExp", async function () {
+    it("test gas cost of mint on MinterDAExp [ @skip-on-coverage ]", async function () {
       this.startingPrice = ethers.utils.parseEther("10");
       this.higherPricePerTokenInWei = this.startingPrice.add(
         ethers.utils.parseEther("0.1")

--- a/test/minter-filter/enumeration/MinterFilterEnumeration.common.ts
+++ b/test/minter-filter/enumeration/MinterFilterEnumeration.common.ts
@@ -20,7 +20,8 @@ export const MinterFilterEnumeration_Common = async () => {
         expect(numProjects).to.be.equal(0);
       });
 
-      it("throws when getting info at non-existent index", async function () {
+      // solidity-coverage swallows the OpenZeppelin's lib error message text, so skip on coverage
+      it("throws when getting info at non-existent index [ @skip-on-coverage ]", async function () {
         await expectRevert(
           this.minterFilter
             .connect(this.accounts.deployer)

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV0.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV0.test.ts
@@ -113,7 +113,7 @@ describe("MinterDAExpV0_V1Core", async function () {
   });
 
   describe("calculate gas", async function () {
-    it("mints and calculates gas values", async function () {
+    it("mints and calculates gas values [ @skip-on-coverage ]", async function () {
       await ethers.provider.send("evm_mine", [
         this.startTime + this.auctionStartTimeOffset,
       ]);

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV1.PRTNR.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV1.PRTNR.test.ts
@@ -112,7 +112,7 @@ describe("MinterDAExpV1_V1Core", async function () {
   });
 
   describe("calculate gas", async function () {
-    it("mints and calculates gas values", async function () {
+    it("mints and calculates gas values [ @skip-on-coverage ]", async function () {
       await ethers.provider.send("evm_mine", [
         this.startTime + this.auctionStartTimeOffset,
       ]);

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV1.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV1.test.ts
@@ -112,7 +112,7 @@ describe("MinterDAExpV1_V1Core", async function () {
   });
 
   describe("calculate gas", async function () {
-    it("mints and calculates gas values", async function () {
+    it("mints and calculates gas values [ @skip-on-coverage ]", async function () {
       await ethers.provider.send("evm_mine", [
         this.startTime + this.auctionStartTimeOffset,
       ]);

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
@@ -112,7 +112,7 @@ describe("MinterDAExpV2_V3Core", async function () {
   });
 
   describe("calculate gas", async function () {
-    it("mints and calculates gas values", async function () {
+    it("mints and calculates gas values [ @skip-on-coverage ]", async function () {
       await ethers.provider.send("evm_mine", [
         this.startTime + this.auctionStartTimeOffset,
       ]);

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV0.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV0.test.ts
@@ -113,7 +113,7 @@ describe("MinterDALinV0_V1Core", async function () {
   });
 
   describe("calculate gas", async function () {
-    it("mints and calculates gas values", async function () {
+    it("mints and calculates gas values [ @skip-on-coverage ]", async function () {
       await ethers.provider.send("evm_mine", [
         this.startTime + this.auctionStartTimeOffset,
       ]);

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV1.PRTNR.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV1.PRTNR.test.ts
@@ -111,7 +111,7 @@ describe("MinterDALinV1_V2PRTNRCore", async function () {
   });
 
   describe("calculate gas", async function () {
-    it("mints and calculates gas values", async function () {
+    it("mints and calculates gas values [ @skip-on-coverage ]", async function () {
       await ethers.provider.send("evm_mine", [
         this.startTime + this.auctionStartTimeOffset,
       ]);

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV1.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV1.test.ts
@@ -111,7 +111,7 @@ describe("MinterDALinV1_V1Core", async function () {
   });
 
   describe("calculate gas", async function () {
-    it("mints and calculates gas values", async function () {
+    it("mints and calculates gas values [ @skip-on-coverage ]", async function () {
       await ethers.provider.send("evm_mine", [
         this.startTime + this.auctionStartTimeOffset,
       ]);

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
@@ -111,7 +111,7 @@ describe("MinterDALinV2_V3Core", async function () {
   });
 
   describe("calculate gas", async function () {
-    it("mints and calculates gas values", async function () {
+    it("mints and calculates gas values [ @skip-on-coverage ]", async function () {
       await ethers.provider.send("evm_mine", [
         this.startTime + this.auctionStartTimeOffset,
       ]);

--- a/test/minter-suite-minters/MinterHolder/MinterHolderV0.test.ts
+++ b/test/minter-suite-minters/MinterHolder/MinterHolderV0.test.ts
@@ -158,7 +158,7 @@ describe("MinterHolderV0", async function () {
   });
 
   describe("calculates gas", async function () {
-    it("mints and calculates gas values", async function () {
+    it("mints and calculates gas values [ @skip-on-coverage ]", async function () {
       const tx = await this.minter
         .connect(this.accounts.artist)
         ["purchase(uint256,address,uint256)"](

--- a/test/minter-suite-minters/MinterHolder/MinterHolderV1.test.ts
+++ b/test/minter-suite-minters/MinterHolder/MinterHolderV1.test.ts
@@ -157,7 +157,7 @@ describe("MinterHolderV1", async function () {
   });
 
   describe("calculates gas", async function () {
-    it("mints and calculates gas values", async function () {
+    it("mints and calculates gas values [ @skip-on-coverage ]", async function () {
       const tx = await this.minter
         .connect(this.accounts.artist)
         ["purchase(uint256,address,uint256)"](

--- a/test/minter-suite-minters/MinterMerkle/MinterMerkleV0.test.ts
+++ b/test/minter-suite-minters/MinterMerkle/MinterMerkleV0.test.ts
@@ -171,7 +171,7 @@ describe("MinterMerkleV0", async function () {
   });
 
   describe("calculates gas", async function () {
-    it("mints and calculates gas values", async function () {
+    it("mints and calculates gas values [ @skip-on-coverage ]", async function () {
       const userMerkleProofOne = this.merkleTreeOne.getHexProof(
         hashAddress(this.accounts.user.address)
       );
@@ -193,7 +193,7 @@ describe("MinterMerkleV0", async function () {
         .true;
     });
 
-    it("is gas performant at 1k length allowlist", async function () {
+    it("is gas performant at 1k length allowlist [ @skip-on-coverage ]", async function () {
       // build new Merkle tree from 1k addresses, including user's address
       const _allowlist = [this.accounts.user.address];
       const crypto = require("crypto");

--- a/test/minter-suite-minters/MinterMerkle/MinterMerkleV1.test.ts
+++ b/test/minter-suite-minters/MinterMerkle/MinterMerkleV1.test.ts
@@ -171,7 +171,7 @@ describe("MinterMerkleV1", async function () {
   });
 
   describe("calculates gas", async function () {
-    it("mints and calculates gas values", async function () {
+    it("mints and calculates gas values [ @skip-on-coverage ]", async function () {
       const userMerkleProofOne = this.merkleTreeOne.getHexProof(
         hashAddress(this.accounts.user.address)
       );
@@ -193,7 +193,7 @@ describe("MinterMerkleV1", async function () {
         .true;
     });
 
-    it("is gas performant at 1k length allowlist", async function () {
+    it("is gas performant at 1k length allowlist [ @skip-on-coverage ]", async function () {
       // build new Merkle tree from 1k addresses, including user's address
       const _allowlist = [this.accounts.user.address];
       const crypto = require("crypto");

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV0.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV0.test.ts
@@ -145,7 +145,7 @@ describe("MinterSetPriceV0_V1Core", async function () {
   });
 
   describe("calculates gas", async function () {
-    it("mints and calculates gas values", async function () {
+    it("mints and calculates gas values [ @skip-on-coverage ]", async function () {
       const tx = await this.minter1
         .connect(this.accounts.user)
         .purchase(this.projectZero, {

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV1.PRTNR.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV1.PRTNR.test.ts
@@ -140,7 +140,7 @@ describe("MinterSetPriceV1_V2PRTNRCore", async function () {
   });
 
   describe("calculates gas", async function () {
-    it("mints and calculates gas values", async function () {
+    it("mints and calculates gas values [ @skip-on-coverage ]", async function () {
       const tx = await this.minter1
         .connect(this.accounts.user)
         .purchase(this.projectZero, {

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV1.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV1.test.ts
@@ -141,7 +141,7 @@ describe("MinterSetPriceV1_V1Core", async function () {
   });
 
   describe("calculates gas", async function () {
-    it("mints and calculates gas values", async function () {
+    it("mints and calculates gas values [ @skip-on-coverage ]", async function () {
       const tx = await this.minter1
         .connect(this.accounts.user)
         .purchase(this.projectZero, {

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
@@ -144,7 +144,7 @@ describe("MinterSetPriceV2_V3Core", async function () {
   });
 
   describe("calculates gas", async function () {
-    it("mints and calculates gas values", async function () {
+    it("mints and calculates gas values [ @skip-on-coverage ]", async function () {
       const tx = await this.minter1
         .connect(this.accounts.user)
         .purchase(this.projectZero, {

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V0.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V0.test.ts
@@ -123,7 +123,7 @@ describe("MinterSetPriceERC20V0_V1Core", async function () {
   });
 
   describe("calculates gas", async function () {
-    it("mints and calculates gas values", async function () {
+    it("mints and calculates gas values [ @skip-on-coverage ]", async function () {
       const tx = await this.minter
         .connect(this.accounts.user)
         .purchase(this.projectOne, {

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V1.PRTNR.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V1.PRTNR.test.ts
@@ -122,7 +122,7 @@ describe("MinterSetPriceERC20V1_V2PRTNRCore", async function () {
   });
 
   describe("calculates gas", async function () {
-    it("mints and calculates gas values", async function () {
+    it("mints and calculates gas values [ @skip-on-coverage ]", async function () {
       const tx = await this.minter
         .connect(this.accounts.user)
         .purchase(this.projectOne, {

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V1.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V1.test.ts
@@ -127,7 +127,7 @@ describe("MinterSetPriceERC20V1_V1Core", async function () {
   });
 
   describe("calculates gas", async function () {
-    it("mints and calculates gas values", async function () {
+    it("mints and calculates gas values [ @skip-on-coverage ]", async function () {
       const tx = await this.minter
         .connect(this.accounts.user)
         .purchase(this.projectOne, {

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
@@ -127,7 +127,7 @@ describe("MinterSetPriceERC20V2_V3Core", async function () {
   });
 
   describe("calculates gas", async function () {
-    it("mints and calculates gas values", async function () {
+    it("mints and calculates gas values [ @skip-on-coverage ]", async function () {
       const tx = await this.minter
         .connect(this.accounts.user)
         .purchase(this.projectOne, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2337,13 +2337,6 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
-"@solidity-parser/parser@^0.13.2":
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.13.2.tgz#b6c71d8ca0b382d90a7bbed241f9bc110af65cbe"
-  integrity sha512-RwHnpRnfrnD2MSPveYoPh8nhofEvX7fgjHk1Oq+NNvCcLx4r1js91CO9o+F/F3fBzOCyvm8kKRTriFICX/odWw==
-  dependencies:
-    antlr4ts "^0.5.0-alpha.4"
-
 "@solidity-parser/parser@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.14.0.tgz#d51f074efb0acce0e953ec48133561ed710cebc0"
@@ -7034,7 +7027,7 @@ functional-red-black-tree@^1.0.1, functional-red-black-tree@~1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-ganache-cli@^6.1.0, ganache-cli@^6.12.2:
+ganache-cli@^6.1.0:
   version "6.12.2"
   resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.12.2.tgz#c0920f7db0d4ac062ffe2375cb004089806f627a"
   integrity sha512-bnmwnJDBDsOWBUP8E/BExWf85TsdDEFelQSzihSJm9VChVO1SHp94YXLP5BlA4j/OTxp0wR4R1Tje9OHOuAJVw==
@@ -11577,18 +11570,17 @@ solidity-comments-extractor@^0.0.7:
   resolved "https://registry.yarnpkg.com/solidity-comments-extractor/-/solidity-comments-extractor-0.0.7.tgz#99d8f1361438f84019795d928b931f4e5c39ca19"
   integrity sha512-wciNMLg/Irp8OKGrh3S2tfvZiZ0NEyILfcRCXCD4mp7SgK/i9gzLfhY2hY7VMCQJ3kH9UB9BzNdibIVMchzyYw==
 
-solidity-coverage@^0.7.10:
-  version "0.7.17"
-  resolved "https://registry.yarnpkg.com/solidity-coverage/-/solidity-coverage-0.7.17.tgz#5139de8f6666d4755d88f453d8e35632a7bb3444"
-  integrity sha512-Erw2hd2xdACAvDX8jUdYkmgJlIIazGznwDJA5dhRaw4def2SisXN9jUjneeyOZnl/E7j6D3XJYug4Zg9iwodsg==
+solidity-coverage@^0.7.21:
+  version "0.7.21"
+  resolved "https://registry.yarnpkg.com/solidity-coverage/-/solidity-coverage-0.7.21.tgz#20c5615a3a543086b243c2ca36e2951a75316b40"
+  integrity sha512-O8nuzJ9yXiKUx3NdzVvHrUW0DxoNVcGzq/I7NzewNO9EZE3wYAQ4l8BwcnV64r4aC/HB6Vnw/q2sF0BQHv/3fg==
   dependencies:
-    "@solidity-parser/parser" "^0.13.2"
+    "@solidity-parser/parser" "^0.14.0"
     "@truffle/provider" "^0.2.24"
     chalk "^2.4.2"
     death "^1.1.0"
     detect-port "^1.3.0"
     fs-extra "^8.1.0"
-    ganache-cli "^6.12.2"
     ghost-testrpc "^0.0.2"
     global-modules "^2.0.0"
     globby "^10.0.1"


### PR DESCRIPTION
## Only merge after #238 

Configure and update solidity-coverage hardhat plugin.

This:
- updates our solidity-coverage plugin to the most recent version
- adds a coverage command to generate a coverage report
- configures our coverage via `.solcover.js`
  - skip appropriate .sol files
  - skip tests flagged with `@skip-on-coverage` [reference solution used](https://github.com/sc-forks/solidity-coverage/blob/master/docs/advanced.md#skipping-tests)
- flags tests related to gas-costs to be skipped
  - (solidity-coverage recommends this because it returns incorrect gas costs and causes invalid test failures)
    - see "distorts gas consumption" [on lib's repo readme](https://github.com/sc-forks/solidity-coverage)


Currently:
- V3 core at 97.2% coverage 🎉 
- Latest minters generally around 85-95% coverage

Overall, we don't have any major holes in our testing, but would like to improve to 100% prior to audit.
  
## Follow-on
- Auto-generate coverage reports for PRs (need to figure out the best way to do this)
- PR to reach 100% coverage on V3 core and most recent minters