### PR TITLE
Add tests to reach 100% line coverage for V3-compatible minters

### DIFF
--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExp.common.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExp.common.ts
@@ -7,6 +7,16 @@ import { ONE_MINUTE, ONE_HOUR, ONE_DAY } from "../../../util/constants";
 
 import { Minter_Common } from "../../Minter.common";
 
+// returns true if exponential auction params are all zero
+const DAExpAuctionParamsAreZero = (auctionParams) => {
+  return (
+    auctionParams.timestampStart == 0 &&
+    auctionParams.priceDecayHalfLifeSeconds == 0 &&
+    auctionParams.startPrice == 0 &&
+    auctionParams.basePrice == 0
+  );
+};
+
 /**
  * These tests are intended to check common DAExp functionality.
  * @dev assumes common BeforeEach to populate accounts, constants, and setup
@@ -212,10 +222,7 @@ export const MinterDAExp_Common = async () => {
       const auctionParams = await this.minter
         .connect(this.accounts.deployer)
         .projectAuctionParameters(this.projectOne);
-      expect(auctionParams.timestampStart).to.be.equal(0);
-      expect(auctionParams.priceDecayHalfLifeSeconds).to.be.equal(0);
-      expect(auctionParams.startPrice).to.be.equal(0);
-      expect(auctionParams.basePrice).to.be.equal(0);
+      expect(DAExpAuctionParamsAreZero(auctionParams)).to.be.true;
     });
 
     it("returns expected values after resetting values", async function () {
@@ -225,10 +232,7 @@ export const MinterDAExp_Common = async () => {
       const auctionParams = await this.minter
         .connect(this.accounts.deployer)
         .projectAuctionParameters(this.projectZero);
-      expect(auctionParams.timestampStart).to.be.equal(0);
-      expect(auctionParams.priceDecayHalfLifeSeconds).to.be.equal(0);
-      expect(auctionParams.startPrice).to.be.equal(0);
-      expect(auctionParams.basePrice).to.be.equal(0);
+      expect(DAExpAuctionParamsAreZero(auctionParams)).to.be.true;
     });
   });
 

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALin.common.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALin.common.ts
@@ -201,6 +201,77 @@ export const MinterDALin_Common = async () => {
     });
   });
 
+  describe("projectAuctionParameters", async function () {
+    it("returns expected populated values", async function () {
+      const auctionParams = await this.minter.projectAuctionParameters(
+        this.projectZero
+      );
+      expect(auctionParams.timestampStart).to.be.equal(
+        this.startTime + this.auctionStartTimeOffset
+      );
+      expect(auctionParams.timestampEnd).to.be.equal(
+        this.startTime + this.auctionStartTimeOffset + ONE_HOUR * 2
+      );
+      expect(auctionParams.startPrice).to.be.equal(this.startingPrice);
+      expect(auctionParams.basePrice).to.be.equal(this.basePrice);
+    });
+
+    it("returns expected initial values", async function () {
+      const auctionParams = await this.minter
+        .connect(this.accounts.deployer)
+        .projectAuctionParameters(this.projectOne);
+      expect(auctionParams.timestampStart).to.be.equal(0);
+      expect(auctionParams.timestampEnd).to.be.equal(0);
+      expect(auctionParams.startPrice).to.be.equal(0);
+      expect(auctionParams.basePrice).to.be.equal(0);
+    });
+
+    it("returns expected values after resetting values", async function () {
+      await this.minter
+        .connect(this.accounts.deployer)
+        .resetAuctionDetails(this.projectZero);
+      const auctionParams = await this.minter
+        .connect(this.accounts.deployer)
+        .projectAuctionParameters(this.projectZero);
+      expect(auctionParams.timestampStart).to.be.equal(0);
+      expect(auctionParams.timestampEnd).to.be.equal(0);
+      expect(auctionParams.startPrice).to.be.equal(0);
+      expect(auctionParams.basePrice).to.be.equal(0);
+    });
+  });
+
+  describe("projectMaxHasBeenInvoked", async function () {
+    it("returns expected value for project zero", async function () {
+      const hasMaxBeenInvoked = await this.minter.projectMaxHasBeenInvoked(
+        this.projectZero
+      );
+      expect(hasMaxBeenInvoked).to.be.false;
+    });
+
+    it("returns true after a project is minted out", async function () {
+      // reduce maxInvocations to 2 on core
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .updateProjectMaxInvocations(this.projectZero, 1);
+      // sync max invocations on minter
+      await this.minter
+        .connect(this.accounts.deployer)
+        .setProjectMaxInvocations(this.projectZero);
+      // mint a token
+      await ethers.provider.send("evm_mine", [
+        this.startTime + this.auctionStartTimeOffset,
+      ]);
+      await this.minter.connect(this.accounts.user).purchase(this.projectZero, {
+        value: this.startingPrice,
+      });
+      // expect projectMaxHasBeenInvoked to be true
+      const hasMaxBeenInvoked = await this.minter.projectMaxHasBeenInvoked(
+        this.projectZero
+      );
+      expect(hasMaxBeenInvoked).to.be.true;
+    });
+  });
+
   describe("resetAuctionDetails", async function () {
     it("allows whitelisted to reset auction details", async function () {
       await expect(

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALin.common.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALin.common.ts
@@ -7,6 +7,16 @@ import { ONE_MINUTE, ONE_HOUR, ONE_DAY } from "../../../util/constants";
 
 import { Minter_Common } from "../../Minter.common";
 
+// returns true if exponential auction params are all zero
+const DALinAuctionParamsAreZero = (auctionParams) => {
+  return (
+    auctionParams.timestampStart == 0 &&
+    auctionParams.timestampEnd == 0 &&
+    auctionParams.startPrice == 0 &&
+    auctionParams.basePrice == 0
+  );
+};
+
 /**
  * These tests are intended to check common DALin functionality.
  * @dev assumes common BeforeEach to populate accounts, constants, and setup
@@ -220,10 +230,7 @@ export const MinterDALin_Common = async () => {
       const auctionParams = await this.minter
         .connect(this.accounts.deployer)
         .projectAuctionParameters(this.projectOne);
-      expect(auctionParams.timestampStart).to.be.equal(0);
-      expect(auctionParams.timestampEnd).to.be.equal(0);
-      expect(auctionParams.startPrice).to.be.equal(0);
-      expect(auctionParams.basePrice).to.be.equal(0);
+      expect(DALinAuctionParamsAreZero(auctionParams)).to.be.true;
     });
 
     it("returns expected values after resetting values", async function () {
@@ -233,10 +240,7 @@ export const MinterDALin_Common = async () => {
       const auctionParams = await this.minter
         .connect(this.accounts.deployer)
         .projectAuctionParameters(this.projectZero);
-      expect(auctionParams.timestampStart).to.be.equal(0);
-      expect(auctionParams.timestampEnd).to.be.equal(0);
-      expect(auctionParams.startPrice).to.be.equal(0);
-      expect(auctionParams.basePrice).to.be.equal(0);
+      expect(DALinAuctionParamsAreZero(auctionParams)).to.be.true;
     });
   });
 

--- a/test/minter-suite-minters/MinterMerkle/MinterMerkle.common.ts
+++ b/test/minter-suite-minters/MinterMerkle/MinterMerkle.common.ts
@@ -704,6 +704,38 @@ export const MinterMerkle_Common = async () => {
     });
   });
 
+  describe("projectMintLimiterDisabled", async function () {
+    it("is false by default", async function () {
+      const projectMintLimiterDisabled = await this.minter
+        .connect(this.accounts.user)
+        .projectMintLimiterDisabled(this.projectZero);
+      expect(projectMintLimiterDisabled).to.be.false;
+    });
+
+    it("is true by when toggled", async function () {
+      await this.minter
+        .connect(this.accounts.artist)
+        .toggleProjectMintLimiter(this.projectZero);
+      const projectMintLimiterDisabled = await this.minter
+        .connect(this.accounts.user)
+        .projectMintLimiterDisabled(this.projectZero);
+      expect(projectMintLimiterDisabled).to.be.true;
+    });
+
+    it("is false by when toggled twice", async function () {
+      await this.minter
+        .connect(this.accounts.artist)
+        .toggleProjectMintLimiter(this.projectZero);
+      await this.minter
+        .connect(this.accounts.artist)
+        .toggleProjectMintLimiter(this.projectZero);
+      const projectMintLimiterDisabled = await this.minter
+        .connect(this.accounts.user)
+        .projectMintLimiterDisabled(this.projectZero);
+      expect(projectMintLimiterDisabled).to.be.false;
+    });
+  });
+
   describe("reentrancy attack", async function () {
     it("does not allow reentrant purchaseTo, when mint limiter on", async function () {
       // contract buys are always allowed by default if in merkle tree


### PR DESCRIPTION
Add tests to reach 100% line coverage for V3-compatible minters.

I missed a few tests when adding the public getters when struct packing over the last day.