### PR TITLE
Remove Enumerable conformance for PBAB and PRTNR

### DIFF
--- a/contracts/PBAB+Collabs/GenArt721CoreV2_PBAB.sol
+++ b/contracts/PBAB+Collabs/GenArt721CoreV2_PBAB.sol
@@ -6,7 +6,7 @@ import "../interfaces/0.8.x/IGenArt721CoreV2_PBAB.sol";
 
 import "@openzeppelin-4.5/contracts/utils/Strings.sol";
 
-import "@openzeppelin-4.5/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+import "@openzeppelin-4.5/contracts/token/ERC721/ERC721.sol";
 
 pragma solidity 0.8.9;
 
@@ -14,7 +14,7 @@ pragma solidity 0.8.9;
  * @title Powered by Art Blocks ERC-721 core contract.
  * @author Art Blocks Inc.
  */
-contract GenArt721CoreV2_PBAB is ERC721Enumerable, IGenArt721CoreV2_PBAB {
+contract GenArt721CoreV2_PBAB is ERC721, IGenArt721CoreV2_PBAB {
     /// randomizer contract
     IRandomizer public randomizerContract;
 

--- a/contracts/PBAB+Collabs/GenArt721CoreV2_PRTNR.sol
+++ b/contracts/PBAB+Collabs/GenArt721CoreV2_PRTNR.sol
@@ -7,7 +7,7 @@ import "../interfaces/0.8.x/IGenArt721CoreContractV1.sol";
 
 import "@openzeppelin-4.5/contracts/utils/Strings.sol";
 
-import "@openzeppelin-4.5/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+import "@openzeppelin-4.5/contracts/token/ERC721/ERC721.sol";
 
 pragma solidity 0.8.9;
 
@@ -17,7 +17,7 @@ pragma solidity 0.8.9;
  * @dev conforms to V1 and V2_PBAB interfaces
  */
 contract GenArt721CoreV2_PRTNR is
-    ERC721Enumerable,
+    ERC721,
     IGenArt721CoreV2_PBAB,
     IGenArt721CoreContractV1
 {

--- a/test/core/GenArt721CoreV2_PRTNR_Integration.tests.ts
+++ b/test/core/GenArt721CoreV2_PRTNR_Integration.tests.ts
@@ -124,7 +124,7 @@ describe("GenArt721CoreV2_PRTNR_Integration", async function () {
       ).to.equal(ethers.utils.parseEther("0.8971063"));
       expect(
         (await this.accounts.user.getBalance()).sub(ownerBalance)
-      ).to.equal(ethers.utils.parseEther("1.018512").mul("-1")); // spent 1 ETH
+      ).to.equal(ethers.utils.parseEther("1.0185247").mul("-1")); // spent 1 ETH
     });
 
     it("can create a token then funds distributed (with additional payee) [ @skip-on-coverage ]", async function () {
@@ -174,7 +174,7 @@ describe("GenArt721CoreV2_PRTNR_Integration", async function () {
       ).to.equal(ethers.utils.parseEther("1.0199105").mul("-1")); // spent 1 ETH
       expect(
         (await this.accounts.artist.getBalance()).sub(artistBalance)
-      ).to.equal(ethers.utils.parseEther("0.8002287"));
+      ).to.equal(ethers.utils.parseEther("0.8002156"));
     });
 
     it("can create a token then funds distributed (with additional payee getting 100%) [ @skip-on-coverage ]", async function () {
@@ -224,7 +224,7 @@ describe("GenArt721CoreV2_PRTNR_Integration", async function () {
       ).to.equal(ethers.utils.parseEther("1.0186381").mul("-1")); // spent 1 ETH
       expect(
         (await this.accounts.artist.getBalance()).sub(artistBalance)
-      ).to.equal(ethers.utils.parseEther("0.0097713").mul("-1"));
+      ).to.equal(ethers.utils.parseEther("0.0097844").mul("-1"));
     });
   });
 });

--- a/test/core/GenArt721CoreV2_PRTNR_Integration.tests.ts
+++ b/test/core/GenArt721CoreV2_PRTNR_Integration.tests.ts
@@ -102,10 +102,10 @@ describe("GenArt721CoreV2_PRTNR_Integration", async function () {
       ).to.equal(ethers.utils.parseEther("0.1"));
       expect(
         (await this.accounts.artist.getBalance()).sub(artistBalance)
-      ).to.equal(ethers.utils.parseEther("0.8971195"));
+      ).to.equal(ethers.utils.parseEther("0.897104"));
       expect(
         (await this.accounts.user.getBalance()).sub(ownerBalance)
-      ).to.equal(ethers.utils.parseEther("1.0216789").mul("-1")); // spent 1 ETH
+      ).to.equal(ethers.utils.parseEther("1.018512").mul("-1")); // spent 1 ETH
     });
 
     it("can create a token then funds distributed (with additional payee) [ @skip-on-coverage ]", async function () {
@@ -152,10 +152,10 @@ describe("GenArt721CoreV2_PRTNR_Integration", async function () {
       ).to.equal(ethers.utils.parseEther("0.09"));
       expect(
         (await this.accounts.user.getBalance()).sub(ownerBalance)
-      ).to.equal(ethers.utils.parseEther("1.0230737").mul("-1")); // spent 1 ETH
+      ).to.equal(ethers.utils.parseEther("1.0199024").mul("-1")); // spent 1 ETH
       expect(
         (await this.accounts.artist.getBalance()).sub(artistBalance)
-      ).to.equal(ethers.utils.parseEther("0.8002442"));
+      ).to.equal(ethers.utils.parseEther("0.8002287"));
     });
 
     it("can create a token then funds distributed (with additional payee getting 100%) [ @skip-on-coverage ]", async function () {
@@ -202,10 +202,10 @@ describe("GenArt721CoreV2_PRTNR_Integration", async function () {
       ).to.equal(ethers.utils.parseEther("0.9"));
       expect(
         (await this.accounts.user.getBalance()).sub(ownerBalance)
-      ).to.equal(ethers.utils.parseEther("1.0218145").mul("-1")); // spent 1 ETH
+      ).to.equal(ethers.utils.parseEther("1.0186454").mul("-1")); // spent 1 ETH
       expect(
         (await this.accounts.artist.getBalance()).sub(artistBalance)
-      ).to.equal(ethers.utils.parseEther("0.0097558").mul("-1"));
+      ).to.equal(ethers.utils.parseEther("0.0097713").mul("-1"));
     });
   });
 });

