### PR TITLE
V2 PBAB/PRTNR non-zero startingProjectId

### DIFF
--- a/contracts/PBAB+Collabs/GenArt721CoreV2_PBAB.sol
+++ b/contracts/PBAB+Collabs/GenArt721CoreV2_PBAB.sol
@@ -65,7 +65,7 @@ contract GenArt721CoreV2_PBAB is ERC721Enumerable, IGenArt721CoreV2_PBAB {
     mapping(address => bool) public isMintWhitelisted;
 
     /// next project ID to be created
-    uint256 public nextProjectId = 0;
+    uint256 public nextProjectId;
 
     modifier onlyValidTokenId(uint256 _tokenId) {
         require(_exists(_tokenId), "Token ID does not exist");
@@ -109,16 +109,22 @@ contract GenArt721CoreV2_PBAB is ERC721Enumerable, IGenArt721CoreV2_PBAB {
      * @param _tokenName Name of token.
      * @param _tokenSymbol Token symbol.
      * @param _randomizerContract Randomizer contract.
+     * @param _startingProjectId The initial next project ID.
+     * @dev _startingProjectId should be set to a value much, much less than
+     * max(uint256) to avoid overflow when adding to it.
      */
     constructor(
         string memory _tokenName,
         string memory _tokenSymbol,
-        address _randomizerContract
+        address _randomizerContract,
+        uint256 _startingProjectId
     ) ERC721(_tokenName, _tokenSymbol) {
         admin = msg.sender;
         isWhitelisted[msg.sender] = true;
         renderProviderAddress = payable(msg.sender);
         randomizerContract = IRandomizer(_randomizerContract);
+        // initialize next project ID
+        nextProjectId = _startingProjectId;
     }
 
     /**

--- a/contracts/PBAB+Collabs/GenArt721CoreV2_PRTNR.sol
+++ b/contracts/PBAB+Collabs/GenArt721CoreV2_PRTNR.sol
@@ -97,10 +97,7 @@ contract GenArt721CoreV2_PRTNR is
     /// next project ID to be created
     uint256
         public
-        override(
-            IGenArt721CoreContractV1,
-            IGenArt721CoreV2_PBAB
-        ) nextProjectId = 0;
+        override(IGenArt721CoreContractV1, IGenArt721CoreV2_PBAB) nextProjectId;
 
     modifier onlyValidTokenId(uint256 _tokenId) {
         require(_exists(_tokenId), "Token ID does not exist");
@@ -144,16 +141,22 @@ contract GenArt721CoreV2_PRTNR is
      * @param _tokenName Name of token.
      * @param _tokenSymbol Token symbol.
      * @param _randomizerContract Randomizer contract.
+     * @param _startingProjectId The initial next project ID.
+     * @dev _startingProjectId should be set to a value much, much less than
+     * max(uint256) to avoid overflow when adding to it.
      */
     constructor(
         string memory _tokenName,
         string memory _tokenSymbol,
-        address _randomizerContract
+        address _randomizerContract,
+        uint256 _startingProjectId
     ) ERC721(_tokenName, _tokenSymbol) {
         admin = msg.sender;
         isWhitelisted[msg.sender] = true;
         renderProviderAddress = payable(msg.sender);
         randomizerContract = IRandomizer(_randomizerContract);
+        // initialize next project ID
+        nextProjectId = _startingProjectId;
     }
 
     /**

--- a/scripts/1_reference_pbab_suite_deployer.ts
+++ b/scripts/1_reference_pbab_suite_deployer.ts
@@ -12,6 +12,7 @@ import { createPBABBucket } from "./util/aws_s3";
 //////////////////////////////////////////////////////////////////////////////
 const pbabTokenName = "TODO :: Placeholder";
 const pbabTokenTicker = "TODO";
+const startingProjectId = 0; // TODO
 const pbabTransferAddress = "0x000000000000000000000000000000000000dEaD";
 const rendererProviderAddress = "0x000000000000000000000000000000000000dEaD";
 const randomizerAddress = "0x000000000000000000000000000000000000dEaD";
@@ -32,10 +33,11 @@ async function main() {
   const genArt721Core = await genArt721CoreFactory.deploy(
     pbabTokenName,
     pbabTokenTicker,
-    randomizerAddress
+    randomizerAddress,
+    startingProjectId
   );
 
-  await createPBABBucket(pbabTokenName);
+  await createPBABBucket(pbabTokenName, networkName);
 
   await genArt721Core.deployed();
   console.log(`GenArt721Core deployed at ${genArt721Core.address}`);
@@ -102,7 +104,7 @@ async function main() {
   const standardVerify = "yarn hardhat verify";
   console.log(`Verify GenArt721CoreV2 deployment with:`);
   console.log(
-    `${standardVerify} --network ${networkName} ${genArt721Core.address} "${pbabTokenName}" "${pbabTokenTicker}" ${randomizerAddress}`
+    `${standardVerify} --network ${networkName} ${genArt721Core.address} "${pbabTokenName}" "${pbabTokenTicker}" ${randomizerAddress} ${startingProjectId}`
   );
   console.log(`Verify GenArt721Minter deployment with:`);
   console.log(

--- a/scripts/1_reference_pbab_suite_deployer_with_royalty_registry.ts
+++ b/scripts/1_reference_pbab_suite_deployer_with_royalty_registry.ts
@@ -16,6 +16,7 @@ const DEAD = "0x000000000000000000000000000000000000dEaD";
 //////////////////////////////////////////////////////////////////////////////
 const pbabTokenName = "TODO :: Placeholder";
 const pbabTokenTicker = "TODO";
+const startingProjectId = 0; // TODO
 const pbabTransferAddress = "0x000000000000000000000000000000000000dEaD";
 const rendererProviderAddress = "0x000000000000000000000000000000000000dEaD";
 const randomizerAddress = "0x000000000000000000000000000000000000dEaD";
@@ -63,7 +64,8 @@ async function main() {
   const genArt721Core = await genArt721CoreFactory.deploy(
     pbabTokenName,
     pbabTokenTicker,
-    randomizerAddress
+    randomizerAddress,
+    startingProjectId
   );
 
   await createPBABBucket(pbabTokenName, networkName);
@@ -181,7 +183,7 @@ async function main() {
   const standardVerify = "yarn hardhat verify";
   console.log(`Verify GenArt721CoreV2 deployment with:`);
   console.log(
-    `${standardVerify} --network ${networkName} ${genArt721Core.address} "${pbabTokenName}" "${pbabTokenTicker}" ${randomizerAddress}`
+    `${standardVerify} --network ${networkName} ${genArt721Core.address} "${pbabTokenName}" "${pbabTokenTicker}" ${randomizerAddress} ${startingProjectId}`
   );
   console.log(`Verify GenArt721Minter deployment with:`);
   console.log(

--- a/test/core/GenArt721CoreV1V2PRTNR.common.ts
+++ b/test/core/GenArt721CoreV1V2PRTNR.common.ts
@@ -8,7 +8,7 @@ import { expect } from "chai";
  * does in fact mint tokens to purchaser.
  * @dev assumes common BeforeEach to populate accounts, constants, and setup
  */
-export const GenArt721MinterV1V2_Common = async () => {
+export const GenArt721MinterV1V2PRTNR_Common = async () => {
   describe("has whitelisted owner", function () {
     it("has an admin", async function () {
       expect(await this.genArt721Core.artblocksAddress()).to.be.equal(

--- a/test/core/GenArt721CoreV1_Integration.tests.ts
+++ b/test/core/GenArt721CoreV1_Integration.tests.ts
@@ -15,7 +15,7 @@ import {
   deployAndGet,
   deployCoreWithMinterFilter,
 } from "../util/common";
-import { GenArt721MinterV1V2_Common } from "./GenArt721CoreV1V2.common";
+import { GenArt721MinterV1V2PRTNR_Common } from "./GenArt721CoreV1V2PRTNR.common";
 
 /**
  * These tests are intended to check integration of the MinterFilter suite
@@ -66,7 +66,7 @@ describe("GenArt721CoreV1 Integration", async function () {
   });
 
   describe("common tests", async function () {
-    GenArt721MinterV1V2_Common();
+    GenArt721MinterV1V2PRTNR_Common();
   });
 
   describe("purchase payments and gas", async function () {

--- a/test/core/GenArt721CoreV2_PBAB_Integration.tests.ts
+++ b/test/core/GenArt721CoreV2_PBAB_Integration.tests.ts
@@ -1,0 +1,67 @@
+import { Coder } from "@ethersproject/abi/lib/coders/abstract-coder";
+import {
+  BN,
+  constants,
+  expectEvent,
+  expectRevert,
+  balance,
+  ether,
+} from "@openzeppelin/test-helpers";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import {
+  getAccounts,
+  assignDefaultConstants,
+  deployAndGet,
+  deployCoreWithMinterFilter,
+} from "../util/common";
+
+/**
+ * These tests are intended to check basic updates to the V2 PBAB core contract.
+ * Note that this test suite is not complete, and does not test all functionality.
+ * It includes tests for any added functionality after initial V2 PBAB release.
+ */
+describe("GenArt721CoreV2_PBAB_Integration", async function () {
+  beforeEach(async function () {
+    // standard accounts and constants
+    this.accounts = await getAccounts();
+    await assignDefaultConstants.call(this);
+    // deploy and configure core, randomizer, and minter
+    this.randomizer = await deployAndGet.call(this, "BasicRandomizer", []);
+    // V2_PRTNR need additional arg for starting project ID
+    this.genArt721Core = await deployAndGet.call(this, "GenArt721CoreV2_PBAB", [
+      this.name,
+      this.symbol,
+      this.randomizer.address,
+      0,
+    ]);
+    this.minter = await deployAndGet.call(this, "GenArt721Minter_PBAB", [
+      this.genArt721Core.address,
+    ]);
+    // add minter
+    this.genArt721Core
+      .connect(this.accounts.deployer)
+      .addMintWhitelisted(this.minter.address);
+    // add project
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .addProject("name", this.accounts.artist.address, 0);
+  });
+
+  describe("initial nextProjectId", function () {
+    it("returns zero when initialized to zero nextProjectId", async function () {
+      // one project has already been added, so should be one
+      expect(await this.genArt721Core.nextProjectId()).to.be.equal(1);
+    });
+
+    it("returns >0 when initialized to >0 nextProjectId", async function () {
+      const differentGenArt721Core = await deployAndGet.call(
+        this,
+        "GenArt721CoreV2_PRTNR",
+        [this.name, this.symbol, this.randomizer.address, 365]
+      );
+      expect(await differentGenArt721Core.nextProjectId()).to.be.equal(365);
+    });
+  });
+});

--- a/test/core/GenArt721CoreV2_PRTNR_Integration.tests.ts
+++ b/test/core/GenArt721CoreV2_PRTNR_Integration.tests.ts
@@ -16,7 +16,7 @@ import {
   deployAndGet,
   deployCoreWithMinterFilter,
 } from "../util/common";
-import { GenArt721MinterV1V2_Common } from "./GenArt721CoreV1V2.common";
+import { GenArt721MinterV1V2PRTNR_Common } from "./GenArt721CoreV1V2PRTNR.common";
 
 /**
  * These tests are intended to check integration of the MinterFilter suite with
@@ -30,12 +30,15 @@ describe("GenArt721CoreV2_PRTNR_Integration", async function () {
     this.accounts = await getAccounts();
     await assignDefaultConstants.call(this);
     // deploy and configure minter filter and minter
-    ({ genArt721Core: this.genArt721Core, minterFilter: this.minterFilter } =
-      await deployCoreWithMinterFilter.call(
-        this,
-        "GenArt721CoreV2_PRTNR",
-        "MinterFilterV0"
-      ));
+    ({
+      genArt721Core: this.genArt721Core,
+      minterFilter: this.minterFilter,
+      randomizer: this.randomizer,
+    } = await deployCoreWithMinterFilter.call(
+      this,
+      "GenArt721CoreV2_PRTNR",
+      "MinterFilterV0"
+    ));
     this.minter = await deployAndGet.call(this, "MinterSetPriceV1", [
       this.genArt721Core.address,
       this.minterFilter.address,
@@ -67,7 +70,23 @@ describe("GenArt721CoreV2_PRTNR_Integration", async function () {
   });
 
   describe("common tests", async function () {
-    GenArt721MinterV1V2_Common();
+    GenArt721MinterV1V2PRTNR_Common();
+  });
+
+  describe("initial nextProjectId", function () {
+    it("returns zero when initialized to zero nextProjectId", async function () {
+      // one project has already been added, so should be one
+      expect(await this.genArt721Core.nextProjectId()).to.be.equal(1);
+    });
+
+    it("returns >0 when initialized to >0 nextProjectId", async function () {
+      const differentGenArt721Core = await deployAndGet.call(
+        this,
+        "GenArt721CoreV2_PRTNR",
+        [this.name, this.symbol, this.randomizer.address, 365]
+      );
+      expect(await differentGenArt721Core.nextProjectId()).to.be.equal(365);
+    });
   });
 
   describe("purchase payments and gas", async function () {

--- a/test/minters-pbab/GenArt721MinterBurner_PBAB.test.ts
+++ b/test/minters-pbab/GenArt721MinterBurner_PBAB.test.ts
@@ -10,7 +10,7 @@ import { GenArt721Minter_PBAB_Common } from "./GenArt721Minter_PBAB.common";
  * These tests intended to ensure Filtered Minter integrates properly with V1
  * core contract.
  */
-describe("GenArt721Minter_PBAB", async function () {
+describe("GenArt721MinterBurner_PBAB", async function () {
   beforeEach(async function () {
     // standard accounts and constants
     this.accounts = await getAccounts();
@@ -25,7 +25,7 @@ describe("GenArt721Minter_PBAB", async function () {
     const PBABFactory = await ethers.getContractFactory("GenArt721CoreV2_PBAB");
     this.genArt721Core = await PBABFactory.connect(
       this.accounts.deployer
-    ).deploy(this.name, this.symbol, this.randomizer.address);
+    ).deploy(this.name, this.symbol, this.randomizer.address, 0);
 
     const minterFactory = await ethers.getContractFactory(
       "GenArt721MinterBurner_PBAB"

--- a/test/minters-pbab/GenArt721Minter_PBAB.test.ts
+++ b/test/minters-pbab/GenArt721Minter_PBAB.test.ts
@@ -22,7 +22,7 @@ describe("GenArt721Minter_PBAB", async function () {
     const PBABFactory = await ethers.getContractFactory("GenArt721CoreV2_PBAB");
     this.genArt721Core = await PBABFactory.connect(
       this.accounts.deployer
-    ).deploy(this.name, this.symbol, this.randomizer.address);
+    ).deploy(this.name, this.symbol, this.randomizer.address, 0);
 
     const minterFactory = await ethers.getContractFactory(
       "GenArt721Minter_PBAB"

--- a/test/royalty-overrides/GenArt721RoyaltyOverride.PRTNR.test.ts
+++ b/test/royalty-overrides/GenArt721RoyaltyOverride.PRTNR.test.ts
@@ -25,7 +25,7 @@ const assertRoyaltiesResponse = async (
  * @notice This ensures responses from a flagship royalty override are as
  * expected when integrating with a GenArt721CoreV2_PRTNR core contract.
  */
-describe("GenArt721RoyaltyOverride", async function () {
+describe("GenArt721RoyaltyOverride_PRTNR", async function () {
   const name = "Non Fungible Token";
   const symbol = "NFT";
 
@@ -72,7 +72,7 @@ describe("GenArt721RoyaltyOverride", async function () {
     );
     this.tokenA = await artblocksFactory
       .connect(adminA)
-      .deploy(name, symbol, this.randomizer.address);
+      .deploy(name, symbol, this.randomizer.address, 0);
 
     // add projects for artists 0 and 1
     await this.tokenA
@@ -159,7 +159,7 @@ describe("GenArt721RoyaltyOverride", async function () {
     // deploy second core contract with two more projects
     this.tokenB = await artblocksFactory
       .connect(adminB)
-      .deploy(name, symbol, this.randomizer.address);
+      .deploy(name, symbol, this.randomizer.address, 0);
 
     // add projects for artists 0 and 1
     await this.tokenB

--- a/test/royalty-overrides/GenArt721RoyaltyOverride_PBAB.test.ts
+++ b/test/royalty-overrides/GenArt721RoyaltyOverride_PBAB.test.ts
@@ -72,7 +72,7 @@ describe("GenArt721RoyaltyOverride_PBAB", async function () {
     );
     this.tokenA = await artblocksFactory_PBAB
       .connect(adminA)
-      .deploy(name, symbol, this.randomizer.address);
+      .deploy(name, symbol, this.randomizer.address, 0);
 
     // set renderProviderAddress for tokenA
     await this.tokenA
@@ -141,7 +141,7 @@ describe("GenArt721RoyaltyOverride_PBAB", async function () {
     // deploy second core contract with two more projects
     this.tokenB = await artblocksFactory_PBAB
       .connect(adminB)
-      .deploy(name, symbol, this.randomizer.address);
+      .deploy(name, symbol, this.randomizer.address, 0);
 
     // set renderProviderAddress for tokenB
     await this.tokenB

--- a/test/util/common.ts
+++ b/test/util/common.ts
@@ -218,7 +218,8 @@ export async function deployAndGetPBAB(): Promise<T_PBAB> {
   const pbabToken = await PBABFactory.connect(this.accounts.deployer).deploy(
     this.name,
     this.symbol,
-    randomizer.address
+    randomizer.address,
+    0
   );
   const minterFactory = await ethers.getContractFactory("GenArt721Minter_PBAB");
   const pbabMinter = await minterFactory.deploy(pbabToken.address);

--- a/test/util/common.ts
+++ b/test/util/common.ts
@@ -82,24 +82,36 @@ export async function deployAndGet(
 }
 
 // utility function to deploy basic randomizer, core, and MinterFilter
-// works for core versions V0, V1, V2, V3
+// works for core versions V0, V1, V2_PRTNR, V3
 export async function deployCoreWithMinterFilter(
   coreContractName: string,
   minterFilterName: string
 ): Promise<CoreWithMinterSuite> {
+  if (coreContractName.endsWith("V2_PBAB")) {
+    throw new Error("V2_PBAB not supported");
+  }
   let randomizer, genArt721Core, minterFilter, adminACL;
+  randomizer = await deployAndGet.call(this, "BasicRandomizer", []);
   if (
     coreContractName.endsWith("V0") ||
     coreContractName.endsWith("V1") ||
-    coreContractName.endsWith("V2") ||
     coreContractName.endsWith("V2_PRTNR")
   ) {
-    randomizer = await deployAndGet.call(this, "BasicRandomizer", []);
-    genArt721Core = await deployAndGet.call(this, coreContractName, [
-      this.name,
-      this.symbol,
-      randomizer.address,
-    ]);
+    if (coreContractName.endsWith("V0") || coreContractName.endsWith("V1")) {
+      genArt721Core = await deployAndGet.call(this, coreContractName, [
+        this.name,
+        this.symbol,
+        randomizer.address,
+      ]);
+    } else {
+      // V2_PRTNR need additional arg for starting project ID
+      genArt721Core = await deployAndGet.call(this, coreContractName, [
+        this.name,
+        this.symbol,
+        randomizer.address,
+        0,
+      ]);
+    }
     minterFilter = await deployAndGet.call(this, minterFilterName, [
       genArt721Core.address,
     ]);


### PR DESCRIPTION
Update V2 PBAB and PRTNR to enable non-zero startingProjectId.

This is follow-on work somewhat related to https://github.com/ArtBlocks/artblocks-contracts/pull/249/files, and also related to https://github.com/ArtBlocks/artblocks-contracts/pull/252.

This keeps startingProjectId as a uint256 to minimize change relative to the existing V2 PBAB and PRTNR contracts. There is also no opportunity to reduce gas by packing, because we don't have any bools nearby (different than the new PBAB flex contract, where there is opportunity).

Tests added for new functionality, PBAB deployer script templates updated for additional constructor arg.