### PR TITLE
Improve gas tests, improve optimizer settings

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -41,7 +41,7 @@ module.exports = {
         settings: {
           optimizer: {
             enabled: true,
-            runs: 100,
+            runs: 25,
           },
         },
       },

--- a/test/core/GenArt721CoreV1_Integration.tests.ts
+++ b/test/core/GenArt721CoreV1_Integration.tests.ts
@@ -104,7 +104,7 @@ describe("GenArt721CoreV1 Integration", async function () {
       ).to.equal(ethers.utils.parseEther("0.8971167"));
       expect(
         (await this.accounts.user.getBalance()).sub(ownerBalance)
-      ).to.equal(ethers.utils.parseEther("1.0361817").mul("-1")); // spent 1 ETH
+      ).to.equal(ethers.utils.parseEther("1.0361882").mul("-1")); // spent 1 ETH
     });
 
     it("can create a token then funds distributed (with additional payee) [ @skip-on-coverage ]", async function () {
@@ -151,7 +151,7 @@ describe("GenArt721CoreV1 Integration", async function () {
       ).to.equal(ethers.utils.parseEther("0.09"));
       expect(
         (await this.accounts.user.getBalance()).sub(ownerBalance)
-      ).to.equal(ethers.utils.parseEther("1.0375547").mul("-1")); // spent 1 ETH
+      ).to.equal(ethers.utils.parseEther("1.0375612").mul("-1")); // spent 1 ETH
       expect(
         (await this.accounts.artist.getBalance()).sub(artistBalance)
       ).to.equal(ethers.utils.parseEther("0.8002491"));
@@ -201,7 +201,7 @@ describe("GenArt721CoreV1 Integration", async function () {
       ).to.equal(ethers.utils.parseEther("0.9"));
       expect(
         (await this.accounts.user.getBalance()).sub(ownerBalance)
-      ).to.equal(ethers.utils.parseEther("1.0362942").mul("-1")); // spent 1 ETH
+      ).to.equal(ethers.utils.parseEther("1.0363007").mul("-1")); // spent 1 ETH
       expect(
         (await this.accounts.artist.getBalance()).sub(artistBalance)
       ).to.equal(ethers.utils.parseEther("0.0097509").mul("-1"));

--- a/test/core/GenArt721CoreV2_PRTNR_Integration.tests.ts
+++ b/test/core/GenArt721CoreV2_PRTNR_Integration.tests.ts
@@ -102,10 +102,10 @@ describe("GenArt721CoreV2_PRTNR_Integration", async function () {
       ).to.equal(ethers.utils.parseEther("0.1"));
       expect(
         (await this.accounts.artist.getBalance()).sub(artistBalance)
-      ).to.equal(ethers.utils.parseEther("0.8971195"));
+      ).to.equal(ethers.utils.parseEther("0.8971019"));
       expect(
         (await this.accounts.user.getBalance()).sub(ownerBalance)
-      ).to.equal(ethers.utils.parseEther("1.0216789").mul("-1")); // spent 1 ETH
+      ).to.equal(ethers.utils.parseEther("1.0217137").mul("-1")); // spent 1 ETH
     });
 
     it("can create a token then funds distributed (with additional payee) [ @skip-on-coverage ]", async function () {
@@ -152,10 +152,10 @@ describe("GenArt721CoreV2_PRTNR_Integration", async function () {
       ).to.equal(ethers.utils.parseEther("0.09"));
       expect(
         (await this.accounts.user.getBalance()).sub(ownerBalance)
-      ).to.equal(ethers.utils.parseEther("1.0230737").mul("-1")); // spent 1 ETH
+      ).to.equal(ethers.utils.parseEther("1.0231039").mul("-1")); // spent 1 ETH
       expect(
         (await this.accounts.artist.getBalance()).sub(artistBalance)
-      ).to.equal(ethers.utils.parseEther("0.8002442"));
+      ).to.equal(ethers.utils.parseEther("0.800209"));
     });
 
     it("can create a token then funds distributed (with additional payee getting 100%) [ @skip-on-coverage ]", async function () {
@@ -202,10 +202,10 @@ describe("GenArt721CoreV2_PRTNR_Integration", async function () {
       ).to.equal(ethers.utils.parseEther("0.9"));
       expect(
         (await this.accounts.user.getBalance()).sub(ownerBalance)
-      ).to.equal(ethers.utils.parseEther("1.0218145").mul("-1")); // spent 1 ETH
+      ).to.equal(ethers.utils.parseEther("1.0218271").mul("-1")); // spent 1 ETH
       expect(
         (await this.accounts.artist.getBalance()).sub(artistBalance)
-      ).to.equal(ethers.utils.parseEther("0.0097558").mul("-1"));
+      ).to.equal(ethers.utils.parseEther("0.009791").mul("-1"));
     });
   });
 });

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV0.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV0.test.ts
@@ -132,7 +132,7 @@ describe("MinterDAExpV0_V1Core", async function () {
         "ETH"
       );
 
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0380107")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0380392")); // assuming a cost of 100 GWEI
     });
   });
 

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV1.PRTNR.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV1.PRTNR.test.ts
@@ -131,7 +131,7 @@ describe("MinterDAExpV1_V1Core", async function () {
         "ETH"
       );
 
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0228514")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0228928")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV1.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV1.test.ts
@@ -131,7 +131,7 @@ describe("MinterDAExpV1_V1Core", async function () {
         "ETH"
       );
 
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0373542")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0373673")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
@@ -149,7 +149,7 @@ describe("MinterDAExpV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.019271")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0192725")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV0.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV0.test.ts
@@ -133,7 +133,7 @@ describe("MinterDALinV0_V1Core", async function () {
         "ETH"
       );
 
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0380046")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0380309")); // assuming a cost of 100 GWEI
     });
   });
 

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV1.PRTNR.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV1.PRTNR.test.ts
@@ -131,7 +131,7 @@ describe("MinterDALinV1_V2PRTNRCore", async function () {
         "ETH"
       );
 
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0228453")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0228845")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV1.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV1.test.ts
@@ -131,7 +131,7 @@ describe("MinterDALinV1_V1Core", async function () {
         "ETH"
       );
 
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0373481")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.037359")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
@@ -149,7 +149,7 @@ describe("MinterDALinV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0192649")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0192642")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV0.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV0.test.ts
@@ -160,7 +160,7 @@ describe("MinterSetPriceV0_V1Core", async function () {
         "ETH"
       );
 
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0368459")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.036859")); // assuming a cost of 100 GWEI
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV1.PRTNR.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV1.PRTNR.test.ts
@@ -155,7 +155,7 @@ describe("MinterSetPriceV1_V2PRTNRCore", async function () {
         "ETH"
       );
 
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0216789")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0217137")); // assuming a cost of 100 GWEI
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV1.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV1.test.ts
@@ -156,7 +156,7 @@ describe("MinterSetPriceV1_V1Core", async function () {
         "ETH"
       );
 
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0361817")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0361882")); // assuming a cost of 100 GWEI
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
@@ -177,7 +177,7 @@ describe("MinterSetPriceV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0180828")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0180777")); // assuming a cost of 100 GWEI
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V0.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V0.test.ts
@@ -138,7 +138,7 @@ describe("MinterSetPriceERC20V0_V1Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0370574"));
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0370837"));
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V1.PRTNR.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V1.PRTNR.test.ts
@@ -137,7 +137,7 @@ describe("MinterSetPriceERC20V1_V2PRTNRCore", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0298604"));
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0298996"));
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V1.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V1.test.ts
@@ -142,7 +142,7 @@ describe("MinterSetPriceERC20V1_V1Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.036402"));
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0364129"));
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
@@ -206,7 +206,7 @@ describe("MinterSetPriceERC20V2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0183048"));
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0183041"));
     });
   });
 


