### PR TITLE
Allow V3 to initialize nextProjectId to non-zero value

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -200,14 +200,14 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
      * @param _randomizerContract Randomizer contract.
      * @param _adminACLContract Address of admin access control contract, to be
      * set as contract owner.
-     * @param _nextProjectId The initial next project ID.
+     * @param _startingProjectId The initial next project ID.
      */
     constructor(
         string memory _tokenName,
         string memory _tokenSymbol,
         address _randomizerContract,
         address _adminACLContract,
-        uint256 _nextProjectId
+        uint256 _startingProjectId
     ) ERC721(_tokenName, _tokenSymbol) {
         _updateArtblocksPrimarySalesAddress(msg.sender);
         _updateArtblocksSecondarySalesAddress(msg.sender);
@@ -215,7 +215,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         // set AdminACL management contract as owner
         _transferOwnership(_adminACLContract);
         // initialize next project ID
-        nextProjectId = _nextProjectId;
+        nextProjectId = _startingProjectId;
         emit PlatformUpdated(FIELD_NEXT_PROJECT_ID);
     }
 

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -133,7 +133,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     address public minterContract;
 
     /// next project ID to be created
-    uint256 public nextProjectId = 0;
+    uint256 public nextProjectId;
 
     /// version & type of this core contract
     string public constant coreVersion = "v3.0.0";

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -22,6 +22,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     uint256 constant FOUR_WEEKS_IN_SECONDS = 2_419_200;
 
     // generic platform event fields
+    bytes32 constant FIELD_NEXT_PROJECT_ID = "nextProjectId";
     bytes32 constant FIELD_ARTBLOCKS_PRIMARY_SALES_ADDRESS =
         "artblocksPrimarySalesAddress";
     bytes32 constant FIELD_ARTBLOCKS_SECONDARY_SALES_ADDRESS =
@@ -199,18 +200,23 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
      * @param _randomizerContract Randomizer contract.
      * @param _adminACLContract Address of admin access control contract, to be
      * set as contract owner.
+     * @param _nextProjectId The initial next project ID.
      */
     constructor(
         string memory _tokenName,
         string memory _tokenSymbol,
         address _randomizerContract,
-        address _adminACLContract
+        address _adminACLContract,
+        uint256 _nextProjectId
     ) ERC721(_tokenName, _tokenSymbol) {
         _updateArtblocksPrimarySalesAddress(msg.sender);
         _updateArtblocksSecondarySalesAddress(msg.sender);
         _updateRandomizerAddress(_randomizerContract);
         // set AdminACL management contract as owner
         _transferOwnership(_adminACLContract);
+        // initialize next project ID
+        nextProjectId = _nextProjectId;
+        emit PlatformUpdated(FIELD_NEXT_PROJECT_ID);
     }
 
     /**

--- a/test/core/V3/GenArt721CoreV3_Events.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Events.test.ts
@@ -80,17 +80,33 @@ describe("GenArt721CoreV3 Events", async function () {
   });
 
   describe("PlatformUpdated", function () {
-    it("emits artblocksPrimarySalesAddress", async function () {
-      // emits expected event arg(s)
-      expect(
-        await this.genArt721Core
-          .connect(this.accounts.deployer)
-          .updateArtblocksPrimarySalesAddress(this.accounts.artist.address)
-      )
-        .to.emit(this.genArt721Core, "PlatformUpdated")
-        .withArgs(
-          ethers.utils.formatBytes32String("artblocksPrimarySalesAddress")
+    it("emits nextProjectId", async function () {
+      // typical expect event helper doesn't work for deploy event
+      const contractFactory = await ethers.getContractFactory(
+        "GenArt721CoreV3"
+      );
+      const tx = await contractFactory
+        .connect(this.accounts.deployer)
+        .deploy(
+          "name",
+          "symbol",
+          constants.ZERO_ADDRESS,
+          constants.ZERO_ADDRESS,
+          365
         );
+      const receipt = await tx.deployTransaction.wait();
+      // target event is the last log
+      const targetLog = receipt.logs[receipt.logs.length - 1];
+      // expect "PlatformUpdated" event as log 0
+      expect(targetLog.topics[0]).to.be.equal(
+        ethers.utils.keccak256(
+          ethers.utils.toUtf8Bytes("PlatformUpdated(bytes32)")
+        )
+      );
+      // expect field to be bytes32 of "nextProjectId" as log 1
+      expect(targetLog.topics[1]).to.be.equal(
+        ethers.utils.formatBytes32String("nextProjectId")
+      );
     });
 
     it("emits artblocksSecondarySalesAddress", async function () {

--- a/test/core/V3/GenArt721CoreV3_Integration.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Integration.test.ts
@@ -252,6 +252,28 @@ describe("GenArt721CoreV3 Integration", async function () {
     });
   });
 
+  describe("initial nextProjectId", function () {
+    it("returns zero when initialized to zero nextProjectId", async function () {
+      // one project has already been added, so should be one
+      expect(await this.genArt721Core.nextProjectId()).to.be.equal(1);
+    });
+
+    it("returns >0 when initialized to >0 nextProjectId", async function () {
+      const differentGenArt721Core = await deployAndGet.call(
+        this,
+        "GenArt721CoreV3",
+        [
+          this.name,
+          this.symbol,
+          this.randomizer.address,
+          this.adminACL.address,
+          365,
+        ]
+      );
+      expect(await differentGenArt721Core.nextProjectId()).to.be.equal(365);
+    });
+  });
+
   describe("mint_ECF", function () {
     it("reverts if not called by the minter contract", async function () {
       await expectRevert(

--- a/test/util/common.ts
+++ b/test/util/common.ts
@@ -115,6 +115,7 @@ export async function deployCoreWithMinterFilter(
       this.symbol,
       randomizer.address,
       adminACL.address,
+      0,
     ]);
     // assign core contract for randomizer to use
     randomizer


### PR DESCRIPTION
Allow V3 to initialize nextProjectId to non-zero value.

We expect the first V3 core's projectId to be immediately after the last V1 core value. This allows the initial value of `nextProjectId` to be initialized in the core contract's constructor.

## Design Choices
- Initialize `nextProjectId` via a constructor input arg `startingProjectId` to avoid hard-coding the initial value of `nextProjectId` in the contract source code
  - This helps reduce the complexity of tests, allows for easy version rolling, etc.
- A `PlatformUpdated` event is emitted in the constructor indicating that `nextProjectId` has been updated
  - This seems more concise vs. adding a more-generic event with a field like "contractDeployed" and implying the subgraph should know what to do
  - Not including the value of nextProjectId in the event opens us up to a state mis-match if a project were added in the same block that the contract is deployed in
    - Recommend that we update `nextProjectId` in the subgraph any time a new project is added (since the new projectId is included in that event), which prevents state mis-match from ever persisting after an entire block is processed.
    
## Audit Impacts
Recommend that this is included in our audit.