### PR TITLE
bytes16 hash

### DIFF
--- a/contracts/BasicRandomizerV2.sol
+++ b/contracts/BasicRandomizerV2.sol
@@ -18,17 +18,19 @@ contract BasicRandomizerV2 is IRandomizerV2, Ownable {
     }
 
     // When `genArt721Core` calls this, it can be assured that the randomizer
-    // will set a bytes32 hash for tokenId `_tokenId` on the core contract.
+    // will set a bytes16 hash for tokenId `_tokenId` on the core contract.
     function assignTokenHash(uint256 _tokenId) external virtual {
         require(msg.sender == address(genArt721Core), "Only core may call");
         uint256 time = block.timestamp;
-        bytes32 hash = keccak256(
-            abi.encodePacked(
-                _tokenId,
-                block.number,
-                blockhash(block.number - 1),
-                time,
-                (time % 200) + 1
+        bytes16 hash = bytes16(
+            keccak256(
+                abi.encodePacked(
+                    _tokenId,
+                    block.number,
+                    blockhash(block.number - 1),
+                    time,
+                    (time % 200) + 1
+                )
             )
         );
         genArt721Core.setTokenHash_8PT(_tokenId, hash);

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -128,7 +128,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
     /// Basis Points of secondary sales royalties allocated to Art Blocks
     uint256 public artblocksSecondarySalesBPS = 250;
 
-    mapping(uint256 => bytes32) public tokenIdToHash;
+    mapping(uint256 => bytes16) public tokenIdToHash;
 
     /// single minter allowed for this core contract
     address public minterContract;
@@ -308,7 +308,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
      * @param _hash Hash to set for the token ID.
      * @dev gas-optimized function name because called during mint sequence
      */
-    function setTokenHash_8PT(uint256 _tokenId, bytes32 _hash)
+    function setTokenHash_8PT(uint256 _tokenId, bytes16 _hash)
         external
         onlyValidTokenId(_tokenId)
     {
@@ -317,7 +317,7 @@ contract GenArt721CoreV3 is ERC721, Ownable, IGenArt721CoreContractV3 {
             "Only randomizer may set"
         );
         require(
-            tokenIdToHash[_tokenId] == bytes32(0),
+            tokenIdToHash[_tokenId] == bytes16(0),
             "Token hash already set."
         );
         tokenIdToHash[_tokenId] = _hash;

--- a/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
+++ b/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
@@ -152,7 +152,7 @@ interface IGenArt721CoreContractV3 is IManifold {
     function artblocksSecondarySalesBPS() external view returns (uint256);
 
     // function to set a token's hash (must be guarded)
-    function setTokenHash_8PT(uint256 _tokenId, bytes32 _hash) external;
+    function setTokenHash_8PT(uint256 _tokenId, bytes16 _hash) external;
 
     // @dev gas-optimized signature in V3 for `mint`
     function mint_Ecf(

--- a/contracts/mock/RandomizerV2_NoAssignMock.sol
+++ b/contracts/mock/RandomizerV2_NoAssignMock.sol
@@ -23,13 +23,15 @@ contract RandomizerV2_NoAssignMock is BasicRandomizerV2 {
     // @dev WARNING - THIS IS NOT SECURE AND SHOULD NOT BE USED IN PRODUCTION.
     function actuallyAssignTokenHash(uint256 _tokenId) external {
         uint256 time = block.timestamp;
-        bytes32 hash = keccak256(
-            abi.encodePacked(
-                _tokenId,
-                block.number,
-                blockhash(block.number - 1),
-                time,
-                (time % 200) + 1
+        bytes16 hash = bytes16(
+            keccak256(
+                abi.encodePacked(
+                    _tokenId,
+                    block.number,
+                    blockhash(block.number - 1),
+                    time,
+                    (time % 200) + 1
+                )
             )
         );
         genArt721Core.setTokenHash_8PT(_tokenId, hash);


### PR DESCRIPTION
(for posterity only) Update V3 core to use bytes16 hash instead of bytes32 hash.

## Result
the EVM likes working in 32-byte chunks. I could only get this to add gas instead of reduce it. Not recommended unless someone can work more magic than my somewhat haste attempts (maybe some assembly would work here?). Overall, does not seem worth our effort.

Before: Fixed price minter cost: 137855 gas
After: Fixed price minter cost: 138353 gas

Cc @jakerockland , immediately closing this PR.