### PR DESCRIPTION
Improve gas tests and improve compiler optimizer settings.

This does not affect the audit because no contracts are touched.

This
- improves gas tests by averaging mint costs over 15 transactions to eliminate noise.
- changes our solc compiler optimizer settings from 100 runs to 25 runs to find some gas savings for purchases. 25 runs was selected based on the table below, because it has 80% of the reduction of 10%, but isn't on the edge of the 0.43% increase.

>note: these results are somewhat unintuitive, as one would generally expect higher runs to reduce costs of calling. In this case, we are only looking at the mint transaction cost, so global optimizer settings could have unexpected results.

| Optimizer Runs | Contract Size (kb) | Typical V3 gas to mint\*  | % gas reduced relative to Optimizer: 100 |
| -------------- | ------------------ | ------------------------- | ---------------------------------------- |
| 0              | 36.005             | N/A - too large to deploy | \-                                       |
| 1              | 19.521             | 147165                    | 0.43%                                    |
| 5              | 19.521             | 147165                    | 0.43%                                    |
| 8              | 19.537             | 146309                    | \-0.15%                                  |
| 10             | 19.537             | 146309                    | \-0.15%                                  |
| 25             | 19.573             | 146345                    | \-0.13%                                  |
| 50             | 19.639             | 146414                    | \-0.08%                                  |
| 100            | 19.778             | 146529                    | 0.00%                                    |
| 200            | 19.998             | 146460                    | \-0.05%                                  |
| 500            | 21.381             | 146529                    | 0.00%                                    |
| 1000           | 23.199             | 146574                    | 0.03%                                    |
| 2500           | 23.832             | 146544                    | 0.01%                                    |