### PR TITLE
Minor core gas reductions

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -238,7 +238,10 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
 
         // load invocations into memory
         uint24 invocationsBefore = projects[_projectId].invocations;
-        uint24 invocationsAfter = invocationsBefore + 1;
+        uint24 invocationsAfter;
+        unchecked {
+            invocationsAfter = invocationsBefore + 1;
+        }
         uint24 maxInvocations = projects[_projectId].maxInvocations;
 
         require(
@@ -259,7 +262,10 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         // EFFECTS
         // increment project's invocations
         projects[_projectId].invocations = invocationsAfter;
-        uint256 thisTokenId = (_projectId * ONE_MILLION) + invocationsBefore;
+        uint256 thisTokenId;
+        unchecked {
+            thisTokenId = (_projectId * ONE_MILLION) + invocationsBefore;
+        }
 
         // mark project as completed if hit max invocations
         if (invocationsAfter == maxInvocations) {
@@ -1170,20 +1176,30 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     {
         // calculate revenues
         artblocksRevenue_ = (_price * artblocksPrimarySalesPercentage) / 100;
-        uint256 projectFunds = _price - artblocksRevenue_;
+        uint256 projectFunds;
+        unchecked {
+            // artblocksRevenue_ is always <=25, so guaranteed to never underflow
+            projectFunds = _price - artblocksRevenue_;
+        }
         additionalPayeePrimaryRevenue_ =
             (projectFunds *
                 projectIdToAdditionalPayeePrimarySalesPercentage[_projectId]) /
             100;
-        artistRevenue_ = projectFunds - additionalPayeePrimaryRevenue_;
+        unchecked {
+            // projectIdToAdditionalPayeePrimarySalesPercentage is always
+            // <=100, so guaranteed to never underflow
+            artistRevenue_ = projectFunds - additionalPayeePrimaryRevenue_;
+        }
         // set addresses from storage
         artblocksAddress_ = artblocksPrimarySalesAddress;
-        artistAddress_ = artistRevenue_ > 0
-            ? projectIdToArtistAddress[_projectId]
-            : payable(address(0));
-        additionalPayeePrimaryAddress_ = additionalPayeePrimaryRevenue_ > 0
-            ? projectIdToAdditionalPayeePrimarySales[_projectId]
-            : payable(address(0));
+        if (artistRevenue_ > 0) {
+            artistAddress_ = projectIdToArtistAddress[_projectId];
+        }
+        if (additionalPayeePrimaryRevenue_ > 0) {
+            additionalPayeePrimaryAddress_ = projectIdToAdditionalPayeePrimarySales[
+                _projectId
+            ];
+        }
     }
 
     /**

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -240,6 +240,8 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         uint24 invocationsBefore = projects[_projectId].invocations;
         uint24 invocationsAfter;
         unchecked {
+            // invocationsBefore guaranteed <= maxInvocations <= 1_000_000,
+            // 1_000_000 << max uint24, so no possible overflow
             invocationsAfter = invocationsBefore + 1;
         }
         uint24 maxInvocations = projects[_projectId].maxInvocations;
@@ -264,6 +266,10 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         projects[_projectId].invocations = invocationsAfter;
         uint256 thisTokenId;
         unchecked {
+            // invocationsBefore is uint24 << max uint256. In production use,
+            // _projectId * ONE_MILLION must be << max uint256, otherwise
+            // tokenIdToProjectId function become invalid.
+            // Therefore, no risk of overflow
             thisTokenId = (_projectId * ONE_MILLION) + invocationsBefore;
         }
 

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
@@ -149,7 +149,7 @@ describe("MinterDAExpV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.016562")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0165046")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
@@ -149,7 +149,7 @@ describe("MinterDALinV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0165542")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0164968")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
@@ -177,7 +177,7 @@ describe("MinterSetPriceV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0155761")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0155187")); // assuming a cost of 100 GWEI
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
@@ -206,7 +206,7 @@ describe("MinterSetPriceERC20V2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0155976"));
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0155402"));
     });
   });
 


### PR DESCRIPTION
Implement minor core gas optimizations to slightly reduce minting costs.

This finds ~0.4% gas reduction on mints via:
- identifying areas where safe math is not required 
- eliminating an unnecessary `address(0)` assignment when no funds are due to artist or additional payee on primary sales

Changes are all internal and do no affect interfaces.

## Gas impacts
Mint costs are slightly reduced. Representative minter cost updates are shown in the table below.

_All gas costs assume project 3 mints avg(501-516) of 1000_
| Gas Test | Previous gas used to purchase | New gas used to purchase | % change |
| --- | --- | --- | --- |
| MinterSetPriceV2_V3Core | 138407 | 137859 | -0.4% (cheaper) |
| MinterDAExpV2_V3Core | 148156 | 147608 | -0.4% (cheaper) |

## Audit impacts
- Highly recommend this is included in audit