### PR TITLE
Add unchecked blocks to minters where unnecessary

### DIFF
--- a/contracts/minter-suite/Minters/MinterDAExp/MinterDAExpV2.sol
+++ b/contracts/minter-suite/Minters/MinterDAExp/MinterDAExpV2.sol
@@ -474,7 +474,7 @@ contract MinterDAExpV2 is ReentrancyGuard, IFilteredMinterV0 {
         // approximate the current place on a perfect exponential decay curve.
         unchecked {
             // value of expression is provably always less than decayedPrice,
-            // given that no underflow not possible
+            // so no underflow is possible
             decayedPrice -=
                 (decayedPrice *
                     (elapsedTimeSeconds % _priceDecayHalfLifeSeconds)) /

--- a/contracts/minter-suite/Minters/MinterDALin/MinterDALinV2.sol
+++ b/contracts/minter-suite/Minters/MinterDALin/MinterDALinV2.sol
@@ -430,9 +430,17 @@ contract MinterDALinV2 is ReentrancyGuard, IFilteredMinterV0 {
             require(_timestampEnd > 0, "Only configured auctions");
             return _basePrice;
         }
-        uint256 elapsedTime = block.timestamp - _timestampStart;
-        uint256 duration = _timestampEnd - _timestampStart;
-        uint256 startToEndDiff = _startPrice - _basePrice;
+        uint256 elapsedTime;
+        uint256 duration;
+        uint256 startToEndDiff;
+        unchecked {
+            // already checked that block.timestamp > _timestampStart
+            elapsedTime = block.timestamp - _timestampStart;
+            // _timestampEnd > _timestampStart enforced during assignment
+            duration = _timestampEnd - _timestampStart;
+            // _startPrice > _basePrice enforced during assignment
+            startToEndDiff = _startPrice - _basePrice;
+        }
         return _startPrice - ((elapsedTime * startToEndDiff) / duration);
     }
 

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
@@ -149,7 +149,7 @@ describe("MinterDAExpV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0165068")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0164719")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
@@ -149,7 +149,7 @@ describe("MinterDALinV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.016499")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0164795")); // assuming a cost of 100 GWEI
     });
   });
 });


### PR DESCRIPTION
Add unchecked blocks to minters where unnecessary to find very minor gas reductions.

## Gas impacts
Only the Dutch Auction minters have reductions

_All gas costs assume project 3 mints avg(501-516) of 1000_
| Gas Test | Previous gas used to purchase | New gas used to purchase | % change |
| --- | --- | --- | --- |
| MinterDAExpV2_V3Core | 147604 | 147255 | -0.2% (cheaper) |
| MinterDALinV2_V3Core | 147548 | 147353 | -0.1% (cheaper) |