### PR TITLE
Optional gas-optimal minter purchase function names

### DIFF
--- a/contracts/minter-suite/Minters/MinterDAExp/MinterDAExpV2.sol
+++ b/contracts/minter-suite/Minters/MinterDAExp/MinterDAExpV2.sol
@@ -264,7 +264,19 @@ contract MinterDAExpV2 is ReentrancyGuard, IFilteredMinterV0 {
         payable
         returns (uint256 tokenId)
     {
-        tokenId = purchaseTo(msg.sender, _projectId);
+        tokenId = purchaseTo_do6(msg.sender, _projectId);
+        return tokenId;
+    }
+
+    /**
+     * @notice gas-optimized version of purchase(uint256).
+     */
+    function purchase_H4M(uint256 _projectId)
+        external
+        payable
+        returns (uint256 tokenId)
+    {
+        tokenId = purchaseTo_do6(msg.sender, _projectId);
         return tokenId;
     }
 
@@ -276,6 +288,17 @@ contract MinterDAExpV2 is ReentrancyGuard, IFilteredMinterV0 {
      * @return tokenId Token ID of minted token
      */
     function purchaseTo(address _to, uint256 _projectId)
+        external
+        payable
+        returns (uint256 tokenId)
+    {
+        return purchaseTo_do6(_to, _projectId);
+    }
+
+    /**
+     * @notice gas-optimized version of purchaseTo(address, uint256).
+     */
+    function purchaseTo_do6(address _to, uint256 _projectId)
         public
         payable
         nonReentrant

--- a/contracts/minter-suite/Minters/MinterDALin/MinterDALinV2.sol
+++ b/contracts/minter-suite/Minters/MinterDALin/MinterDALinV2.sol
@@ -238,7 +238,19 @@ contract MinterDALinV2 is ReentrancyGuard, IFilteredMinterV0 {
         payable
         returns (uint256 tokenId)
     {
-        tokenId = purchaseTo(msg.sender, _projectId);
+        tokenId = purchaseTo_do6(msg.sender, _projectId);
+        return tokenId;
+    }
+
+    /**
+     * @notice gas-optimized version of purchase(uint256).
+     */
+    function purchase_H4M(uint256 _projectId)
+        external
+        payable
+        returns (uint256 tokenId)
+    {
+        tokenId = purchaseTo_do6(msg.sender, _projectId);
         return tokenId;
     }
 
@@ -250,6 +262,17 @@ contract MinterDALinV2 is ReentrancyGuard, IFilteredMinterV0 {
      * @return tokenId Token ID of minted token
      */
     function purchaseTo(address _to, uint256 _projectId)
+        external
+        payable
+        returns (uint256 tokenId)
+    {
+        return purchaseTo_do6(_to, _projectId);
+    }
+
+    /**
+     * @notice gas-optimized version of purchaseTo(address, uint256).
+     */
+    function purchaseTo_do6(address _to, uint256 _projectId)
         public
         payable
         nonReentrant

--- a/contracts/minter-suite/Minters/MinterHolder/MinterHolderV1.sol
+++ b/contracts/minter-suite/Minters/MinterHolder/MinterHolderV1.sol
@@ -398,7 +398,24 @@ contract MinterHolderV1 is ReentrancyGuard, IFilteredMinterHolderV0 {
         address _ownedNFTAddress,
         uint256 _ownedNFTTokenId
     ) external payable returns (uint256 tokenId) {
-        tokenId = purchaseTo(
+        tokenId = purchaseTo_L69(
+            msg.sender,
+            _projectId,
+            _ownedNFTAddress,
+            _ownedNFTTokenId
+        );
+        return tokenId;
+    }
+
+    /**
+     * @notice gas-optimized version of purchase(uint256,address,uint256).
+     */
+    function purchase_nnf(
+        uint256 _projectId,
+        address _ownedNFTAddress,
+        uint256 _ownedNFTTokenId
+    ) external payable returns (uint256 tokenId) {
+        tokenId = purchaseTo_L69(
             msg.sender,
             _projectId,
             _ownedNFTAddress,
@@ -419,6 +436,19 @@ contract MinterHolderV1 is ReentrancyGuard, IFilteredMinterHolderV0 {
      * @return tokenId Token ID of minted token
      */
     function purchaseTo(
+        address _to,
+        uint256 _projectId,
+        address _ownedNFTAddress,
+        uint256 _ownedNFTTokenId
+    ) external payable returns (uint256 tokenId) {
+        return
+            purchaseTo_L69(_to, _projectId, _ownedNFTAddress, _ownedNFTTokenId);
+    }
+
+    /**
+     * @notice gas-optimized version of purchaseTo(address,uint256,address,uint256).
+     */
+    function purchaseTo_L69(
         address _to,
         uint256 _projectId,
         address _ownedNFTAddress,

--- a/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
+++ b/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
@@ -241,7 +241,19 @@ contract MinterMerkleV1 is ReentrancyGuard, IFilteredMinterMerkleV0 {
         payable
         returns (uint256 tokenId)
     {
-        tokenId = purchaseTo(msg.sender, _projectId, _proof);
+        tokenId = purchaseTo_K1L(msg.sender, _projectId, _proof);
+        return tokenId;
+    }
+
+    /**
+     * @notice gas-optimized version of purchase(uint256,bytes32[]).
+     */
+    function purchase_gD5(uint256 _projectId, bytes32[] calldata _proof)
+        external
+        payable
+        returns (uint256 tokenId)
+    {
+        tokenId = purchaseTo_K1L(msg.sender, _projectId, _proof);
         return tokenId;
     }
 
@@ -254,6 +266,17 @@ contract MinterMerkleV1 is ReentrancyGuard, IFilteredMinterMerkleV0 {
      * @return tokenId Token ID of minted token
      */
     function purchaseTo(
+        address _to,
+        uint256 _projectId,
+        bytes32[] calldata _proof
+    ) external payable returns (uint256 tokenId) {
+        return purchaseTo_K1L(_to, _projectId, _proof);
+    }
+
+    /**
+     * @notice gas-optimized version of purchaseTo(address,uint256,bytes32[]).
+     */
+    function purchaseTo_K1L(
         address _to,
         uint256 _projectId,
         bytes32[] calldata _proof

--- a/contracts/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
+++ b/contracts/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
@@ -177,7 +177,7 @@ contract MinterSetPriceV2 is ReentrancyGuard, IFilteredMinterV0 {
     }
 
     /**
-     * @notice gas-optimized version of purchase(address, uint256).
+     * @notice gas-optimized version of purchaseTo(address, uint256).
      */
     function purchaseTo_do6(address _to, uint256 _projectId)
         public

--- a/contracts/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
+++ b/contracts/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
@@ -145,7 +145,7 @@ contract MinterSetPriceV2 is ReentrancyGuard, IFilteredMinterV0 {
         payable
         returns (uint256 tokenId)
     {
-        tokenId = purchaseTo(msg.sender, _projectId);
+        tokenId = purchaseTo_do6(msg.sender, _projectId);
         return tokenId;
     }
 
@@ -169,7 +169,7 @@ contract MinterSetPriceV2 is ReentrancyGuard, IFilteredMinterV0 {
      * @return tokenId Token ID of minted token
      */
     function purchaseTo(address _to, uint256 _projectId)
-        public
+        external
         payable
         returns (uint256 tokenId)
     {

--- a/contracts/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
+++ b/contracts/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
@@ -178,9 +178,6 @@ contract MinterSetPriceV2 is ReentrancyGuard, IFilteredMinterV0 {
 
     /**
      * @notice gas-optimized version of purchase(address, uint256).
-     * @param _to Address to be the new token's owner.
-     * @param _projectId Project ID to mint a token on.
-     * @return tokenId Token ID of minted token
      */
     function purchaseTo_do6(address _to, uint256 _projectId)
         public

--- a/contracts/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
+++ b/contracts/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
@@ -150,6 +150,18 @@ contract MinterSetPriceV2 is ReentrancyGuard, IFilteredMinterV0 {
     }
 
     /**
+     * @notice gas-optimized version of purchase(uint256).
+     */
+    function purchase_H4M(uint256 _projectId)
+        external
+        payable
+        returns (uint256 tokenId)
+    {
+        tokenId = purchaseTo_do6(msg.sender, _projectId);
+        return tokenId;
+    }
+
+    /**
      * @notice Purchases a token from project `_projectId` and sets
      * the token's owner to `_to`.
      * @param _to Address to be the new token's owner.
@@ -157,6 +169,20 @@ contract MinterSetPriceV2 is ReentrancyGuard, IFilteredMinterV0 {
      * @return tokenId Token ID of minted token
      */
     function purchaseTo(address _to, uint256 _projectId)
+        public
+        payable
+        returns (uint256 tokenId)
+    {
+        return purchaseTo_do6(_to, _projectId);
+    }
+
+    /**
+     * @notice gas-optimized version of purchase(address, uint256).
+     * @param _to Address to be the new token's owner.
+     * @param _projectId Project ID to mint a token on.
+     * @return tokenId Token ID of minted token
+     */
+    function purchaseTo_do6(address _to, uint256 _projectId)
         public
         payable
         nonReentrant

--- a/contracts/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V2.sol
+++ b/contracts/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V2.sol
@@ -215,7 +215,19 @@ contract MinterSetPriceERC20V2 is ReentrancyGuard, IFilteredMinterV0 {
         payable
         returns (uint256 tokenId)
     {
-        tokenId = purchaseTo(msg.sender, _projectId);
+        tokenId = purchaseTo_do6(msg.sender, _projectId);
+        return tokenId;
+    }
+
+    /**
+     * @notice gas-optimized version of purchase(uint256).
+     */
+    function purchase_H4M(uint256 _projectId)
+        external
+        payable
+        returns (uint256 tokenId)
+    {
+        tokenId = purchaseTo_do6(msg.sender, _projectId);
         return tokenId;
     }
 
@@ -227,6 +239,17 @@ contract MinterSetPriceERC20V2 is ReentrancyGuard, IFilteredMinterV0 {
      * @return tokenId Token ID of minted token
      */
     function purchaseTo(address _to, uint256 _projectId)
+        external
+        payable
+        returns (uint256 tokenId)
+    {
+        return purchaseTo_do6(_to, _projectId);
+    }
+
+    /**
+     * @notice gas-optimized version of purchase(address, uint256).
+     */
+    function purchaseTo_do6(address _to, uint256 _projectId)
         public
         payable
         nonReentrant

--- a/contracts/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V2.sol
+++ b/contracts/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V2.sol
@@ -247,7 +247,7 @@ contract MinterSetPriceERC20V2 is ReentrancyGuard, IFilteredMinterV0 {
     }
 
     /**
-     * @notice gas-optimized version of purchase(address, uint256).
+     * @notice gas-optimized version of purchaseTo(address, uint256).
      */
     function purchaseTo_do6(address _to, uint256 _projectId)
         public

--- a/test/core/gas-tests/GenArt721CoreV3_GasTests.test.ts
+++ b/test/core/gas-tests/GenArt721CoreV3_GasTests.test.ts
@@ -218,7 +218,7 @@ describe("GenArt721CoreV3 Gas Tests", async function () {
       // mint
       const tx = await this.minterDAExp
         .connect(this.accounts.user)
-        .purchase(this.projectThree, { value: this.startingPrice });
+        .purchase_H4M(this.projectThree, { value: this.startingPrice });
       const receipt = await ethers.provider.getTransactionReceipt(tx.hash);
       console.log(`gas used for mint optimization test: ${receipt.gasUsed}`);
       const gasCostAt100gwei = receipt.effectiveGasPrice

--- a/test/core/gas-tests/GenArt721CoreV3_GasTests.test.ts
+++ b/test/core/gas-tests/GenArt721CoreV3_GasTests.test.ts
@@ -269,7 +269,7 @@ describe("GenArt721CoreV3 Gas Tests", async function () {
       // mint
       const tx = await this.minterDALin
         .connect(this.accounts.user)
-        .purchase(this.projectThree, { value: this.startingPrice });
+        .purchase_H4M(this.projectThree, { value: this.startingPrice });
       const receipt = await ethers.provider.getTransactionReceipt(tx.hash);
       console.log(`gas used for mint optimization test: ${receipt.gasUsed}`);
       const gasCostAt100gwei = receipt.effectiveGasPrice

--- a/test/core/gas-tests/GenArt721CoreV3_GasTests.test.ts
+++ b/test/core/gas-tests/GenArt721CoreV3_GasTests.test.ts
@@ -135,7 +135,7 @@ describe("GenArt721CoreV3 Gas Tests", async function () {
       // mint
       const tx = await this.minter
         .connect(this.accounts.user)
-        .purchase(this.projectThree, { value: this.pricePerTokenInWei });
+        .purchase_H4M(this.projectThree, { value: this.pricePerTokenInWei });
       const receipt = await ethers.provider.getTransactionReceipt(tx.hash);
       console.log(`gas used for mint optimization test: ${receipt.gasUsed}`);
       const gasCostAt100gwei = receipt.effectiveGasPrice

--- a/test/core/gas-tests/GenArt721CoreV3_GasTests.test.ts
+++ b/test/core/gas-tests/GenArt721CoreV3_GasTests.test.ts
@@ -323,7 +323,7 @@ describe("GenArt721CoreV3 Gas Tests", async function () {
       // mint
       const tx = await this.minterMerkle
         .connect(this.accounts.user)
-        ["purchase(uint256,bytes32[])"](this.projectThree, userMerkleProof, {
+        .purchase_gD5(this.projectThree, userMerkleProof, {
           value: this.pricePerTokenInWei,
         });
       // report gas

--- a/test/core/gas-tests/GenArt721CoreV3_GasTests.test.ts
+++ b/test/core/gas-tests/GenArt721CoreV3_GasTests.test.ts
@@ -393,7 +393,7 @@ describe("GenArt721CoreV3 Gas Tests", async function () {
       // mint on MinterHolder
       const tx = await this.minterHolder
         .connect(this.accounts.user)
-        ["purchase(uint256,address,uint256)"](
+        .purchase_nnf(
           this.projectThree,
           this.genArt721Core.address,
           this.projectOneTokenOne.toNumber(),

--- a/test/core/gas-tests/GenArt721CoreV3_GasTests.test.ts
+++ b/test/core/gas-tests/GenArt721CoreV3_GasTests.test.ts
@@ -167,7 +167,7 @@ describe("GenArt721CoreV3 Gas Tests", async function () {
       // mint
       const tx = await this.minterSetPriceERC20
         .connect(this.accounts.user)
-        .purchase(this.projectThree, { value: this.pricePerTokenInWei });
+        .purchase_H4M(this.projectThree, { value: this.pricePerTokenInWei });
       const receipt = await ethers.provider.getTransactionReceipt(tx.hash);
       console.log(`gas used for mint optimization test: ${receipt.gasUsed}`);
       const gasCostAt100gwei = receipt.effectiveGasPrice

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
@@ -130,7 +130,7 @@ describe("MinterDAExpV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0192699")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.019271")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
@@ -130,7 +130,7 @@ describe("MinterDALinV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0192638")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0192649")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
@@ -158,7 +158,7 @@ describe("MinterSetPriceV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0180817")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0180828")); // assuming a cost of 100 GWEI
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
@@ -142,7 +142,7 @@ describe("MinterSetPriceERC20V2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0183037"));
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0183048"));
     });
   });
 


### PR DESCRIPTION
Add optional, gas-optimal V3 minter `purchase` and `purchaseTo` function names.

Note: This uses [Solidity Optimize Name](https://emn178.github.io/solidity-optimize-name/) to minimize important external/public function signatures.

## Design Choices
This PR keeps legacy and intuitive `purchase(uint256)` and `purchaseTo(address,uint256)` functions, but adds gas-optimized `purchase_H4M(uint256): 0x0000b460` and `purchaseTo_do6(address,uint256): 0x00009987` functions. The suffixes (e.g. "_H4M") are consistent across all minters, other than one-off minters that require extra arguments (where our frontend already requires extra minting logic anyway). One-off minters are updated as part of this PR - e.g. for MinterMerkle, `purchase(uint256,bytes32[]) -> purchase_gD5(uint256,bytes32[])`

Legacy `purchase` and `purchaseTo` functions remain, decoupling this logic from our frontend, and making use of the gas-optimized functions an "opt-in" option for users/fontend/integrators.

## Notes
- This PR also includes gas-optimized functions with different signatures for one-off purchase functions such as MinterMerkle and MinterHolder (e.g. for MinterMerkle, `purchase(uint256,bytes32[]) -> purchase_gD5(uint256,bytes32[])`)

## Gas impacts
Mint costs are slightly reduced (assuming optimized version of purchase, e.g. `purchase_H4M`, is called). Representative minter cost updates are shown in the table below.

_(All gas costs assume project 3 mint 501 of 1000)_
| Gas Test | Previous gas used to purchase | New gas used to purchase | % change |
| --- | --- | --- | --- |
| MinterSetPriceV2_V3Core | 146790 | 146529 | -0.2% (cheaper) |
| MinterDAExpV2_V3Core | 158511 | 158367 | -0.1% (cheaper) |
| MinterMerkleV1_V3Core | 180531 | 180410 | -0.1% (cheaper) |