### PR TITLE
Pack structs on all V3-compatible minters

### DIFF
--- a/contracts/V3_CHANGELOG.md
+++ b/contracts/V3_CHANGELOG.md
@@ -55,6 +55,11 @@ _This document is intended to document and explain the Art Blocks Core V3 change
   - A couple breaking changes were made on the V3 core contract that required changes to the minter suite contracts.
 - Improve gas efficiency of minting on the V3 core contract
   - Minimize costly SLOAD operations & re-organize logic to minimize gas usage
+  - Pack structs
+  - Optimize mint function signature to reduce gas usage
+- Improve gas efficiency of V3-compatible minters
+  - Minimize costly SLOAD operations & re-organize logic to minimize gas usage
+  - Pack structs
   - Optimize mint function signature to reduce gas usage
 - Update randomizer interface for V3 core contract
 - Only allow artists to reduce the number of maximum invocations

--- a/contracts/minter-suite/Minters/MinterDAExp/MinterDAExpV2.sol
+++ b/contracts/minter-suite/Minters/MinterDAExp/MinterDAExpV2.sol
@@ -51,11 +51,17 @@ contract MinterDAExpV2 is ReentrancyGuard, IFilteredMinterV0 {
 
     uint256 constant ONE_MILLION = 1_000_000;
 
-    /// projectId => has project reached its maximum number of invocations?
-    mapping(uint256 => bool) public projectMaxHasBeenInvoked;
-    /// projectId => project's maximum number of invocations
-    /// optionally synced with core contract value, for gas optimization
-    mapping(uint256 => uint256) public projectMaxInvocations;
+    struct ProjectConfig {
+        bool maxHasBeenInvoked;
+        uint24 maxInvocations;
+        // max uint64 ~= 1.8e19 sec ~= 570 billion years
+        uint64 timestampStart;
+        uint64 priceDecayHalfLifeSeconds;
+        uint256 startPrice;
+        uint256 basePrice;
+    }
+
+    mapping(uint256 => ProjectConfig) public projectConfig;
 
     /// Minimum price decay half life: price must decay with a half life of at
     /// least this amount (must cut in half at least every N seconds).
@@ -63,15 +69,6 @@ contract MinterDAExpV2 is ReentrancyGuard, IFilteredMinterV0 {
     /// Maximum price decay half life: price may decay with a half life of no
     /// more than this amount (may cut in half at no more than every N seconds).
     uint256 public maximumPriceDecayHalfLifeSeconds = 3600; // 60 minutes
-
-    /// projectId => auction parameters
-    mapping(uint256 => AuctionParameters) public projectAuctionParameters;
-    struct AuctionParameters {
-        uint256 timestampStart;
-        uint256 priceDecayHalfLifeSeconds;
-        uint256 startPrice;
-        uint256 basePrice;
-    }
 
     // modifier to restrict access to only AdminACL allowed calls
     // @dev defers which ACL contract is used to the core contract
@@ -134,7 +131,7 @@ contract MinterDAExpV2 is ReentrancyGuard, IFilteredMinterV0 {
             _projectId
         );
         // update storage with results
-        projectMaxInvocations[_projectId] = maxInvocations;
+        projectConfig[_projectId].maxInvocations = uint24(maxInvocations);
     }
 
     /**
@@ -147,6 +144,54 @@ contract MinterDAExpV2 is ReentrancyGuard, IFilteredMinterV0 {
         onlyArtist(_projectId)
     {
         revert("Action not supported");
+    }
+
+    /**
+     * @notice projectId => has project reached its maximum number of
+     * invocations?
+     */
+    function projectMaxHasBeenInvoked(uint256 _projectId)
+        external
+        view
+        returns (bool)
+    {
+        return projectConfig[_projectId].maxHasBeenInvoked;
+    }
+
+    /**
+     * @notice projectId => project's maximum number of invocations.
+     * Optionally synced with core contract value, for gas optimization.
+     * @dev this value my be out-of-sync with the core contract's value, and is
+     * used for gas-minimization of failed mint transactions only.
+     */
+    function projectMaxInvocations(uint256 _projectId)
+        external
+        view
+        returns (uint256)
+    {
+        return uint256(projectConfig[_projectId].maxInvocations);
+    }
+
+    /**
+     * @notice projectId => auction parameters
+     */
+    function projectAuctionParameters(uint256 _projectId)
+        external
+        view
+        returns (
+            uint256 timestampStart,
+            uint256 priceDecayHalfLifeSeconds,
+            uint256 startPrice,
+            uint256 basePrice
+        )
+    {
+        ProjectConfig storage _projectConfig = projectConfig[_projectId];
+        return (
+            _projectConfig.timestampStart,
+            _projectConfig.priceDecayHalfLifeSeconds,
+            _projectConfig.startPrice,
+            _projectConfig.basePrice
+        );
     }
 
     /**
@@ -200,12 +245,11 @@ contract MinterDAExpV2 is ReentrancyGuard, IFilteredMinterV0 {
         uint256 _startPrice,
         uint256 _basePrice
     ) external onlyArtist(_projectId) {
-        AuctionParameters memory auctionParams = projectAuctionParameters[
-            _projectId
-        ];
+        // CHECKS
+        ProjectConfig storage _projectConfig = projectConfig[_projectId];
         require(
-            auctionParams.timestampStart == 0 ||
-                block.timestamp < auctionParams.timestampStart,
+            _projectConfig.timestampStart == 0 ||
+                block.timestamp < _projectConfig.timestampStart,
             "No modifications mid-auction"
         );
         require(
@@ -222,12 +266,14 @@ contract MinterDAExpV2 is ReentrancyGuard, IFilteredMinterV0 {
                     maximumPriceDecayHalfLifeSeconds),
             "Price decay half life must fall between min and max allowable values"
         );
-        projectAuctionParameters[_projectId] = AuctionParameters(
-            _auctionTimestampStart,
-            _priceDecayHalfLifeSeconds,
-            _startPrice,
-            _basePrice
+        // EFFECTS
+        _projectConfig.timestampStart = uint64(_auctionTimestampStart);
+        _projectConfig.priceDecayHalfLifeSeconds = uint64(
+            _priceDecayHalfLifeSeconds
         );
+        _projectConfig.startPrice = _startPrice;
+        _projectConfig.basePrice = _basePrice;
+
         emit SetAuctionDetails(
             _projectId,
             _auctionTimestampStart,
@@ -247,7 +293,13 @@ contract MinterDAExpV2 is ReentrancyGuard, IFilteredMinterV0 {
         external
         onlyCoreAdminACL(this.resetAuctionDetails.selector)
     {
-        delete projectAuctionParameters[_projectId];
+        ProjectConfig storage _projectConfig = projectConfig[_projectId];
+        // reset to initial values
+        _projectConfig.timestampStart = 0;
+        _projectConfig.priceDecayHalfLifeSeconds = 0;
+        _projectConfig.startPrice = 0;
+        _projectConfig.basePrice = 0;
+
         emit ResetAuctionDetails(_projectId);
     }
 
@@ -302,8 +354,9 @@ contract MinterDAExpV2 is ReentrancyGuard, IFilteredMinterV0 {
         returns (uint256 tokenId)
     {
         // CHECKS
+        ProjectConfig storage _projectConfig = projectConfig[_projectId];
         require(
-            !projectMaxHasBeenInvoked[_projectId],
+            !_projectConfig.maxHasBeenInvoked,
             "Maximum number of invocations reached"
         );
 
@@ -320,10 +373,8 @@ contract MinterDAExpV2 is ReentrancyGuard, IFilteredMinterV0 {
         // okay if this underflows because if statement will always eval false.
         // this is only for gas optimization (core enforces maxInvocations).
         unchecked {
-            if (
-                tokenId % ONE_MILLION == projectMaxInvocations[_projectId] - 1
-            ) {
-                projectMaxHasBeenInvoked[_projectId] = true;
+            if (tokenId % ONE_MILLION == _projectConfig.maxInvocations - 1) {
+                _projectConfig.maxHasBeenInvoked = true;
             }
         }
 
@@ -397,36 +448,30 @@ contract MinterDAExpV2 is ReentrancyGuard, IFilteredMinterV0 {
      * decay, `_priceDecayHalfLifeSeconds`.
      */
     function _getPrice(uint256 _projectId) private view returns (uint256) {
-        AuctionParameters memory auctionParams = projectAuctionParameters[
-            _projectId
-        ];
-        require(
-            block.timestamp > auctionParams.timestampStart,
-            "Auction not yet started"
+        ProjectConfig storage _projectConfig = projectConfig[_projectId];
+        // move parameters to memory if used more than once
+        uint256 _timestampStart = uint256(_projectConfig.timestampStart);
+        uint256 _priceDecayHalfLifeSeconds = uint256(
+            _projectConfig.priceDecayHalfLifeSeconds
         );
-        require(
-            auctionParams.priceDecayHalfLifeSeconds > 0,
-            "Only configured auctions"
-        );
-        uint256 decayedPrice = auctionParams.startPrice;
-        uint256 elapsedTimeSeconds = block.timestamp -
-            auctionParams.timestampStart;
+        uint256 _basePrice = _projectConfig.basePrice;
+
+        require(block.timestamp > _timestampStart, "Auction not yet started");
+        require(_priceDecayHalfLifeSeconds > 0, "Only configured auctions");
+        uint256 decayedPrice = _projectConfig.startPrice;
+        uint256 elapsedTimeSeconds = block.timestamp - _timestampStart;
         // Divide by two (via bit-shifting) for the number of entirely completed
         // half-lives that have elapsed since auction start time.
-        decayedPrice >>=
-            elapsedTimeSeconds /
-            auctionParams.priceDecayHalfLifeSeconds;
+        decayedPrice >>= elapsedTimeSeconds / _priceDecayHalfLifeSeconds;
         // Perform a linear interpolation between partial half-life points, to
         // approximate the current place on a perfect exponential decay curve.
         decayedPrice -=
-            (decayedPrice *
-                (elapsedTimeSeconds %
-                    auctionParams.priceDecayHalfLifeSeconds)) /
-            auctionParams.priceDecayHalfLifeSeconds /
+            (decayedPrice * (elapsedTimeSeconds % _priceDecayHalfLifeSeconds)) /
+            _priceDecayHalfLifeSeconds /
             2;
-        if (decayedPrice < auctionParams.basePrice) {
+        if (decayedPrice < _basePrice) {
             // Price may not decay below stay `basePrice`.
-            return auctionParams.basePrice;
+            return _basePrice;
         }
         return decayedPrice;
     }
@@ -455,15 +500,14 @@ contract MinterDAExpV2 is ReentrancyGuard, IFilteredMinterV0 {
             address currencyAddress
         )
     {
-        AuctionParameters memory auctionParams = projectAuctionParameters[
-            _projectId
-        ];
-        isConfigured = (auctionParams.startPrice > 0);
-        if (block.timestamp <= auctionParams.timestampStart) {
+        ProjectConfig storage _projectConfig = projectConfig[_projectId];
+
+        isConfigured = (_projectConfig.startPrice > 0);
+        if (block.timestamp <= _projectConfig.timestampStart) {
             // Provide a reasonable value for `tokenPriceInWei` when it would
             // otherwise revert, using the starting price before auction starts.
-            tokenPriceInWei = auctionParams.startPrice;
-        } else if (auctionParams.startPrice == 0) {
+            tokenPriceInWei = _projectConfig.startPrice;
+        } else if (_projectConfig.startPrice == 0) {
             // In the case of unconfigured auction, return price of zero when
             // it would otherwise revert
             tokenPriceInWei = 0;

--- a/contracts/minter-suite/Minters/MinterDALin/MinterDALinV2.sol
+++ b/contracts/minter-suite/Minters/MinterDALin/MinterDALinV2.sol
@@ -50,22 +50,20 @@ contract MinterDALinV2 is ReentrancyGuard, IFilteredMinterV0 {
 
     uint256 constant ONE_MILLION = 1_000_000;
 
-    /// projectId => has project reached its maximum number of invocations?
-    mapping(uint256 => bool) public projectMaxHasBeenInvoked;
-    /// projectId => project's maximum number of invocations
-    /// optionally synced with core contract value, for gas optimization
-    mapping(uint256 => uint256) public projectMaxInvocations;
-    /// Minimum auction length in seconds
-    uint256 public minimumAuctionLengthSeconds = 3600;
-
-    /// projectId => auction parameters
-    mapping(uint256 => AuctionParameters) public projectAuctionParameters;
-    struct AuctionParameters {
-        uint256 timestampStart;
-        uint256 timestampEnd;
+    struct ProjectConfig {
+        bool maxHasBeenInvoked;
+        uint24 maxInvocations;
+        // max uint64 ~= 1.8e19 sec ~= 570 billion years
+        uint64 timestampStart;
+        uint64 timestampEnd;
         uint256 startPrice;
         uint256 basePrice;
     }
+
+    mapping(uint256 => ProjectConfig) public projectConfig;
+
+    /// Minimum auction length in seconds
+    uint256 public minimumAuctionLengthSeconds = 3600;
 
     // modifier to restrict access to only AdminACL allowed calls
     // @dev defers which ACL contract is used to the core contract
@@ -128,7 +126,7 @@ contract MinterDALinV2 is ReentrancyGuard, IFilteredMinterV0 {
             _projectId
         );
         // update storage with results
-        projectMaxInvocations[_projectId] = maxInvocations;
+        projectConfig[_projectId].maxInvocations = uint24(maxInvocations);
     }
 
     /**
@@ -141,6 +139,54 @@ contract MinterDALinV2 is ReentrancyGuard, IFilteredMinterV0 {
         onlyArtist(_projectId)
     {
         revert("Action not supported");
+    }
+
+    /**
+     * @notice projectId => has project reached its maximum number of
+     * invocations?
+     */
+    function projectMaxHasBeenInvoked(uint256 _projectId)
+        external
+        view
+        returns (bool)
+    {
+        return projectConfig[_projectId].maxHasBeenInvoked;
+    }
+
+    /**
+     * @notice projectId => project's maximum number of invocations.
+     * Optionally synced with core contract value, for gas optimization.
+     * @dev this value my be out-of-sync with the core contract's value, and is
+     * used for gas-minimization of failed mint transactions only.
+     */
+    function projectMaxInvocations(uint256 _projectId)
+        external
+        view
+        returns (uint256)
+    {
+        return uint256(projectConfig[_projectId].maxInvocations);
+    }
+
+    /**
+     * @notice projectId => auction parameters
+     */
+    function projectAuctionParameters(uint256 _projectId)
+        external
+        view
+        returns (
+            uint256 timestampStart,
+            uint256 timestampEnd,
+            uint256 startPrice,
+            uint256 basePrice
+        )
+    {
+        ProjectConfig storage _projectConfig = projectConfig[_projectId];
+        return (
+            _projectConfig.timestampStart,
+            _projectConfig.timestampEnd,
+            _projectConfig.startPrice,
+            _projectConfig.basePrice
+        );
     }
 
     /**
@@ -171,12 +217,11 @@ contract MinterDALinV2 is ReentrancyGuard, IFilteredMinterV0 {
         uint256 _startPrice,
         uint256 _basePrice
     ) external onlyArtist(_projectId) {
-        AuctionParameters memory auctionParams = projectAuctionParameters[
-            _projectId
-        ];
+        // CHECKS
+        ProjectConfig storage _projectConfig = projectConfig[_projectId];
         require(
-            auctionParams.timestampStart == 0 ||
-                block.timestamp < auctionParams.timestampStart,
+            _projectConfig.timestampStart == 0 ||
+                block.timestamp < _projectConfig.timestampStart,
             "No modifications mid-auction"
         );
         require(
@@ -196,12 +241,11 @@ contract MinterDALinV2 is ReentrancyGuard, IFilteredMinterV0 {
             _startPrice > _basePrice,
             "Auction start price must be greater than auction end price"
         );
-        projectAuctionParameters[_projectId] = AuctionParameters(
-            _auctionTimestampStart,
-            _auctionTimestampEnd,
-            _startPrice,
-            _basePrice
-        );
+        // EFFECTS
+        _projectConfig.timestampStart = uint64(_auctionTimestampStart);
+        _projectConfig.timestampEnd = uint64(_auctionTimestampEnd);
+        _projectConfig.startPrice = _startPrice;
+        _projectConfig.basePrice = _basePrice;
         emit SetAuctionDetails(
             _projectId,
             _auctionTimestampStart,
@@ -221,7 +265,13 @@ contract MinterDALinV2 is ReentrancyGuard, IFilteredMinterV0 {
         external
         onlyCoreAdminACL(this.resetAuctionDetails.selector)
     {
-        delete projectAuctionParameters[_projectId];
+        ProjectConfig storage _projectConfig = projectConfig[_projectId];
+        // reset to initial values
+        _projectConfig.timestampStart = 0;
+        _projectConfig.timestampEnd = 0;
+        _projectConfig.startPrice = 0;
+        _projectConfig.basePrice = 0;
+
         emit ResetAuctionDetails(_projectId);
     }
 
@@ -276,8 +326,9 @@ contract MinterDALinV2 is ReentrancyGuard, IFilteredMinterV0 {
         returns (uint256 tokenId)
     {
         // CHECKS
+        ProjectConfig storage _projectConfig = projectConfig[_projectId];
         require(
-            !projectMaxHasBeenInvoked[_projectId],
+            !_projectConfig.maxHasBeenInvoked,
             "Maximum number of invocations reached"
         );
 
@@ -294,10 +345,8 @@ contract MinterDALinV2 is ReentrancyGuard, IFilteredMinterV0 {
         // okay if this underflows because if statement will always eval false.
         // this is only for gas optimization (core enforces maxInvocations).
         unchecked {
-            if (
-                tokenId % ONE_MILLION == projectMaxInvocations[_projectId] - 1
-            ) {
-                projectMaxHasBeenInvoked[_projectId] = true;
+            if (tokenId % ONE_MILLION == _projectConfig.maxInvocations - 1) {
+                _projectConfig.maxHasBeenInvoked = true;
             }
         }
 
@@ -369,25 +418,22 @@ contract MinterDALinV2 is ReentrancyGuard, IFilteredMinterV0 {
      * @return current price of token in Wei
      */
     function _getPrice(uint256 _projectId) private view returns (uint256) {
-        AuctionParameters memory auctionParams = projectAuctionParameters[
-            _projectId
-        ];
-        require(
-            block.timestamp > auctionParams.timestampStart,
-            "Auction not yet started"
-        );
-        if (block.timestamp >= auctionParams.timestampEnd) {
-            require(auctionParams.timestampEnd > 0, "Only configured auctions");
-            return auctionParams.basePrice;
+        ProjectConfig storage _projectConfig = projectConfig[_projectId];
+        // move parameters to memory if used more than once
+        uint256 _timestampStart = uint256(_projectConfig.timestampStart);
+        uint256 _timestampEnd = uint256(_projectConfig.timestampEnd);
+        uint256 _startPrice = _projectConfig.startPrice;
+        uint256 _basePrice = _projectConfig.basePrice;
+
+        require(block.timestamp > _timestampStart, "Auction not yet started");
+        if (block.timestamp >= _timestampEnd) {
+            require(_timestampEnd > 0, "Only configured auctions");
+            return _basePrice;
         }
-        uint256 elapsedTime = block.timestamp - auctionParams.timestampStart;
-        uint256 duration = auctionParams.timestampEnd -
-            auctionParams.timestampStart;
-        uint256 startToEndDiff = auctionParams.startPrice -
-            auctionParams.basePrice;
-        return
-            auctionParams.startPrice -
-            ((elapsedTime * startToEndDiff) / duration);
+        uint256 elapsedTime = block.timestamp - _timestampStart;
+        uint256 duration = _timestampEnd - _timestampStart;
+        uint256 startToEndDiff = _startPrice - _basePrice;
+        return _startPrice - ((elapsedTime * startToEndDiff) / duration);
     }
 
     /**
@@ -414,15 +460,14 @@ contract MinterDALinV2 is ReentrancyGuard, IFilteredMinterV0 {
             address currencyAddress
         )
     {
-        AuctionParameters memory auctionParams = projectAuctionParameters[
-            _projectId
-        ];
-        isConfigured = (auctionParams.startPrice > 0);
-        if (block.timestamp <= auctionParams.timestampStart) {
+        ProjectConfig storage _projectConfig = projectConfig[_projectId];
+
+        isConfigured = (_projectConfig.startPrice > 0);
+        if (block.timestamp <= _projectConfig.timestampStart) {
             // Provide a reasonable value for `tokenPriceInWei` when it would
             // otherwise revert, using the starting price before auction starts.
-            tokenPriceInWei = auctionParams.startPrice;
-        } else if (auctionParams.timestampEnd == 0) {
+            tokenPriceInWei = _projectConfig.startPrice;
+        } else if (_projectConfig.timestampEnd == 0) {
             // In the case of unconfigured auction, return price of zero when
             // it would otherwise revert
             tokenPriceInWei = 0;

--- a/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV0.sol
+++ b/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV0.sol
@@ -45,7 +45,7 @@ contract MinterMerkleV0 is ReentrancyGuard, IFilteredMinterMerkleV0 {
     mapping(uint256 => bytes32) public projectMerkleRoot;
     /// projectId => purchaser address => has purchased one or more mints
     mapping(uint256 => mapping(address => bool)) public projectMintedBy;
-    /// projectId => are addresses limited to one mint each?
+    /// projectId => may a single address mint multiple times?
     /// (default behavior is limit one mint per address)
     mapping(uint256 => bool) public projectMintLimiterDisabled;
     /// projectId => has project reached its maximum number of invocations?

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
@@ -149,7 +149,7 @@ describe("MinterDAExpV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0171837")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.016562")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
@@ -149,7 +149,7 @@ describe("MinterDALinV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0171754")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0165542")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/MinterHolder/MinterHolderV1.test.ts
+++ b/test/minter-suite-minters/MinterHolder/MinterHolderV1.test.ts
@@ -236,7 +236,7 @@ describe("MinterHolderV1", async function () {
         ethers.utils.formatUnits(txCost.toString(), "ether").toString(),
         "ETH"
       );
-      expect(compareBN(txCost, ethers.utils.parseEther("0.0146807"), 1)).to.be
+      expect(compareBN(txCost, ethers.utils.parseEther("0.0142657"), 1)).to.be
         .true;
     });
   });

--- a/test/minter-suite-minters/MinterMerkle/MinterMerkleV1.test.ts
+++ b/test/minter-suite-minters/MinterMerkle/MinterMerkleV1.test.ts
@@ -244,7 +244,7 @@ describe("MinterMerkleV1", async function () {
         ethers.utils.formatUnits(txCost.toString(), "ether").toString(),
         "ETH"
       );
-      expect(compareBN(txCost, ethers.utils.parseEther("0.0185667"), 1)).to.be
+      expect(compareBN(txCost, ethers.utils.parseEther("0.0181539"), 1)).to.be
         .true;
     });
 
@@ -286,7 +286,7 @@ describe("MinterMerkleV1", async function () {
         "ETH"
       );
       // the following is not much more than the gas cost with a very small allowlist
-      expect(compareBN(txCost, ethers.utils.parseEther("0.0193937"), 1)).to.be
+      expect(compareBN(txCost, ethers.utils.parseEther("0.0189799"), 1)).to.be
         .true;
     });
   });

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
@@ -177,7 +177,7 @@ describe("MinterSetPriceV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0159889")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0155761")); // assuming a cost of 100 GWEI
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
@@ -206,7 +206,7 @@ describe("MinterSetPriceERC20V2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0162153"));
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0155976"));
     });
   });
 


### PR DESCRIPTION
Pack structs on all V3-compatible minters for gas efficiency.

This implements:
- Packed structs to minimize gas costs
- ABIs are unchanged or appended to, eliminating downstream impacts
  - e.g. public getter functions are added for any public mappings moved to a struct

This does not update any minters not compatible with V3.

## Gas Impacts
Gas savings are realized, as shown below.

_All gas costs assume project 3 mint avg(501-516) of 1000_
| Gas Test | Previous gas used to purchase | New gas used to purchase | % change |
| --- | --- | --- | --- |
| MinterSetPriceV2_V3Core | 142557 | 138407 | -2.9% (cheaper) |
| MinterSetPriceERC20V2_V3Core | 144765 | 138566 | -4.3% (cheaper) |
| MinterDAExpV2_V3Core | 154395 | 148156 | -4.0% (cheaper) |
| MinterDALinV2_V3Core | 154334 | 148100 | -4.0% (cheaper) |
| MinterMerkleV1_V3Core | 159621 | 153511 | -3.8% (cheaper) |
| MinterHolderV1_V3Core | 149155 | 145005 | -2.8% (cheaper) |

## Audit Impacts
Although the ABIs and basic logic of the minters are not changed, the implementation details are changed enough that it is recommended to have the auditors include these updates in their analysis. They could probably be decoupled from the main report because no interfaces are changed.
