### PR TITLE
Update details regarding minter projectMaxInvocations

### DIFF
--- a/contracts/V3_CHANGELOG.md
+++ b/contracts/V3_CHANGELOG.md
@@ -54,3 +54,5 @@ _This document is intended to document and explain the Art Blocks Core V3 change
   - Minimize costly SLOAD operations & re-organize logic to minimize gas usage
   - Optimize mint function signature to reduce gas usage
 - Update randomizer interface for V3 core contract
+- Only allow artists to reduce the number of maximum invocations
+  - Remove any unnecessary minter logic accordingly

--- a/contracts/minter-suite/Minters/MinterDALin/MinterDALinV2.sol
+++ b/contracts/minter-suite/Minters/MinterDALin/MinterDALinV2.sol
@@ -53,6 +53,7 @@ contract MinterDALinV2 is ReentrancyGuard, IFilteredMinterV0 {
     /// projectId => has project reached its maximum number of invocations?
     mapping(uint256 => bool) public projectMaxHasBeenInvoked;
     /// projectId => project's maximum number of invocations
+    /// optionally synced with core contract value, for gas optimization
     mapping(uint256 => uint256) public projectMaxInvocations;
     /// Minimum auction length in seconds
     uint256 public minimumAuctionLengthSeconds = 3600;
@@ -112,26 +113,22 @@ contract MinterDALinV2 is ReentrancyGuard, IFilteredMinterV0 {
     }
 
     /**
-     * @notice Sets the maximum invocations of project `_projectId` based
-     * on the value currently defined in the core contract.
+     * @notice Syncs local maximum invocations of project `_projectId` based on
+     * the value currently defined in the core contract. Only used for gas
+     * optimization of mints after maxInvocations has been reached.
      * @param _projectId Project ID to set the maximum invocations for.
-     * @dev also checks and may refresh projectMaxHasBeenInvoked for project
      * @dev this enables gas reduction after maxInvocations have been reached -
      * core contracts shall still enforce a maxInvocation check during mint.
+     * @dev function is intentionally not gated to any specific access control;
+     * it only syncs a local state variable to the core contract's state.
      */
-    function setProjectMaxInvocations(uint256 _projectId)
-        external
-        onlyCoreAdminACL(this.setProjectMaxInvocations.selector)
-    {
-        uint256 invocations;
+    function setProjectMaxInvocations(uint256 _projectId) external {
         uint256 maxInvocations;
-        (invocations, maxInvocations, , , ) = genArtCoreContract
-            .projectStateData(_projectId);
+        (, maxInvocations, , , ) = genArtCoreContract.projectStateData(
+            _projectId
+        );
         // update storage with results
         projectMaxInvocations[_projectId] = maxInvocations;
-        if (invocations < maxInvocations) {
-            projectMaxHasBeenInvoked[_projectId] = false;
-        }
     }
 
     /**
@@ -294,10 +291,8 @@ contract MinterDALinV2 is ReentrancyGuard, IFilteredMinterV0 {
         // EFFECTS
         tokenId = minterFilter.mint(_to, _projectId, msg.sender);
 
-        // What if this overflows, since default value of uint256 is 0?
-        // that is intended, so that by default the minter allows infinite transactions,
-        // allowing the artblocks contract to stop minting
-        // uint256 tokenInvocation = tokenId % ONE_MILLION;
+        // okay if this underflows because if statement will always eval false.
+        // this is only for gas optimization (core enforces maxInvocations).
         unchecked {
             if (
                 tokenId % ONE_MILLION == projectMaxInvocations[_projectId] - 1

--- a/contracts/minter-suite/Minters/MinterHolder/MinterHolderV1.sol
+++ b/contracts/minter-suite/Minters/MinterHolder/MinterHolderV1.sol
@@ -83,6 +83,7 @@ contract MinterHolderV1 is ReentrancyGuard, IFilteredMinterHolderV0 {
     /// projectId => has project reached its maximum number of invocations?
     mapping(uint256 => bool) public projectMaxHasBeenInvoked;
     /// projectId => project's maximum number of invocations
+    /// optionally synced with core contract value, for gas optimization
     mapping(uint256 => uint256) public projectMaxInvocations;
     /// projectId => price per token in wei - supersedes any defined core price
     mapping(uint256 => uint256) private projectIdToPricePerTokenInWei;
@@ -322,26 +323,22 @@ contract MinterHolderV1 is ReentrancyGuard, IFilteredMinterHolderV0 {
     }
 
     /**
-     * @notice Sets the maximum invocations of project `_projectId` based
-     * on the value currently defined in the core contract.
+     * @notice Syncs local maximum invocations of project `_projectId` based on
+     * the value currently defined in the core contract. Only used for gas
+     * optimization of mints after maxInvocations has been reached.
      * @param _projectId Project ID to set the maximum invocations for.
-     * @dev also checks and may refresh projectMaxHasBeenInvoked for project
      * @dev this enables gas reduction after maxInvocations have been reached -
      * core contracts shall still enforce a maxInvocation check during mint.
+     * @dev function is intentionally not gated to any specific access control;
+     * it only syncs a local state variable to the core contract's state.
      */
-    function setProjectMaxInvocations(uint256 _projectId)
-        external
-        onlyCoreAdminACL(this.setProjectMaxInvocations.selector)
-    {
-        uint256 invocations;
+    function setProjectMaxInvocations(uint256 _projectId) external {
         uint256 maxInvocations;
-        (invocations, maxInvocations, , , ) = genArtCoreContract
-            .projectStateData(_projectId);
+        (, maxInvocations, , , ) = genArtCoreContract.projectStateData(
+            _projectId
+        );
         // update storage with results
         projectMaxInvocations[_projectId] = maxInvocations;
-        if (invocations < maxInvocations) {
-            projectMaxHasBeenInvoked[_projectId] = false;
-        }
     }
 
     /**
@@ -483,10 +480,8 @@ contract MinterHolderV1 is ReentrancyGuard, IFilteredMinterHolderV0 {
         // EFFECTS
         tokenId = minterFilter.mint(_to, _projectId, msg.sender);
 
-        // What if this overflows, since default value of uint256 is 0?
-        // that is intended, so that by default the minter allows infinite transactions,
-        // allowing the artblocks contract to stop minting
-        // uint256 tokenInvocation = tokenId % ONE_MILLION;
+        // okay if this underflows because if statement will always eval false.
+        // this is only for gas optimization (core enforces maxInvocations).
         unchecked {
             if (
                 tokenId % ONE_MILLION == projectMaxInvocations[_projectId] - 1

--- a/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
+++ b/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
@@ -52,6 +52,7 @@ contract MinterMerkleV1 is ReentrancyGuard, IFilteredMinterMerkleV0 {
     /// projectId => has project reached its maximum number of invocations?
     mapping(uint256 => bool) public projectMaxHasBeenInvoked;
     /// projectId => project's maximum number of invocations
+    /// optionally synced with core contract value, for gas optimization
     mapping(uint256 => uint256) public projectMaxInvocations;
     /// projectId => price per token in wei - supersedes any defined core price
     mapping(uint256 => uint256) private projectIdToPricePerTokenInWei;
@@ -168,26 +169,22 @@ contract MinterMerkleV1 is ReentrancyGuard, IFilteredMinterMerkleV0 {
     }
 
     /**
-     * @notice Sets the maximum invocations of project `_projectId` based
-     * on the value currently defined in the core contract.
+     * @notice Syncs local maximum invocations of project `_projectId` based on
+     * the value currently defined in the core contract. Only used for gas
+     * optimization of mints after maxInvocations has been reached.
      * @param _projectId Project ID to set the maximum invocations for.
-     * @dev also checks and may refresh projectMaxHasBeenInvoked for project
      * @dev this enables gas reduction after maxInvocations have been reached -
      * core contracts shall still enforce a maxInvocation check during mint.
+     * @dev function is intentionally not gated to any specific access control;
+     * it only syncs a local state variable to the core contract's state.
      */
-    function setProjectMaxInvocations(uint256 _projectId)
-        external
-        onlyCoreAdminACL(this.setProjectMaxInvocations.selector)
-    {
-        uint256 invocations;
+    function setProjectMaxInvocations(uint256 _projectId) external {
         uint256 maxInvocations;
-        (invocations, maxInvocations, , , ) = genArtCoreContract
-            .projectStateData(_projectId);
+        (, maxInvocations, , , ) = genArtCoreContract.projectStateData(
+            _projectId
+        );
         // update storage with results
         projectMaxInvocations[_projectId] = maxInvocations;
-        if (invocations < maxInvocations) {
-            projectMaxHasBeenInvoked[_projectId] = false;
-        }
     }
 
     /**
@@ -322,10 +319,8 @@ contract MinterMerkleV1 is ReentrancyGuard, IFilteredMinterMerkleV0 {
 
         tokenId = minterFilter.mint(_to, _projectId, msg.sender);
 
-        // What if this overflows, since default value of uint256 is 0?
-        // that is intended, so that by default the minter allows infinite transactions,
-        // allowing the artblocks contract to stop minting
-        // uint256 tokenInvocation = tokenId % ONE_MILLION;
+        // okay if this underflows because if statement will always eval false.
+        // this is only for gas optimization (core enforces maxInvocations).
         unchecked {
             if (
                 tokenId % ONE_MILLION == projectMaxInvocations[_projectId] - 1

--- a/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
+++ b/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
@@ -59,20 +59,6 @@ contract MinterMerkleV1 is ReentrancyGuard, IFilteredMinterMerkleV0 {
     /// projectId => price per token has been configured on this minter
     mapping(uint256 => bool) private projectIdToPriceIsConfigured;
 
-    // modifier to restrict access to only AdminACL allowed calls
-    // @dev defers which ACL contract is used to the core contract
-    modifier onlyCoreAdminACL(bytes4 _selector) {
-        require(
-            genArtCoreContract.adminACLAllowed(
-                msg.sender,
-                address(this),
-                _selector
-            ),
-            "Only Core AdminACL allowed"
-        );
-        _;
-    }
-
     modifier onlyArtist(uint256 _projectId) {
         require(
             msg.sender ==

--- a/contracts/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
+++ b/contracts/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
@@ -88,9 +88,9 @@ contract MinterSetPriceV2 is ReentrancyGuard, IFilteredMinterV0 {
     }
 
     /**
-     * @notice Only used for gas optimization of mints after maxInvocations has
-     * been reached. Syncs local maximum invocations of project `_projectId`
-     * based on the value currently defined in the core contract.
+     * @notice Syncs local maximum invocations of project `_projectId` based on
+     * the value currently defined in the core contract. Only used for gas
+     * optimization of mints after maxInvocations has been reached.
      * @param _projectId Project ID to set the maximum invocations for.
      * @dev this enables gas reduction after maxInvocations have been reached -
      * core contracts shall still enforce a maxInvocation check during mint.
@@ -205,8 +205,8 @@ contract MinterSetPriceV2 is ReentrancyGuard, IFilteredMinterV0 {
         // EFFECTS
         tokenId = minterFilter.mint(_to, _projectId, msg.sender);
 
-        // Okay if this underflows because if statement will always eval false.
-        // This is only for gas optimization (core enforces maxInvocations).
+        // okay if this underflows because if statement will always eval false.
+        // this is only for gas optimization (core enforces maxInvocations).
         unchecked {
             if (
                 tokenId % ONE_MILLION == projectMaxInvocations[_projectId] - 1

--- a/contracts/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
+++ b/contracts/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
@@ -35,6 +35,7 @@ contract MinterSetPriceV2 is ReentrancyGuard, IFilteredMinterV0 {
     /// projectId => has project reached its maximum number of invocations?
     mapping(uint256 => bool) public projectMaxHasBeenInvoked;
     /// projectId => project's maximum number of invocations
+    /// optionally synced with core contract value, for gas optimization
     mapping(uint256 => uint256) public projectMaxInvocations;
     /// projectId => price per token in wei - supersedes any defined core price
     mapping(uint256 => uint256) private projectIdToPricePerTokenInWei;
@@ -87,26 +88,22 @@ contract MinterSetPriceV2 is ReentrancyGuard, IFilteredMinterV0 {
     }
 
     /**
-     * @notice Sets the maximum invocations of project `_projectId` based
-     * on the value currently defined in the core contract.
+     * @notice Only used for gas optimization of mints after maxInvocations has
+     * been reached. Syncs local maximum invocations of project `_projectId`
+     * based on the value currently defined in the core contract.
      * @param _projectId Project ID to set the maximum invocations for.
-     * @dev also checks and may refresh projectMaxHasBeenInvoked for project
      * @dev this enables gas reduction after maxInvocations have been reached -
      * core contracts shall still enforce a maxInvocation check during mint.
+     * @dev function is intentionally not gated to any specific access control;
+     * it only syncs a local state variable to the core contract's state.
      */
-    function setProjectMaxInvocations(uint256 _projectId)
-        external
-        onlyCoreAdminACL(this.setProjectMaxInvocations.selector)
-    {
-        uint256 invocations;
+    function setProjectMaxInvocations(uint256 _projectId) external {
         uint256 maxInvocations;
-        (invocations, maxInvocations, , , ) = genArtCoreContract
-            .projectStateData(_projectId);
+        (, maxInvocations, , , ) = genArtCoreContract.projectStateData(
+            _projectId
+        );
         // update storage with results
         projectMaxInvocations[_projectId] = maxInvocations;
-        if (invocations < maxInvocations) {
-            projectMaxHasBeenInvoked[_projectId] = false;
-        }
     }
 
     /**
@@ -208,10 +205,8 @@ contract MinterSetPriceV2 is ReentrancyGuard, IFilteredMinterV0 {
         // EFFECTS
         tokenId = minterFilter.mint(_to, _projectId, msg.sender);
 
-        // What if this overflows, since default value of uint256 is 0?
-        // that is intended, so that by default the minter allows infinite transactions,
-        // allowing the artblocks contract to stop minting
-        // uint256 tokenInvocation = tokenId % ONE_MILLION;
+        // Okay if this underflows because if statement will always eval false.
+        // This is only for gas optimization (core enforces maxInvocations).
         unchecked {
             if (
                 tokenId % ONE_MILLION == projectMaxInvocations[_projectId] - 1

--- a/contracts/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
+++ b/contracts/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
@@ -42,20 +42,6 @@ contract MinterSetPriceV2 is ReentrancyGuard, IFilteredMinterV0 {
     /// projectId => price per token has been configured on this minter
     mapping(uint256 => bool) private projectIdToPriceIsConfigured;
 
-    // modifier to restrict access to only AdminACL allowed calls
-    // @dev defers which ACL contract is used to the core contract
-    modifier onlyCoreAdminACL(bytes4 _selector) {
-        require(
-            genArtCoreContract.adminACLAllowed(
-                msg.sender,
-                address(this),
-                _selector
-            ),
-            "Only Core AdminACL allowed"
-        );
-        _;
-    }
-
     modifier onlyArtist(uint256 _projectId) {
         require(
             msg.sender ==

--- a/contracts/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V2.sol
+++ b/contracts/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V2.sol
@@ -48,20 +48,6 @@ contract MinterSetPriceERC20V2 is ReentrancyGuard, IFilteredMinterV0 {
     /// projectId => currency address - supersedes any defined core value
     mapping(uint256 => address) private projectIdToCurrencyAddress;
 
-    // modifier to restrict access to only AdminACL allowed calls
-    // @dev defers which ACL contract is used to the core contract
-    modifier onlyCoreAdminACL(bytes4 _selector) {
-        require(
-            genArtCoreContract.adminACLAllowed(
-                msg.sender,
-                address(this),
-                _selector
-            ),
-            "Only Core AdminACL allowed"
-        );
-        _;
-    }
-
     modifier onlyArtist(uint256 _projectId) {
         require(
             msg.sender ==

--- a/contracts/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V2.sol
+++ b/contracts/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V2.sol
@@ -37,6 +37,7 @@ contract MinterSetPriceERC20V2 is ReentrancyGuard, IFilteredMinterV0 {
     /// projectId => has project reached its maximum number of invocations?
     mapping(uint256 => bool) public projectMaxHasBeenInvoked;
     /// projectId => project's maximum number of invocations
+    /// optionally synced with core contract value, for gas optimization
     mapping(uint256 => uint256) public projectMaxInvocations;
     /// projectId => price per token in wei - supersedes any defined core price
     mapping(uint256 => uint256) private projectIdToPricePerTokenInWei;
@@ -129,26 +130,22 @@ contract MinterSetPriceERC20V2 is ReentrancyGuard, IFilteredMinterV0 {
     }
 
     /**
-     * @notice Sets the maximum invocations of project `_projectId` based
-     * on the value currently defined in the core contract.
+     * @notice Syncs local maximum invocations of project `_projectId` based on
+     * the value currently defined in the core contract. Only used for gas
+     * optimization of mints after maxInvocations has been reached.
      * @param _projectId Project ID to set the maximum invocations for.
-     * @dev also checks and may refresh projectMaxHasBeenInvoked for project
      * @dev this enables gas reduction after maxInvocations have been reached -
      * core contracts shall still enforce a maxInvocation check during mint.
+     * @dev function is intentionally not gated to any specific access control;
+     * it only syncs a local state variable to the core contract's state.
      */
-    function setProjectMaxInvocations(uint256 _projectId)
-        external
-        onlyCoreAdminACL(this.setProjectMaxInvocations.selector)
-    {
-        uint256 invocations;
+    function setProjectMaxInvocations(uint256 _projectId) external {
         uint256 maxInvocations;
-        (invocations, maxInvocations, , , ) = genArtCoreContract
-            .projectStateData(_projectId);
+        (, maxInvocations, , , ) = genArtCoreContract.projectStateData(
+            _projectId
+        );
         // update storage with results
         projectMaxInvocations[_projectId] = maxInvocations;
-        if (invocations < maxInvocations) {
-            projectMaxHasBeenInvoked[_projectId] = false;
-        }
     }
 
     /**
@@ -270,10 +267,8 @@ contract MinterSetPriceERC20V2 is ReentrancyGuard, IFilteredMinterV0 {
         // EFFECTS
         tokenId = minterFilter.mint(_to, _projectId, msg.sender);
 
-        // What if this overflows, since default value of uint256 is 0?
-        // that is intended, so that by default the minter allows infinite transactions,
-        // allowing the artblocks contract to stop minting
-        // uint256 tokenInvocation = tokenId % ONE_MILLION;
+        // okay if this underflows because if statement will always eval false.
+        // this is only for gas optimization (core enforces maxInvocations).
         unchecked {
             if (
                 tokenId % ONE_MILLION == projectMaxInvocations[_projectId] - 1

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
@@ -111,6 +111,20 @@ describe("MinterDAExpV2_V3Core", async function () {
     MinterDAV1V2_Common();
   });
 
+  describe("setProjectMaxInvocations", async function () {
+    it("allows artist to call setProjectMaxInvocations", async function () {
+      await this.minter
+        .connect(this.accounts.artist)
+        .setProjectMaxInvocations(this.projectZero);
+    });
+
+    it("allows user to call setProjectMaxInvocations", async function () {
+      await this.minter
+        .connect(this.accounts.user)
+        .setProjectMaxInvocations(this.projectZero);
+    });
+  });
+
   describe("calculate gas", async function () {
     it("mints and calculates gas values [ @skip-on-coverage ]", async function () {
       await ethers.provider.send("evm_mine", [

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
@@ -110,6 +110,20 @@ describe("MinterDALinV2_V3Core", async function () {
     MinterDAV1V2_Common();
   });
 
+  describe("setProjectMaxInvocations", async function () {
+    it("allows artist to call setProjectMaxInvocations", async function () {
+      await this.minter
+        .connect(this.accounts.artist)
+        .setProjectMaxInvocations(this.projectZero);
+    });
+
+    it("allows user to call setProjectMaxInvocations", async function () {
+      await this.minter
+        .connect(this.accounts.user)
+        .setProjectMaxInvocations(this.projectZero);
+    });
+  });
+
   describe("calculate gas", async function () {
     it("mints and calculates gas values [ @skip-on-coverage ]", async function () {
       await ethers.provider.send("evm_mine", [

--- a/test/minter-suite-minters/Minter.common.ts
+++ b/test/minter-suite-minters/Minter.common.ts
@@ -82,7 +82,7 @@ export const Minter_Common = async () => {
       // update max invocations to 1 on the core
       await this.genArt721Core
         .connect(this.accounts.artist)
-        .updateProjectMaxInvocations(this.projectZero, 1);
+        .updateProjectMaxInvocations(this.projectZero, 2);
       // sync max invocations on minter
       await this.minter
         .connect(this.accounts.deployer)
@@ -90,7 +90,7 @@ export const Minter_Common = async () => {
       // expect max invocations to be 1 on the minter
       expect(
         await this.minter.projectMaxInvocations(this.projectZero)
-      ).to.be.equal(1);
+      ).to.be.equal(2);
     });
   });
 };

--- a/test/minter-suite-minters/Minter.common.ts
+++ b/test/minter-suite-minters/Minter.common.ts
@@ -70,4 +70,27 @@ export const Minter_Common = async () => {
       expect(priceInfo.currencyAddress).to.be.equal(constants.ZERO_ADDRESS);
     });
   });
+
+  describe("setProjectMaxInvocations", async function () {
+    it("allows deployer to call setProjectMaxInvocations", async function () {
+      await this.minter
+        .connect(this.accounts.deployer)
+        .setProjectMaxInvocations(this.projectZero);
+    });
+
+    it("updates local projectMaxInvocations after syncing to core", async function () {
+      // update max invocations to 1 on the core
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .updateProjectMaxInvocations(this.projectZero, 1);
+      // sync max invocations on minter
+      await this.minter
+        .connect(this.accounts.deployer)
+        .setProjectMaxInvocations(this.projectZero);
+      // expect max invocations to be 1 on the minter
+      expect(
+        await this.minter.projectMaxInvocations(this.projectZero)
+      ).to.be.equal(1);
+    });
+  });
 };

--- a/test/minter-suite-minters/MinterHolder/MinterHolderV1.test.ts
+++ b/test/minter-suite-minters/MinterHolder/MinterHolderV1.test.ts
@@ -156,6 +156,20 @@ describe("MinterHolderV1", async function () {
     MinterHolder_Common();
   });
 
+  describe("setProjectMaxInvocations", async function () {
+    it("allows artist to call setProjectMaxInvocations", async function () {
+      await this.minter
+        .connect(this.accounts.artist)
+        .setProjectMaxInvocations(this.projectZero);
+    });
+
+    it("allows user to call setProjectMaxInvocations", async function () {
+      await this.minter
+        .connect(this.accounts.user)
+        .setProjectMaxInvocations(this.projectZero);
+    });
+  });
+
   describe("calculates gas", async function () {
     it("mints and calculates gas values [ @skip-on-coverage ]", async function () {
       const tx = await this.minter

--- a/test/minter-suite-minters/MinterMerkle/MinterMerkleV1.test.ts
+++ b/test/minter-suite-minters/MinterMerkle/MinterMerkleV1.test.ts
@@ -170,6 +170,20 @@ describe("MinterMerkleV1", async function () {
     MinterMerkle_Common();
   });
 
+  describe("setProjectMaxInvocations", async function () {
+    it("allows artist to call setProjectMaxInvocations", async function () {
+      await this.minter
+        .connect(this.accounts.artist)
+        .setProjectMaxInvocations(this.projectZero);
+    });
+
+    it("allows user to call setProjectMaxInvocations", async function () {
+      await this.minter
+        .connect(this.accounts.user)
+        .setProjectMaxInvocations(this.projectZero);
+    });
+  });
+
   describe("calculates gas", async function () {
     it("mints and calculates gas values [ @skip-on-coverage ]", async function () {
       const userMerkleProofOne = this.merkleTreeOne.getHexProof(

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
@@ -143,6 +143,20 @@ describe("MinterSetPriceV2_V3Core", async function () {
     MinterSetPriceV1V2_Common();
   });
 
+  describe("setProjectMaxInvocations", async function () {
+    it("allows artist to call setProjectMaxInvocations", async function () {
+      await this.minter
+        .connect(this.accounts.artist)
+        .setProjectMaxInvocations(this.projectZero);
+    });
+
+    it("allows user to call setProjectMaxInvocations", async function () {
+      await this.minter
+        .connect(this.accounts.user)
+        .setProjectMaxInvocations(this.projectZero);
+    });
+  });
+
   describe("calculates gas", async function () {
     it("mints and calculates gas values [ @skip-on-coverage ]", async function () {
       const tx = await this.minter1

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
@@ -126,6 +126,20 @@ describe("MinterSetPriceERC20V2_V3Core", async function () {
     MinterSetPriceV1V2_Common();
   });
 
+  describe("setProjectMaxInvocations", async function () {
+    it("allows artist to call setProjectMaxInvocations", async function () {
+      await this.minter
+        .connect(this.accounts.artist)
+        .setProjectMaxInvocations(this.projectZero);
+    });
+
+    it("allows user to call setProjectMaxInvocations", async function () {
+      await this.minter
+        .connect(this.accounts.user)
+        .setProjectMaxInvocations(this.projectZero);
+    });
+  });
+
   describe("calculates gas", async function () {
     it("mints and calculates gas values [ @skip-on-coverage ]", async function () {
       const tx = await this.minter


### PR DESCRIPTION
Update details regarding the optionally-populated minter `projectMaxInvocations`.

This updates minters regarding how they describe and populate their local mapping of `projectMaxInvocations`:
- mapping is described as optionally synced to the core contract
- `function setProjectMaxInvocations(projectId)` is no longer gated to any specific caller, because it no longer checks to see if maxInvocations has been increased on the core contract (V3 core does not ever allow maxInvocations to ever increase).
  - This is only enabled by the V3 core change of never allowing maxInvocations to increase, and should help reduce overhead (function must be gated to onlyWhitelisted on pre-V3 minters)
- comment about unchecked underflow improved

## Design Choices
- Opted to not change the name of mapping `projectMaxInvocations` on minters because it is an existing public mapping on V1-compatible minters. Better name would probably be `localProjectMaxInvocations` or something, but adding comments around the variable to better describe that it is optionally synced to the core contract for gas optimization purposes seemed sufficient.
- Opted to not change the function name `setProjectMaxInvocations` to `syncProjectMaxInvocations`, because existing function already integrates with our frontend today (I think, Cc @yoshiwarab if keeping this consistent in any way would help us).