--- a/test/core/GenArt721CoreV2_PRTNR_Integration.tests.ts
+++ b/test/core/GenArt721CoreV2_PRTNR_Integration.tests.ts
@@ -121,7 +121,7 @@ describe("GenArt721CoreV2_PRTNR_Integration", async function () {
       ).to.equal(ethers.utils.parseEther("0.1"));
       expect(
         (await this.accounts.artist.getBalance()).sub(artistBalance)
-      ).to.equal(ethers.utils.parseEther("0.897104"));
+      ).to.equal(ethers.utils.parseEther("0.8971063"));
       expect(
         (await this.accounts.user.getBalance()).sub(ownerBalance)
       ).to.equal(ethers.utils.parseEther("1.018512").mul("-1")); // spent 1 ETH
@@ -171,7 +171,7 @@ describe("GenArt721CoreV2_PRTNR_Integration", async function () {
       ).to.equal(ethers.utils.parseEther("0.09"));
       expect(
         (await this.accounts.user.getBalance()).sub(ownerBalance)
-      ).to.equal(ethers.utils.parseEther("1.0199024").mul("-1")); // spent 1 ETH
+      ).to.equal(ethers.utils.parseEther("1.0199105").mul("-1")); // spent 1 ETH
       expect(
         (await this.accounts.artist.getBalance()).sub(artistBalance)
       ).to.equal(ethers.utils.parseEther("0.8002287"));
@@ -221,7 +221,7 @@ describe("GenArt721CoreV2_PRTNR_Integration", async function () {
       ).to.equal(ethers.utils.parseEther("0.9"));
       expect(
         (await this.accounts.user.getBalance()).sub(ownerBalance)
-      ).to.equal(ethers.utils.parseEther("1.0186454").mul("-1")); // spent 1 ETH
+      ).to.equal(ethers.utils.parseEther("1.0186381").mul("-1")); // spent 1 ETH
       expect(
         (await this.accounts.artist.getBalance()).sub(artistBalance)
       ).to.equal(ethers.utils.parseEther("0.0097713").mul("-1"));

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV1.PRTNR.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV1.PRTNR.test.ts
@@ -26,7 +26,7 @@ import { MinterDAV1V2_Common } from "../MinterDAV1V2.common";
  * These tests intended to ensure this Filtered Minter integrates properly with
  * V1 core contract.
  */
-describe("MinterDAExpV1_V1Core", async function () {
+describe("MinterDAExpV1_V1PRTNRCore", async function () {
   beforeEach(async function () {
     // standard accounts and constants
     this.accounts = await getAccounts();
@@ -131,7 +131,7 @@ describe("MinterDAExpV1_V1Core", async function () {
         "ETH"
       );
 
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0228514")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0196845")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV1.PRTNR.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV1.PRTNR.test.ts
@@ -131,7 +131,7 @@ describe("MinterDAExpV1_V1PRTNRCore", async function () {
         "ETH"
       );
 
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0196845")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0197038")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV1.PRTNR.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV1.PRTNR.test.ts
@@ -131,7 +131,7 @@ describe("MinterDALinV1_V2PRTNRCore", async function () {
         "ETH"
       );
 
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0228453")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0196784")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV1.PRTNR.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV1.PRTNR.test.ts
@@ -131,7 +131,7 @@ describe("MinterDALinV1_V2PRTNRCore", async function () {
         "ETH"
       );
 
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0196784")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0196955")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV1.PRTNR.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV1.PRTNR.test.ts
@@ -155,7 +155,7 @@ describe("MinterSetPriceV1_V2PRTNRCore", async function () {
         "ETH"
       );
 
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0216789")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.018512")); // assuming a cost of 100 GWEI
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV1.PRTNR.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV1.PRTNR.test.ts
@@ -155,7 +155,7 @@ describe("MinterSetPriceV1_V2PRTNRCore", async function () {
         "ETH"
       );
 
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.018512")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0185247")); // assuming a cost of 100 GWEI
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V1.PRTNR.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V1.PRTNR.test.ts
@@ -137,7 +137,7 @@ describe("MinterSetPriceERC20V1_V2PRTNRCore", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0227135"));
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0227306"));
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V1.PRTNR.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V1.PRTNR.test.ts
@@ -137,7 +137,7 @@ describe("MinterSetPriceERC20V1_V2PRTNRCore", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0298604"));
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0227135"));
     });
   });
 


### PR DESCRIPTION
~~This PR is very much just a draft/proposal.~~

~~That said,~~ I don't think that there is a meaningful enough divergence in functionality when removing `Enumerable` conformance that we need to treat this as a new version for our templates, but open to feedback here to the contrary.

There is a big enough gas savings from removing this in V3 that I am inclined to remove from PBAB/PRTNR templates **now** rather than waiting until V4 (the new PBAB/PRTNR standard/template that we should pursue as a follow on once V3 is 🚢 'd)~~, but would love additional input from @ryley-o @yoshiwarab @lyaunzbe before moving this out of draft mode.~~

~~WDYT folks?~~