### PR TITLE
Enable admin to forbid new projects on V3 core

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -206,6 +206,8 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
      * @param _adminACLContract Address of admin access control contract, to be
      * set as contract owner.
      * @param _startingProjectId The initial next project ID.
+     * @dev _startingProjectId should be set to a value much, much less than
+     * max(uint248) to avoid overflow when adding to it.
      */
     constructor(
         string memory _tokenName,
@@ -220,7 +222,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
         // set AdminACL management contract as owner
         _transferOwnership(_adminACLContract);
         // initialize next project ID
-        nextProjectId = _startingProjectId;
+        _nextProjectId = uint248(_startingProjectId);
         emit PlatformUpdated(FIELD_NEXT_PROJECT_ID);
     }
 

--- a/contracts/V3_CHANGELOG.md
+++ b/contracts/V3_CHANGELOG.md
@@ -64,3 +64,5 @@ _This document is intended to document and explain the Art Blocks Core V3 change
 - Update randomizer interface for V3 core contract
 - Only allow artists to reduce the number of maximum invocations
   - Remove any unnecessary minter logic accordingly
+- Enable admin to forever prevent new projects from being added to the core contract
+  - This is to prevent the core contract from being used to mint new projects if Art Blocks ever changes to a new contract in the future.

--- a/test/core/V3/GenArt721CoreV3_ContractConfigure.test.ts
+++ b/test/core/V3/GenArt721CoreV3_ContractConfigure.test.ts
@@ -118,4 +118,28 @@ describe("GenArt721CoreV3 Contract Configure", async function () {
         .updateArtblocksSecondarySalesBPS(0);
     });
   });
+
+  describe("forbidNewProjects", function () {
+    it("prevents new projects from being added after calling", async function () {
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .forbidNewProjects();
+      await expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.deployer)
+          .addProject("shouldn't work", this.accounts.artist.address),
+        "New projects forbidden"
+      );
+    });
+
+    it("does allow to call forbidNewProjects more than once", async function () {
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .forbidNewProjects();
+      await expectRevert(
+        this.genArt721Core.connect(this.accounts.deployer).forbidNewProjects(),
+        "Already forbidden"
+      );
+    });
+  });
 });

--- a/test/core/V3/GenArt721CoreV3_Events.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Events.test.ts
@@ -182,6 +182,17 @@ describe("GenArt721CoreV3 Events", async function () {
         .to.emit(this.genArt721Core, "PlatformUpdated")
         .withArgs(ethers.utils.formatBytes32String("artblocksSecondaryBPS"));
     });
+
+    it("emits 'newProjectsForbidden'", async function () {
+      // emits expected event arg(s)
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.deployer)
+          .forbidNewProjects()
+      )
+        .to.emit(this.genArt721Core, "PlatformUpdated")
+        .withArgs(ethers.utils.formatBytes32String("newProjectsForbidden"));
+    });
   });
 
   describe("ProjectUpdated", function () {

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
@@ -149,7 +149,7 @@ describe("MinterDAExpV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0165046")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0165068")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
@@ -149,7 +149,7 @@ describe("MinterDALinV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0164968")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.016499")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
@@ -177,7 +177,7 @@ describe("MinterSetPriceV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0155187")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0155209")); // assuming a cost of 100 GWEI
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
@@ -206,7 +206,7 @@ describe("MinterSetPriceERC20V2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0155402"));
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0155424"));
     });
   });
 


### PR DESCRIPTION
Enable admin to forever forbid new projects from being added to V3 core.

A new function is added, gated to admin, that can forever forbid new projects from ever being added to the V3 core contract.

## Design Choices
This also packs `_nextProjectId` and the new bool into the same storage slot by internally limiting `_nextProjectId` to a uint248. Previous interface maintained via a getter function that returns `nextProjectId` as uint256. 