### PR TITLE
Pack hash seed with owner

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -307,11 +307,11 @@ contract GenArt721CoreV3 is
      * May only be called for tokens that have not already been assigned a
      * non-zero hash.
      * @param _tokenId Token ID to set the hash for.
-     * @param _hash Hash seed set for the token ID. Only last 12 bytes will be
-     * used.
+     * @param _hashSeed Hash seed to set for the token ID. Only last 12 bytes
+     * will be used.
      * @dev gas-optimized function name because called during mint sequence
      */
-    function setTokenHash_8PT(uint256 _tokenId, bytes32 _hash)
+    function setTokenHash_8PT(uint256 _tokenId, bytes32 _hashSeed)
         external
         onlyValidTokenId(_tokenId)
     {
@@ -326,7 +326,7 @@ contract GenArt721CoreV3 is
             ownerAndHashSeed.hashSeed == bytes12(0),
             "Token hash already set"
         );
-        ownerAndHashSeed.hashSeed = bytes12(_hash);
+        ownerAndHashSeed.hashSeed = bytes12(_hashSeed);
     }
 
     /**

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -881,11 +881,16 @@ contract GenArt721CoreV3 is
     }
 
     /**
-     * @notice Returns token hash for token ID `_tokenId`.
+     * @notice Returns token hash for token ID `_tokenId`. Returns null if hash
+     * has not been set.
      * @dev token hash is the keccak256 hash of the stored hash seed
      */
     function tokenIdToHash(uint256 _tokenId) external view returns (bytes32) {
-        return keccak256(abi.encode(_ownersAndHashSeeds[_tokenId].hashSeed));
+        bytes12 _hashSeed = _ownersAndHashSeeds[_tokenId].hashSeed;
+        if (_hashSeed == 0) {
+            return 0;
+        }
+        return keccak256(abi.encode(_hashSeed));
     }
 
     /**

--- a/contracts/libs/0.8.x/ERC721_PackedHashSeed.sol
+++ b/contracts/libs/0.8.x/ERC721_PackedHashSeed.sol
@@ -1,0 +1,541 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v4.7.0) (token/ERC721/ERC721.sol)
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin-4.7/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin-4.7/contracts/token/ERC721/IERC721.sol";
+import "@openzeppelin-4.7/contracts/token/ERC721/IERC721Receiver.sol";
+import "@openzeppelin-4.7/contracts/token/ERC721/extensions/IERC721Metadata.sol";
+import "@openzeppelin-4.7/contracts/utils/Address.sol";
+import "@openzeppelin-4.7/contracts/utils/Context.sol";
+import "@openzeppelin-4.7/contracts/utils/Strings.sol";
+import "@openzeppelin-4.7/contracts/utils/introspection/ERC165.sol";
+
+/**
+ * @dev Forked version of the OpenZeppelin v4.7.1 ERC721 contract. Utilizes a
+ * struct to pack owner and hash seed into a single storage slot.
+ * ---------------------
+ * @dev Implementation of https://eips.ethereum.org/EIPS/eip-721[ERC721] Non-Fungible Token Standard, including
+ * the Metadata extension, but not including the Enumerable extension, which is available separately as
+ * {ERC721Enumerable}.
+ */
+contract ERC721_PackedHashSeed is Context, ERC165, IERC721, IERC721Metadata {
+    using Address for address;
+    using Strings for uint256;
+
+    // Token name
+    string private _name;
+
+    // Token symbol
+    string private _symbol;
+
+    /// struct to pack a token owner and hash seed into same storage slot
+    struct OwnerAndHashSeed {
+        // 20 bytes for address of token's owner
+        address owner;
+        // remaining 12 bytes allocated to token hash seed
+        bytes12 hashSeed;
+    }
+
+    /// mapping of token ID to OwnerAndHashSeed
+    /// @dev visibility internal so inheriting contracts can access
+    mapping(uint256 => OwnerAndHashSeed) internal _ownersAndHashSeeds;
+
+    // Mapping owner address to token count
+    mapping(address => uint256) private _balances;
+
+    // Mapping from token ID to approved address
+    mapping(uint256 => address) private _tokenApprovals;
+
+    // Mapping from owner to operator approvals
+    mapping(address => mapping(address => bool)) private _operatorApprovals;
+
+    /**
+     * @dev Initializes the contract by setting a `name` and a `symbol` to the token collection.
+     */
+    constructor(string memory name_, string memory symbol_) {
+        _name = name_;
+        _symbol = symbol_;
+    }
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC165, IERC165)
+        returns (bool)
+    {
+        return
+            interfaceId == type(IERC721).interfaceId ||
+            interfaceId == type(IERC721Metadata).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+
+    /**
+     * @dev See {IERC721-balanceOf}.
+     */
+    function balanceOf(address owner)
+        public
+        view
+        virtual
+        override
+        returns (uint256)
+    {
+        require(
+            owner != address(0),
+            "ERC721: address zero is not a valid owner"
+        );
+        return _balances[owner];
+    }
+
+    /**
+     * @dev See {IERC721-ownerOf}.
+     */
+    function ownerOf(uint256 tokenId)
+        public
+        view
+        virtual
+        override
+        returns (address)
+    {
+        address owner = _ownersAndHashSeeds[tokenId].owner;
+        require(owner != address(0), "ERC721: invalid token ID");
+        return owner;
+    }
+
+    /**
+     * @dev See {IERC721Metadata-name}.
+     */
+    function name() public view virtual override returns (string memory) {
+        return _name;
+    }
+
+    /**
+     * @dev See {IERC721Metadata-symbol}.
+     */
+    function symbol() public view virtual override returns (string memory) {
+        return _symbol;
+    }
+
+    /**
+     * @dev See {IERC721Metadata-tokenURI}.
+     */
+    function tokenURI(uint256 tokenId)
+        public
+        view
+        virtual
+        override
+        returns (string memory)
+    {
+        _requireMinted(tokenId);
+
+        string memory baseURI = _baseURI();
+        return
+            bytes(baseURI).length > 0
+                ? string(abi.encodePacked(baseURI, tokenId.toString()))
+                : "";
+    }
+
+    /**
+     * @dev Base URI for computing {tokenURI}. If set, the resulting URI for each
+     * token will be the concatenation of the `baseURI` and the `tokenId`. Empty
+     * by default, can be overridden in child contracts.
+     */
+    function _baseURI() internal view virtual returns (string memory) {
+        return "";
+    }
+
+    /**
+     * @dev See {IERC721-approve}.
+     */
+    function approve(address to, uint256 tokenId) public virtual override {
+        address owner = ERC721_PackedHashSeed.ownerOf(tokenId);
+        require(to != owner, "ERC721: approval to current owner");
+
+        require(
+            _msgSender() == owner || isApprovedForAll(owner, _msgSender()),
+            "ERC721: approve caller is not token owner nor approved for all"
+        );
+
+        _approve(to, tokenId);
+    }
+
+    /**
+     * @dev See {IERC721-getApproved}.
+     */
+    function getApproved(uint256 tokenId)
+        public
+        view
+        virtual
+        override
+        returns (address)
+    {
+        _requireMinted(tokenId);
+
+        return _tokenApprovals[tokenId];
+    }
+
+    /**
+     * @dev See {IERC721-setApprovalForAll}.
+     */
+    function setApprovalForAll(address operator, bool approved)
+        public
+        virtual
+        override
+    {
+        _setApprovalForAll(_msgSender(), operator, approved);
+    }
+
+    /**
+     * @dev See {IERC721-isApprovedForAll}.
+     */
+    function isApprovedForAll(address owner, address operator)
+        public
+        view
+        virtual
+        override
+        returns (bool)
+    {
+        return _operatorApprovals[owner][operator];
+    }
+
+    /**
+     * @dev See {IERC721-transferFrom}.
+     */
+    function transferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    ) public virtual override {
+        //solhint-disable-next-line max-line-length
+        require(
+            _isApprovedOrOwner(_msgSender(), tokenId),
+            "ERC721: caller is not token owner nor approved"
+        );
+
+        _transfer(from, to, tokenId);
+    }
+
+    /**
+     * @dev See {IERC721-safeTransferFrom}.
+     */
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    ) public virtual override {
+        safeTransferFrom(from, to, tokenId, "");
+    }
+
+    /**
+     * @dev See {IERC721-safeTransferFrom}.
+     */
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId,
+        bytes memory data
+    ) public virtual override {
+        require(
+            _isApprovedOrOwner(_msgSender(), tokenId),
+            "ERC721: caller is not token owner nor approved"
+        );
+        _safeTransfer(from, to, tokenId, data);
+    }
+
+    /**
+     * @dev Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients
+     * are aware of the ERC721 protocol to prevent tokens from being forever locked.
+     *
+     * `data` is additional data, it has no specified format and it is sent in call to `to`.
+     *
+     * This internal function is equivalent to {safeTransferFrom}, and can be used to e.g.
+     * implement alternative mechanisms to perform token transfer, such as signature-based.
+     *
+     * Requirements:
+     *
+     * - `from` cannot be the zero address.
+     * - `to` cannot be the zero address.
+     * - `tokenId` token must exist and be owned by `from`.
+     * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
+     *
+     * Emits a {Transfer} event.
+     */
+    function _safeTransfer(
+        address from,
+        address to,
+        uint256 tokenId,
+        bytes memory data
+    ) internal virtual {
+        _transfer(from, to, tokenId);
+        require(
+            _checkOnERC721Received(from, to, tokenId, data),
+            "ERC721: transfer to non ERC721Receiver implementer"
+        );
+    }
+
+    /**
+     * @dev Returns whether `tokenId` exists.
+     *
+     * Tokens can be managed by their owner or approved accounts via {approve} or {setApprovalForAll}.
+     *
+     * Tokens start existing when they are minted (`_mint`),
+     * and stop existing when they are burned (`_burn`).
+     */
+    function _exists(uint256 tokenId) internal view virtual returns (bool) {
+        return _ownersAndHashSeeds[tokenId].owner != address(0);
+    }
+
+    /**
+     * @dev Returns whether `spender` is allowed to manage `tokenId`.
+     *
+     * Requirements:
+     *
+     * - `tokenId` must exist.
+     */
+    function _isApprovedOrOwner(address spender, uint256 tokenId)
+        internal
+        view
+        virtual
+        returns (bool)
+    {
+        address owner = ERC721_PackedHashSeed.ownerOf(tokenId);
+        return (spender == owner ||
+            isApprovedForAll(owner, spender) ||
+            getApproved(tokenId) == spender);
+    }
+
+    /**
+     * @dev Safely mints `tokenId` and transfers it to `to`.
+     *
+     * Requirements:
+     *
+     * - `tokenId` must not exist.
+     * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
+     *
+     * Emits a {Transfer} event.
+     */
+    function _safeMint(address to, uint256 tokenId) internal virtual {
+        _safeMint(to, tokenId, "");
+    }
+
+    /**
+     * @dev Same as {xref-ERC721-_safeMint-address-uint256-}[`_safeMint`], with an additional `data` parameter which is
+     * forwarded in {IERC721Receiver-onERC721Received} to contract recipients.
+     */
+    function _safeMint(
+        address to,
+        uint256 tokenId,
+        bytes memory data
+    ) internal virtual {
+        _mint(to, tokenId);
+        require(
+            _checkOnERC721Received(address(0), to, tokenId, data),
+            "ERC721: transfer to non ERC721Receiver implementer"
+        );
+    }
+
+    /**
+     * @dev Mints `tokenId` and transfers it to `to`.
+     *
+     * WARNING: Usage of this method is discouraged, use {_safeMint} whenever possible
+     *
+     * Requirements:
+     *
+     * - `tokenId` must not exist.
+     * - `to` cannot be the zero address.
+     *
+     * Emits a {Transfer} event.
+     */
+    function _mint(address to, uint256 tokenId) internal virtual {
+        require(to != address(0), "ERC721: mint to the zero address");
+        require(!_exists(tokenId), "ERC721: token already minted");
+
+        _beforeTokenTransfer(address(0), to, tokenId);
+
+        _balances[to] += 1;
+        _ownersAndHashSeeds[tokenId].owner = to;
+
+        emit Transfer(address(0), to, tokenId);
+
+        _afterTokenTransfer(address(0), to, tokenId);
+    }
+
+    /**
+     * @dev Destroys `tokenId`.
+     * The approval is cleared when the token is burned.
+     *
+     * Requirements:
+     *
+     * - `tokenId` must exist.
+     *
+     * Emits a {Transfer} event.
+     */
+    function _burn(uint256 tokenId) internal virtual {
+        address owner = ERC721_PackedHashSeed.ownerOf(tokenId);
+
+        _beforeTokenTransfer(owner, address(0), tokenId);
+
+        // Clear approvals
+        _approve(address(0), tokenId);
+
+        _balances[owner] -= 1;
+        delete _ownersAndHashSeeds[tokenId].owner;
+
+        emit Transfer(owner, address(0), tokenId);
+
+        _afterTokenTransfer(owner, address(0), tokenId);
+    }
+
+    /**
+     * @dev Transfers `tokenId` from `from` to `to`.
+     *  As opposed to {transferFrom}, this imposes no restrictions on msg.sender.
+     *
+     * Requirements:
+     *
+     * - `to` cannot be the zero address.
+     * - `tokenId` token must be owned by `from`.
+     *
+     * Emits a {Transfer} event.
+     */
+    function _transfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal virtual {
+        require(
+            ERC721_PackedHashSeed.ownerOf(tokenId) == from,
+            "ERC721: transfer from incorrect owner"
+        );
+        require(to != address(0), "ERC721: transfer to the zero address");
+
+        _beforeTokenTransfer(from, to, tokenId);
+
+        // Clear approvals from the previous owner
+        _approve(address(0), tokenId);
+
+        _balances[from] -= 1;
+        _balances[to] += 1;
+        _ownersAndHashSeeds[tokenId].owner = to;
+
+        emit Transfer(from, to, tokenId);
+
+        _afterTokenTransfer(from, to, tokenId);
+    }
+
+    /**
+     * @dev Approve `to` to operate on `tokenId`
+     *
+     * Emits an {Approval} event.
+     */
+    function _approve(address to, uint256 tokenId) internal virtual {
+        _tokenApprovals[tokenId] = to;
+        emit Approval(ERC721_PackedHashSeed.ownerOf(tokenId), to, tokenId);
+    }
+
+    /**
+     * @dev Approve `operator` to operate on all of `owner` tokens
+     *
+     * Emits an {ApprovalForAll} event.
+     */
+    function _setApprovalForAll(
+        address owner,
+        address operator,
+        bool approved
+    ) internal virtual {
+        require(owner != operator, "ERC721: approve to caller");
+        _operatorApprovals[owner][operator] = approved;
+        emit ApprovalForAll(owner, operator, approved);
+    }
+
+    /**
+     * @dev Reverts if the `tokenId` has not been minted yet.
+     */
+    function _requireMinted(uint256 tokenId) internal view virtual {
+        require(_exists(tokenId), "ERC721: invalid token ID");
+    }
+
+    /**
+     * @dev Internal function to invoke {IERC721Receiver-onERC721Received} on a target address.
+     * The call is not executed if the target address is not a contract.
+     *
+     * @param from address representing the previous owner of the given token ID
+     * @param to target address that will receive the tokens
+     * @param tokenId uint256 ID of the token to be transferred
+     * @param data bytes optional data to send along with the call
+     * @return bool whether the call correctly returned the expected magic value
+     */
+    function _checkOnERC721Received(
+        address from,
+        address to,
+        uint256 tokenId,
+        bytes memory data
+    ) private returns (bool) {
+        if (to.isContract()) {
+            try
+                IERC721Receiver(to).onERC721Received(
+                    _msgSender(),
+                    from,
+                    tokenId,
+                    data
+                )
+            returns (bytes4 retval) {
+                return retval == IERC721Receiver.onERC721Received.selector;
+            } catch (bytes memory reason) {
+                if (reason.length == 0) {
+                    revert(
+                        "ERC721: transfer to non ERC721Receiver implementer"
+                    );
+                } else {
+                    /// @solidity memory-safe-assembly
+                    assembly {
+                        revert(add(32, reason), mload(reason))
+                    }
+                }
+            }
+        } else {
+            return true;
+        }
+    }
+
+    /**
+     * @dev Hook that is called before any token transfer. This includes minting
+     * and burning.
+     *
+     * Calling conditions:
+     *
+     * - When `from` and `to` are both non-zero, ``from``'s `tokenId` will be
+     * transferred to `to`.
+     * - When `from` is zero, `tokenId` will be minted for `to`.
+     * - When `to` is zero, ``from``'s `tokenId` will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal virtual {}
+
+    /**
+     * @dev Hook that is called after any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    function _afterTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal virtual {}
+}

--- a/contracts/libs/0.8.x/ERC721_PackedHashSeed.sol
+++ b/contracts/libs/0.8.x/ERC721_PackedHashSeed.sol
@@ -3,7 +3,6 @@
 
 pragma solidity ^0.8.0;
 
-import "@openzeppelin-4.7/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin-4.7/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin-4.7/contracts/token/ERC721/IERC721Receiver.sol";
 import "@openzeppelin-4.7/contracts/token/ERC721/extensions/IERC721Metadata.sol";

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
@@ -149,7 +149,7 @@ describe("MinterDAExpV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0164719")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.014297")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
@@ -149,7 +149,7 @@ describe("MinterDALinV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0164795")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0143046")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/MinterHolder/MinterHolderV1.test.ts
+++ b/test/minter-suite-minters/MinterHolder/MinterHolderV1.test.ts
@@ -236,7 +236,7 @@ describe("MinterHolderV1", async function () {
         ethers.utils.formatUnits(txCost.toString(), "ether").toString(),
         "ETH"
       );
-      expect(compareBN(txCost, ethers.utils.parseEther("0.0142657"), 1)).to.be
+      expect(compareBN(txCost, ethers.utils.parseEther("0.01204"), 1)).to.be
         .true;
     });
   });

--- a/test/minter-suite-minters/MinterMerkle/MinterMerkleV1.test.ts
+++ b/test/minter-suite-minters/MinterMerkle/MinterMerkleV1.test.ts
@@ -244,7 +244,7 @@ describe("MinterMerkleV1", async function () {
         ethers.utils.formatUnits(txCost.toString(), "ether").toString(),
         "ETH"
       );
-      expect(compareBN(txCost, ethers.utils.parseEther("0.0181539"), 1)).to.be
+      expect(compareBN(txCost, ethers.utils.parseEther("0.0159238"), 1)).to.be
         .true;
     });
 
@@ -286,7 +286,7 @@ describe("MinterMerkleV1", async function () {
         "ETH"
       );
       // the following is not much more than the gas cost with a very small allowlist
-      expect(compareBN(txCost, ethers.utils.parseEther("0.0189799"), 1)).to.be
+      expect(compareBN(txCost, ethers.utils.parseEther("0.0167494"), 1)).to.be
         .true;
     });
   });

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
@@ -177,7 +177,7 @@ describe("MinterSetPriceV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0155209")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.013346")); // assuming a cost of 100 GWEI
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
@@ -206,7 +206,7 @@ describe("MinterSetPriceERC20V2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0155424"));
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0133675"));
     });
   });
 

--- a/test/randomizer/basicRandomizerV2/basicRandomizerV2.test.ts
+++ b/test/randomizer/basicRandomizerV2/basicRandomizerV2.test.ts
@@ -136,6 +136,26 @@ describe("BasicRandomizerV2 w/V3 core", async function () {
         )
       ).to.not.be.equal(ethers.constants.HashZero);
     });
+
+    it("multiple tokens minted have different hashes", async function () {
+      // expect 2 successful mints
+      await this.minter
+        .connect(this.accounts.artist)
+        .purchase(this.projectZero);
+      await this.minter
+        .connect(this.accounts.artist)
+        .purchase(this.projectZero);
+      // expect token hash to be assigned
+      const projectZeroTokenZeroHash = await this.genArt721Core.tokenIdToHash(
+        this.projectZeroTokenZero.toNumber()
+      );
+      const projectZeroTokenOneHash = await this.genArt721Core.tokenIdToHash(
+        this.projectZeroTokenOne.toNumber()
+      );
+      expect(projectZeroTokenZeroHash).to.not.be.equal(projectZeroTokenOneHash);
+      console.info(`projectZeroTokenZeroHash: ${projectZeroTokenZeroHash}`);
+      console.info(`projectZeroTokenOneHash: ${projectZeroTokenOneHash}`);
+    });
   });
 
   describe("owner", function () {


### PR DESCRIPTION
Pack hash seed with token owner to eliminate storage slot accessed during mint transaction (assuming atomic randomizer callback).

Based on brainstorming session w/ @jakerockland, this uses a packed struct to store token owner and a bytes12 hashSeed into the same storage slot. The net result is an entire storage slot is not longer accessed or written to during the mint flow, resulting in gas cost reduction for users.

Note that a bytes12 hashSeed provides sufficient theoretical entropy for our token generation; the chance of a hash seed collision of any two tokens in a 1-million token project (maximum possible for the V3 core contract) is less than 1 in 100 million.

This specific implementation forks OpenZeppelin's ERC721 v4.7.1 contract to provide an internally-accessible packed struct. See further discussion in the following section for alternate designs considered to achieve the same end result of packing token hash and token owner into the same storage slot.

## Design Considerations
Using a struct to pack owner address and bytes12 hash seed is a safe way to write/read/parse the two values in storage. Assembly could also be used to access this storage slot and read/write hash seed directly, but our team currently isn't completely sure if some unintended effects could be encountered unless we also managed reading/writing owner via assembly. The simpler implementation for now is to simply fork OpenZeppelin's ERC721 and utilize struct packing.

Inheriting from ERC721 directly, defining a mapping to a packed struct in the V3 core contract, and overriding methods that interact with ERC721's `_owners` method would be another strategy of achieving the gas reductions in this PR. Unfortunately, ERC721's `_mint` function also increments the ERC721 `private _balances` variable, and `private` variables are not accessible from inheriting contracts. This means that a variable representing balances would also have to be defined on the V3 core, and all functions on ERC721 that interact with `_balances` would also have to be overridden and defined on the V3 core contract. All things considered, it was simpler to just fork the ERC721 contract and design `ERC721_PackedHashSeed` directly.

## Gas impacts
Mint costs are reduced, as shown in the table below.

_(All gas costs assume project 3 mints avg(501-516) of 1000)_
| Gas Test | Previous gas used to purchase | New gas used to purchase | % change |
| --- | --- | --- | --- |
| MinterSetPriceV2_V3Core | 137855 | 116106 | -15.8% |
| MinterSetPriceERC20V2_V3Core | 138014 | 116265 | -15.8% (cheaper) |
| MinterDAExpV2_V3Core | 147255 | 125506 | -14.8% (cheaper) |
| MinterDALinV2_V3Core | 147353 | 125604 | -14.8% (cheaper) |
| MinterMerkleV1_V3Core | 153003 | 131254 | -14.2% (cheaper) |
| MinterHolderV1_V3Core | 144497 | 122748 | -15.1% (cheaper) |

## Audit
This is required to be included in third party audits of the V3 contract.