### PR TITLE
Pack Project struct to reduce gas costs

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -82,6 +82,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         uint24 invocations;
         uint24 maxInvocations;
         uint24 scriptCount;
+        // max uint64 ~= 1.8e19 sec ~= 570 billion years
         uint64 completedTimestamp;
         bool active;
         bool paused;

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -18,6 +18,7 @@ import "@openzeppelin-4.7/contracts/token/ERC721/ERC721.sol";
  */
 contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     uint256 constant ONE_MILLION = 1_000_000;
+    uint24 constant ONE_MILLION_UINT24 = 1_000_000;
     uint256 constant FOUR_WEEKS_IN_SECONDS = 2_419_200;
 
     // generic platform event fields
@@ -78,6 +79,12 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     IAdminACLV0 public adminACLContract;
 
     struct Project {
+        uint24 invocations;
+        uint24 maxInvocations;
+        uint24 scriptCount;
+        uint64 completedTimestamp;
+        bool active;
+        bool paused;
         string name;
         string artist;
         string description;
@@ -87,14 +94,8 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         string scriptType;
         string scriptTypeVersion;
         string aspectRatio;
-        uint256 invocations;
-        uint256 maxInvocations;
-        mapping(uint256 => string) scripts;
-        uint256 scriptCount;
         string ipfsHash;
-        bool active;
-        bool paused;
-        uint256 completedTimestamp;
+        mapping(uint256 => string) scripts;
     }
 
     mapping(uint256 => Project) projects;
@@ -229,9 +230,9 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         require(msg.sender == minterContract, "Must mint from minter contract");
 
         // load invocations into memory
-        uint256 invocationsBefore = projects[_projectId].invocations;
-        uint256 invocationsAfter = invocationsBefore + 1;
-        uint256 maxInvocations = projects[_projectId].maxInvocations;
+        uint24 invocationsBefore = projects[_projectId].invocations;
+        uint24 invocationsAfter = invocationsBefore + 1;
+        uint24 maxInvocations = projects[_projectId].maxInvocations;
 
         require(
             invocationsBefore < maxInvocations,
@@ -568,7 +569,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         projectIdToArtistAddress[projectId] = _artistAddress;
         projects[projectId].name = _projectName;
         projects[projectId].paused = true;
-        projects[projectId].maxInvocations = ONE_MILLION;
+        projects[projectId].maxInvocations = ONE_MILLION_UINT24;
 
         nextProjectId = nextProjectId + 1;
         emit ProjectUpdated(projectId, FIELD_PROJECT_CREATED);
@@ -686,7 +687,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
      */
     function updateProjectMaxInvocations(
         uint256 _projectId,
-        uint256 _maxInvocations
+        uint24 _maxInvocations
     ) external onlyArtist(_projectId) {
         // checks
         require(
@@ -1321,7 +1322,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
      * @notice Internal function to complete a project.
      */
     function _completeProject(uint256 _projectId) internal {
-        projects[_projectId].completedTimestamp = block.timestamp;
+        projects[_projectId].completedTimestamp = uint64(block.timestamp);
         emit ProjectUpdated(_projectId, FIELD_PROJECT_COMPLETED);
     }
 

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
@@ -149,7 +149,7 @@ describe("MinterDAExpV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0192725")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0171837")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
@@ -149,7 +149,7 @@ describe("MinterDALinV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0192642")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0171754")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/MinterHolder/MinterHolderV1.test.ts
+++ b/test/minter-suite-minters/MinterHolder/MinterHolderV1.test.ts
@@ -236,7 +236,7 @@ describe("MinterHolderV1", async function () {
         ethers.utils.formatUnits(txCost.toString(), "ether").toString(),
         "ETH"
       );
-      expect(compareBN(txCost, ethers.utils.parseEther("0.0150405"), 1)).to.be
+      expect(compareBN(txCost, ethers.utils.parseEther("0.0146807"), 1)).to.be
         .true;
     });
   });

--- a/test/minter-suite-minters/MinterMerkle/MinterMerkleV1.test.ts
+++ b/test/minter-suite-minters/MinterMerkle/MinterMerkleV1.test.ts
@@ -244,7 +244,7 @@ describe("MinterMerkleV1", async function () {
         ethers.utils.formatUnits(txCost.toString(), "ether").toString(),
         "ETH"
       );
-      expect(compareBN(txCost, ethers.utils.parseEther("0.0206439"), 1)).to.be
+      expect(compareBN(txCost, ethers.utils.parseEther("0.0185667"), 1)).to.be
         .true;
     });
 
@@ -286,7 +286,7 @@ describe("MinterMerkleV1", async function () {
         "ETH"
       );
       // the following is not much more than the gas cost with a very small allowlist
-      expect(compareBN(txCost, ethers.utils.parseEther("0.0214727"), 1)).to.be
+      expect(compareBN(txCost, ethers.utils.parseEther("0.0193937"), 1)).to.be
         .true;
     });
   });

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
@@ -177,7 +177,7 @@ describe("MinterSetPriceV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0180777")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0159889")); // assuming a cost of 100 GWEI
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
@@ -206,7 +206,7 @@ describe("MinterSetPriceERC20V2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0183041"));
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0162153"));
     });
   });
 


### PR DESCRIPTION
Pack Project struct where possible to reduce gas costs

## Gas impacts
Mint costs are slightly reduced. Representative minter cost updates are shown in the table below.

_All gas costs assume project 3 mints avg(501-516) of 1000_
| Gas Test | Previous gas used to purchase | New gas used to purchase | % change |
| --- | --- | --- | --- |
| MinterSetPriceV2_V3Core | 146345 | 142557 | -2.6% (cheaper) |
| MinterDAExpV2_V3Core | 158183 | 154395 | -2.4% (cheaper) |

## Audit impacts
- No interfaces are affected by this code
- Would still be good to Cc ongoing auditors of this update