### PR TITLE
Pack financial data on V3 core

### DIFF
--- a/test/core/V3/GenArt721CoreV3_Views.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Views.test.ts
@@ -1,3 +1,4 @@
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import {
   BN,
   constants,
@@ -15,6 +16,40 @@ import {
   deployAndGet,
   deployCoreWithMinterFilter,
 } from "../../util/common";
+
+export type ArtistFinanceProposal = {
+  artistAddress: string;
+  additionalPayeePrimarySalesAddress: string;
+  additionalPayeePrimarySalesPercentage: number;
+  additionalPayeeSecondarySalesAddress: string;
+  additionalPayeeSecondarySalesPercentage: number;
+};
+
+// helper function to update artist financial data
+async function updateArtistFinance(
+  projectId: number,
+  currentArtistAccount: SignerWithAddress,
+  proposal: ArtistFinanceProposal
+): Promise<void> {
+  const proposeArtistPaymentAddressesAndSplitsArgs = [
+    projectId,
+    proposal.artistAddress,
+    proposal.additionalPayeePrimarySalesAddress,
+    proposal.additionalPayeePrimarySalesPercentage,
+    proposal.additionalPayeeSecondarySalesAddress,
+    proposal.additionalPayeeSecondarySalesPercentage,
+  ];
+  await this.genArt721Core
+    .connect(currentArtistAccount)
+    .proposeArtistPaymentAddressesAndSplits(
+      ...proposeArtistPaymentAddressesAndSplitsArgs
+    );
+  await this.genArt721Core
+    .connect(this.accounts.deployer)
+    .adminAcceptArtistAddressesAndSplits(
+      ...proposeArtistPaymentAddressesAndSplitsArgs
+    );
+}
 
 /**
  * Tests regarding view functions for V3 core.
@@ -394,25 +429,18 @@ describe("GenArt721CoreV3 Views", async function () {
       await this.genArt721Core
         .connect(this.accounts.deployer)
         .addProject("name", this.accounts.artist2.address);
-      // artist2 populates an addditional payee
-      const proposeArtistPaymentAddressesAndSplitsArgs = [
+      await updateArtistFinance.call(
+        this,
         this.projectOne,
-        this.accounts.artist2.address,
-        this.accounts.additional2.address,
-        51,
-        this.accounts.user2.address,
-        0,
-      ];
-      await this.genArt721Core
-        .connect(this.accounts.artist2)
-        .proposeArtistPaymentAddressesAndSplits(
-          ...proposeArtistPaymentAddressesAndSplitsArgs
-        );
-      await this.genArt721Core
-        .connect(this.accounts.deployer)
-        .adminAcceptArtistAddressesAndSplits(
-          ...proposeArtistPaymentAddressesAndSplitsArgs
-        );
+        this.accounts.artist2,
+        {
+          artistAddress: this.accounts.artist2.address,
+          additionalPayeePrimarySalesAddress: this.accounts.additional2.address,
+          additionalPayeePrimarySalesPercentage: 51,
+          additionalPayeeSecondarySalesAddress: this.accounts.user2.address,
+          additionalPayeeSecondarySalesPercentage: 52,
+        }
+      );
       // update Art Blocks percentage to 20%
       await this.genArt721Core
         .connect(this.accounts.deployer)
@@ -435,14 +463,14 @@ describe("GenArt721CoreV3 Views", async function () {
       );
       // Additional Payee (0.8 * 0.51 = 0.408)
       expect(revenueSplits.additionalPayeePrimaryAddress_).to.be.equal(
-        proposeArtistPaymentAddressesAndSplitsArgs[2]
+        this.accounts.additional2.address
       );
       expect(revenueSplits.additionalPayeePrimaryRevenue_).to.be.equal(
         ethers.utils.parseEther("0.408")
       );
       // Artist (0.8 * 0.51 = 0.392)
       expect(revenueSplits.artistAddress_).to.be.equal(
-        proposeArtistPaymentAddressesAndSplitsArgs[1]
+        this.accounts.artist2.address
       );
       expect(revenueSplits.artistRevenue_).to.be.equal(
         ethers.utils.parseEther("0.392")
@@ -455,24 +483,18 @@ describe("GenArt721CoreV3 Views", async function () {
         .connect(this.accounts.deployer)
         .addProject("name", this.accounts.artist2.address);
       // artist2 populates an addditional payee
-      const proposeArtistPaymentAddressesAndSplitsArgs = [
+      await updateArtistFinance.call(
+        this,
         this.projectOne,
-        this.accounts.artist2.address,
-        this.accounts.additional2.address,
-        100,
-        this.accounts.user2.address,
-        0,
-      ];
-      await this.genArt721Core
-        .connect(this.accounts.artist2)
-        .proposeArtistPaymentAddressesAndSplits(
-          ...proposeArtistPaymentAddressesAndSplitsArgs
-        );
-      await this.genArt721Core
-        .connect(this.accounts.deployer)
-        .adminAcceptArtistAddressesAndSplits(
-          ...proposeArtistPaymentAddressesAndSplitsArgs
-        );
+        this.accounts.artist2,
+        {
+          artistAddress: this.accounts.artist2.address,
+          additionalPayeePrimarySalesAddress: this.accounts.additional2.address,
+          additionalPayeePrimarySalesPercentage: 100,
+          additionalPayeeSecondarySalesAddress: this.accounts.user2.address,
+          additionalPayeeSecondarySalesPercentage: 0,
+        }
+      );
       // update Art Blocks primary sales percentage to 20%
       await this.genArt721Core
         .connect(this.accounts.deployer)
@@ -495,7 +517,7 @@ describe("GenArt721CoreV3 Views", async function () {
       );
       // Additional Payee (0.8 * 1.00 = 0.0.8)
       expect(revenueSplits.additionalPayeePrimaryAddress_).to.be.equal(
-        proposeArtistPaymentAddressesAndSplitsArgs[2]
+        this.accounts.additional2.address
       );
       expect(revenueSplits.additionalPayeePrimaryRevenue_).to.be.equal(
         ethers.utils.parseEther("0.8")
@@ -563,24 +585,19 @@ describe("GenArt721CoreV3 Views", async function () {
         .connect(this.accounts.artist2)
         .updateProjectSecondaryMarketRoyaltyPercentage(this.projectOne, 10);
       // artist2 populates an addditional payee
-      const proposeArtistPaymentAddressesAndSplitsArgs = [
+      await updateArtistFinance.call(
+        this,
         this.projectOne,
-        this.accounts.artist2.address,
-        constants.ZERO_ADDRESS,
-        0,
-        this.accounts.additional2.address, // additional secondary address
-        51, // additonal secondary percentage
-      ];
-      await this.genArt721Core
-        .connect(this.accounts.artist2)
-        .proposeArtistPaymentAddressesAndSplits(
-          ...proposeArtistPaymentAddressesAndSplitsArgs
-        );
-      await this.genArt721Core
-        .connect(this.accounts.deployer)
-        .adminAcceptArtistAddressesAndSplits(
-          ...proposeArtistPaymentAddressesAndSplitsArgs
-        );
+        this.accounts.artist2,
+        {
+          artistAddress: this.accounts.artist2.address,
+          additionalPayeePrimarySalesAddress: constants.ZERO_ADDRESS,
+          additionalPayeePrimarySalesPercentage: 0,
+          additionalPayeeSecondarySalesAddress:
+            this.accounts.additional2.address,
+          additionalPayeeSecondarySalesPercentage: 51,
+        }
+      );
       // update Art Blocks secondary BPS to 2.4%
       await this.genArt721Core
         .connect(this.accounts.deployer)
@@ -724,24 +741,19 @@ describe("GenArt721CoreV3 Views", async function () {
         .connect(this.accounts.artist2)
         .updateProjectSecondaryMarketRoyaltyPercentage(this.projectOne, 10);
       // artist2 populates an addditional payee
-      const proposeArtistPaymentAddressesAndSplitsArgs = [
+      await updateArtistFinance.call(
+        this,
         this.projectOne,
-        this.accounts.artist2.address,
-        constants.ZERO_ADDRESS,
-        0,
-        this.accounts.additional2.address, // additional secondary address
-        0, // additonal secondary percentage
-      ];
-      await this.genArt721Core
-        .connect(this.accounts.artist2)
-        .proposeArtistPaymentAddressesAndSplits(
-          ...proposeArtistPaymentAddressesAndSplitsArgs
-        );
-      await this.genArt721Core
-        .connect(this.accounts.deployer)
-        .adminAcceptArtistAddressesAndSplits(
-          ...proposeArtistPaymentAddressesAndSplitsArgs
-        );
+        this.accounts.artist2,
+        {
+          artistAddress: this.accounts.artist2.address,
+          additionalPayeePrimarySalesAddress: constants.ZERO_ADDRESS,
+          additionalPayeePrimarySalesPercentage: 0,
+          additionalPayeeSecondarySalesAddress:
+            this.accounts.additional2.address,
+          additionalPayeeSecondarySalesPercentage: 0,
+        }
+      );
       // update Art Blocks secondary BPS to 2.4%
       await this.genArt721Core
         .connect(this.accounts.deployer)
@@ -800,24 +812,19 @@ describe("GenArt721CoreV3 Views", async function () {
         .connect(this.accounts.artist2)
         .updateProjectSecondaryMarketRoyaltyPercentage(this.projectOne, 10);
       // artist2 populates an addditional payee
-      const proposeArtistPaymentAddressesAndSplitsArgs = [
+      await updateArtistFinance.call(
+        this,
         this.projectOne,
-        this.accounts.artist2.address,
-        constants.ZERO_ADDRESS,
-        0,
-        this.accounts.additional2.address, // additional secondary address
-        51, // additonal secondary percentage
-      ];
-      await this.genArt721Core
-        .connect(this.accounts.artist2)
-        .proposeArtistPaymentAddressesAndSplits(
-          ...proposeArtistPaymentAddressesAndSplitsArgs
-        );
-      await this.genArt721Core
-        .connect(this.accounts.deployer)
-        .adminAcceptArtistAddressesAndSplits(
-          ...proposeArtistPaymentAddressesAndSplitsArgs
-        );
+        this.accounts.artist2,
+        {
+          artistAddress: this.accounts.artist2.address,
+          additionalPayeePrimarySalesAddress: constants.ZERO_ADDRESS,
+          additionalPayeePrimarySalesPercentage: 0,
+          additionalPayeeSecondarySalesAddress:
+            this.accounts.additional2.address,
+          additionalPayeeSecondarySalesPercentage: 51,
+        }
+      );
       // update Art Blocks secondary BPS to 0%
       await this.genArt721Core
         .connect(this.accounts.deployer)
@@ -880,24 +887,19 @@ describe("GenArt721CoreV3 Views", async function () {
         .connect(this.accounts.artist2)
         .updateProjectSecondaryMarketRoyaltyPercentage(this.projectOne, 0);
       // artist2 populates an addditional payee
-      const proposeArtistPaymentAddressesAndSplitsArgs = [
+      await updateArtistFinance.call(
+        this,
         this.projectOne,
-        this.accounts.artist2.address,
-        constants.ZERO_ADDRESS,
-        0,
-        this.accounts.additional2.address, // additional secondary address
-        51, // additonal secondary percentage
-      ];
-      await this.genArt721Core
-        .connect(this.accounts.artist2)
-        .proposeArtistPaymentAddressesAndSplits(
-          ...proposeArtistPaymentAddressesAndSplitsArgs
-        );
-      await this.genArt721Core
-        .connect(this.accounts.deployer)
-        .adminAcceptArtistAddressesAndSplits(
-          ...proposeArtistPaymentAddressesAndSplitsArgs
-        );
+        this.accounts.artist2,
+        {
+          artistAddress: this.accounts.artist2.address,
+          additionalPayeePrimarySalesAddress: constants.ZERO_ADDRESS,
+          additionalPayeePrimarySalesPercentage: 0,
+          additionalPayeeSecondarySalesAddress:
+            this.accounts.additional2.address,
+          additionalPayeeSecondarySalesPercentage: 51,
+        }
+      );
       // update Art Blocks secondary BPS to 0%
       await this.genArt721Core
         .connect(this.accounts.deployer)
@@ -980,24 +982,19 @@ describe("GenArt721CoreV3 Views", async function () {
         .connect(this.accounts.artist2)
         .updateProjectSecondaryMarketRoyaltyPercentage(this.projectOne, 10);
       // artist2 populates an addditional payee
-      const proposeArtistPaymentAddressesAndSplitsArgs = [
+      await updateArtistFinance.call(
+        this,
         this.projectOne,
-        this.accounts.artist2.address,
-        constants.ZERO_ADDRESS,
-        0,
-        this.accounts.additional2.address, // additional secondary address
-        51, // additonal secondary percentage
-      ];
-      await this.genArt721Core
-        .connect(this.accounts.artist2)
-        .proposeArtistPaymentAddressesAndSplits(
-          ...proposeArtistPaymentAddressesAndSplitsArgs
-        );
-      await this.genArt721Core
-        .connect(this.accounts.deployer)
-        .adminAcceptArtistAddressesAndSplits(
-          ...proposeArtistPaymentAddressesAndSplitsArgs
-        );
+        this.accounts.artist2,
+        {
+          artistAddress: this.accounts.artist2.address,
+          additionalPayeePrimarySalesAddress: constants.ZERO_ADDRESS,
+          additionalPayeePrimarySalesPercentage: 0,
+          additionalPayeeSecondarySalesAddress:
+            this.accounts.additional2.address,
+          additionalPayeeSecondarySalesPercentage: 51,
+        }
+      );
       // update Art Blocks secondary BPS to 2.4%
       await this.genArt721Core
         .connect(this.accounts.deployer)
@@ -1052,24 +1049,19 @@ describe("GenArt721CoreV3 Views", async function () {
         .connect(this.accounts.artist2)
         .updateProjectSecondaryMarketRoyaltyPercentage(this.projectOne, 10);
       // artist2 populates an addditional payee
-      const proposeArtistPaymentAddressesAndSplitsArgs = [
+      await updateArtistFinance.call(
+        this,
         this.projectOne,
-        this.accounts.artist2.address,
-        constants.ZERO_ADDRESS,
-        0,
-        this.accounts.additional2.address, // additional secondary address
-        100, // additonal secondary percentage
-      ];
-      await this.genArt721Core
-        .connect(this.accounts.artist2)
-        .proposeArtistPaymentAddressesAndSplits(
-          ...proposeArtistPaymentAddressesAndSplitsArgs
-        );
-      await this.genArt721Core
-        .connect(this.accounts.deployer)
-        .adminAcceptArtistAddressesAndSplits(
-          ...proposeArtistPaymentAddressesAndSplitsArgs
-        );
+        this.accounts.artist2,
+        {
+          artistAddress: this.accounts.artist2.address,
+          additionalPayeePrimarySalesAddress: constants.ZERO_ADDRESS,
+          additionalPayeePrimarySalesPercentage: 0,
+          additionalPayeeSecondarySalesAddress:
+            this.accounts.additional2.address,
+          additionalPayeeSecondarySalesPercentage: 100,
+        }
+      );
       // update Art Blocks secondary BPS to 2.4%
       await this.genArt721Core
         .connect(this.accounts.deployer)
@@ -1124,24 +1116,19 @@ describe("GenArt721CoreV3 Views", async function () {
         .connect(this.accounts.artist2)
         .updateProjectSecondaryMarketRoyaltyPercentage(this.projectOne, 10);
       // artist2 populates an addditional payee
-      const proposeArtistPaymentAddressesAndSplitsArgs = [
+      await updateArtistFinance.call(
+        this,
         this.projectOne,
-        this.accounts.artist2.address,
-        constants.ZERO_ADDRESS,
-        0,
-        this.accounts.additional2.address, // additional secondary address
-        0, // additonal secondary percentage
-      ];
-      await this.genArt721Core
-        .connect(this.accounts.artist2)
-        .proposeArtistPaymentAddressesAndSplits(
-          ...proposeArtistPaymentAddressesAndSplitsArgs
-        );
-      await this.genArt721Core
-        .connect(this.accounts.deployer)
-        .adminAcceptArtistAddressesAndSplits(
-          ...proposeArtistPaymentAddressesAndSplitsArgs
-        );
+        this.accounts.artist2,
+        {
+          artistAddress: this.accounts.artist2.address,
+          additionalPayeePrimarySalesAddress: constants.ZERO_ADDRESS,
+          additionalPayeePrimarySalesPercentage: 0,
+          additionalPayeeSecondarySalesAddress:
+            this.accounts.additional2.address,
+          additionalPayeeSecondarySalesPercentage: 0,
+        }
+      );
       // update Art Blocks secondary BPS to 2.4%
       await this.genArt721Core
         .connect(this.accounts.deployer)
@@ -1237,25 +1224,19 @@ describe("GenArt721CoreV3 Views", async function () {
         .connect(this.accounts.deployer)
         .addProject("name", this.accounts.artist2.address);
       // artist2 populates an addditional payee
-      const proposeArtistPaymentAddressesAndSplitsArgs = [
+      await updateArtistFinance.call(
+        this,
         this.projectOne,
-        this.accounts.artist2.address,
-        this.accounts.additional.address,
-        49,
-        this.accounts.additional2.address, // additional secondary address
-        51, // additonal secondary percentage
-      ];
-      await this.genArt721Core
-        .connect(this.accounts.artist2)
-        .proposeArtistPaymentAddressesAndSplits(
-          ...proposeArtistPaymentAddressesAndSplitsArgs
-        );
-      await this.genArt721Core
-        .connect(this.accounts.deployer)
-        .adminAcceptArtistAddressesAndSplits(
-          ...proposeArtistPaymentAddressesAndSplitsArgs
-        );
-
+        this.accounts.artist2,
+        {
+          artistAddress: this.accounts.artist2.address,
+          additionalPayeePrimarySalesAddress: this.accounts.additional.address,
+          additionalPayeePrimarySalesPercentage: 49,
+          additionalPayeeSecondarySalesAddress:
+            this.accounts.additional2.address,
+          additionalPayeeSecondarySalesPercentage: 51,
+        }
+      );
       // check for expected values
       const viewData = await this.genArt721Core
         .connect(this.accounts.user)
@@ -1279,25 +1260,19 @@ describe("GenArt721CoreV3 Views", async function () {
         .connect(this.accounts.deployer)
         .addProject("name", this.accounts.artist2.address);
       // artist2 populates an addditional payee
-      const proposeArtistPaymentAddressesAndSplitsArgs = [
+      await updateArtistFinance.call(
+        this,
         this.projectOne,
-        this.accounts.artist2.address,
-        this.accounts.additional.address,
-        49,
-        this.accounts.additional2.address, // additional secondary address
-        51, // additonal secondary percentage
-      ];
-      await this.genArt721Core
-        .connect(this.accounts.artist2)
-        .proposeArtistPaymentAddressesAndSplits(
-          ...proposeArtistPaymentAddressesAndSplitsArgs
-        );
-      await this.genArt721Core
-        .connect(this.accounts.deployer)
-        .adminAcceptArtistAddressesAndSplits(
-          ...proposeArtistPaymentAddressesAndSplitsArgs
-        );
-
+        this.accounts.artist2,
+        {
+          artistAddress: this.accounts.artist2.address,
+          additionalPayeePrimarySalesAddress: this.accounts.additional.address,
+          additionalPayeePrimarySalesPercentage: 49,
+          additionalPayeeSecondarySalesAddress:
+            this.accounts.additional2.address,
+          additionalPayeeSecondarySalesPercentage: 51,
+        }
+      );
       // check for expected values
       const viewData = await this.genArt721Core
         .connect(this.accounts.user)
@@ -1321,25 +1296,19 @@ describe("GenArt721CoreV3 Views", async function () {
         .connect(this.accounts.deployer)
         .addProject("name", this.accounts.artist2.address);
       // artist2 populates an addditional payee
-      const proposeArtistPaymentAddressesAndSplitsArgs = [
+      await updateArtistFinance.call(
+        this,
         this.projectOne,
-        this.accounts.artist2.address,
-        this.accounts.additional.address,
-        49,
-        this.accounts.additional2.address, // additional secondary address
-        51, // additonal secondary percentage
-      ];
-      await this.genArt721Core
-        .connect(this.accounts.artist2)
-        .proposeArtistPaymentAddressesAndSplits(
-          ...proposeArtistPaymentAddressesAndSplitsArgs
-        );
-      await this.genArt721Core
-        .connect(this.accounts.deployer)
-        .adminAcceptArtistAddressesAndSplits(
-          ...proposeArtistPaymentAddressesAndSplitsArgs
-        );
-
+        this.accounts.artist2,
+        {
+          artistAddress: this.accounts.artist2.address,
+          additionalPayeePrimarySalesAddress: this.accounts.additional.address,
+          additionalPayeePrimarySalesPercentage: 49,
+          additionalPayeeSecondarySalesAddress:
+            this.accounts.additional2.address,
+          additionalPayeeSecondarySalesPercentage: 51,
+        }
+      );
       // check for expected values
       const viewData = await this.genArt721Core
         .connect(this.accounts.user)
@@ -1363,25 +1332,19 @@ describe("GenArt721CoreV3 Views", async function () {
         .connect(this.accounts.deployer)
         .addProject("name", this.accounts.artist2.address);
       // artist2 populates an addditional payee
-      const proposeArtistPaymentAddressesAndSplitsArgs = [
+      await updateArtistFinance.call(
+        this,
         this.projectOne,
-        this.accounts.artist2.address,
-        this.accounts.additional.address,
-        49,
-        this.accounts.additional2.address, // additional secondary address
-        51, // additonal secondary percentage
-      ];
-      await this.genArt721Core
-        .connect(this.accounts.artist2)
-        .proposeArtistPaymentAddressesAndSplits(
-          ...proposeArtistPaymentAddressesAndSplitsArgs
-        );
-      await this.genArt721Core
-        .connect(this.accounts.deployer)
-        .adminAcceptArtistAddressesAndSplits(
-          ...proposeArtistPaymentAddressesAndSplitsArgs
-        );
-
+        this.accounts.artist2,
+        {
+          artistAddress: this.accounts.artist2.address,
+          additionalPayeePrimarySalesAddress: this.accounts.additional.address,
+          additionalPayeePrimarySalesPercentage: 49,
+          additionalPayeeSecondarySalesAddress:
+            this.accounts.additional2.address,
+          additionalPayeeSecondarySalesPercentage: 51,
+        }
+      );
       // check for expected values
       const viewData = await this.genArt721Core
         .connect(this.accounts.user)

--- a/test/core/V3/GenArt721CoreV3_Views.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Views.test.ts
@@ -1176,6 +1176,220 @@ describe("GenArt721CoreV3 Views", async function () {
     });
   });
 
+  describe("artblocksPrimarySalesPercentage", function () {
+    it("returns expected default value", async function () {
+      // check for expected values
+      const viewData = await this.genArt721Core
+        .connect(this.accounts.user)
+        .artblocksPrimarySalesPercentage();
+      expect(viewData).to.be.equal(10);
+    });
+
+    it("returns expected configured values for projectZero", async function () {
+      // configure Art Blocks primary sales percentage
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .updateArtblocksPrimarySalesPercentage(11);
+
+      // check for expected values
+      const viewData = await this.genArt721Core
+        .connect(this.accounts.user)
+        .artblocksPrimarySalesPercentage();
+      expect(viewData).to.be.equal(11);
+    });
+  });
+
+  describe("projectIdToSecondaryMarketRoyaltyPercentage", function () {
+    it("returns expected default value", async function () {
+      // check for expected values
+      const viewData = await this.genArt721Core
+        .connect(this.accounts.user)
+        .projectIdToSecondaryMarketRoyaltyPercentage(this.projectZero);
+      expect(viewData).to.be.equal(0);
+    });
+
+    it("returns expected configured values for projectZero", async function () {
+      // configure royalties for projectOne
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .updateProjectSecondaryMarketRoyaltyPercentage(this.projectZero, 10);
+
+      // check for expected values
+      const viewData = await this.genArt721Core
+        .connect(this.accounts.user)
+        .projectIdToSecondaryMarketRoyaltyPercentage(this.projectZero);
+      expect(viewData).to.be.equal(10);
+    });
+  });
+
+  describe("projectIdToAdditionalPayeePrimarySales", function () {
+    it("returns expected default value", async function () {
+      // check for expected values
+      const viewData = await this.genArt721Core
+        .connect(this.accounts.user)
+        .projectIdToAdditionalPayeePrimarySales(this.projectZero);
+      expect(viewData).to.be.equal(constants.ZERO_ADDRESS);
+    });
+
+    it("returns expected configured values for projectOne", async function () {
+      // add project
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .addProject("name", this.accounts.artist2.address);
+      // artist2 populates an addditional payee
+      const proposeArtistPaymentAddressesAndSplitsArgs = [
+        this.projectOne,
+        this.accounts.artist2.address,
+        this.accounts.additional.address,
+        49,
+        this.accounts.additional2.address, // additional secondary address
+        51, // additonal secondary percentage
+      ];
+      await this.genArt721Core
+        .connect(this.accounts.artist2)
+        .proposeArtistPaymentAddressesAndSplits(
+          ...proposeArtistPaymentAddressesAndSplitsArgs
+        );
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .adminAcceptArtistAddressesAndSplits(
+          ...proposeArtistPaymentAddressesAndSplitsArgs
+        );
+
+      // check for expected values
+      const viewData = await this.genArt721Core
+        .connect(this.accounts.user)
+        .projectIdToAdditionalPayeePrimarySales(this.projectOne);
+      expect(viewData).to.be.equal(this.accounts.additional.address);
+    });
+  });
+
+  describe("projectIdToAdditionalPayeePrimarySalesPercentage", function () {
+    it("returns expected default value", async function () {
+      // check for expected values
+      const viewData = await this.genArt721Core
+        .connect(this.accounts.user)
+        .projectIdToAdditionalPayeePrimarySalesPercentage(this.projectZero);
+      expect(viewData).to.be.equal(0);
+    });
+
+    it("returns expected configured values for projectOne", async function () {
+      // add project
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .addProject("name", this.accounts.artist2.address);
+      // artist2 populates an addditional payee
+      const proposeArtistPaymentAddressesAndSplitsArgs = [
+        this.projectOne,
+        this.accounts.artist2.address,
+        this.accounts.additional.address,
+        49,
+        this.accounts.additional2.address, // additional secondary address
+        51, // additonal secondary percentage
+      ];
+      await this.genArt721Core
+        .connect(this.accounts.artist2)
+        .proposeArtistPaymentAddressesAndSplits(
+          ...proposeArtistPaymentAddressesAndSplitsArgs
+        );
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .adminAcceptArtistAddressesAndSplits(
+          ...proposeArtistPaymentAddressesAndSplitsArgs
+        );
+
+      // check for expected values
+      const viewData = await this.genArt721Core
+        .connect(this.accounts.user)
+        .projectIdToAdditionalPayeePrimarySalesPercentage(this.projectOne);
+      expect(viewData).to.be.equal(49);
+    });
+  });
+
+  describe("projectIdToAdditionalPayeeSecondarySales", function () {
+    it("returns expected default value", async function () {
+      // check for expected values
+      const viewData = await this.genArt721Core
+        .connect(this.accounts.user)
+        .projectIdToAdditionalPayeeSecondarySales(this.projectZero);
+      expect(viewData).to.be.equal(constants.ZERO_ADDRESS);
+    });
+
+    it("returns expected configured values for projectOne", async function () {
+      // add project
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .addProject("name", this.accounts.artist2.address);
+      // artist2 populates an addditional payee
+      const proposeArtistPaymentAddressesAndSplitsArgs = [
+        this.projectOne,
+        this.accounts.artist2.address,
+        this.accounts.additional.address,
+        49,
+        this.accounts.additional2.address, // additional secondary address
+        51, // additonal secondary percentage
+      ];
+      await this.genArt721Core
+        .connect(this.accounts.artist2)
+        .proposeArtistPaymentAddressesAndSplits(
+          ...proposeArtistPaymentAddressesAndSplitsArgs
+        );
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .adminAcceptArtistAddressesAndSplits(
+          ...proposeArtistPaymentAddressesAndSplitsArgs
+        );
+
+      // check for expected values
+      const viewData = await this.genArt721Core
+        .connect(this.accounts.user)
+        .projectIdToAdditionalPayeeSecondarySales(this.projectOne);
+      expect(viewData).to.be.equal(this.accounts.additional2.address);
+    });
+  });
+
+  describe("projectIdToAdditionalPayeeSecondarySalesPercentage", function () {
+    it("returns expected default value", async function () {
+      // check for expected values
+      const viewData = await this.genArt721Core
+        .connect(this.accounts.user)
+        .projectIdToAdditionalPayeeSecondarySalesPercentage(this.projectZero);
+      expect(viewData).to.be.equal(0);
+    });
+
+    it("returns expected configured values for projectOne", async function () {
+      // add project
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .addProject("name", this.accounts.artist2.address);
+      // artist2 populates an addditional payee
+      const proposeArtistPaymentAddressesAndSplitsArgs = [
+        this.projectOne,
+        this.accounts.artist2.address,
+        this.accounts.additional.address,
+        49,
+        this.accounts.additional2.address, // additional secondary address
+        51, // additonal secondary percentage
+      ];
+      await this.genArt721Core
+        .connect(this.accounts.artist2)
+        .proposeArtistPaymentAddressesAndSplits(
+          ...proposeArtistPaymentAddressesAndSplitsArgs
+        );
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .adminAcceptArtistAddressesAndSplits(
+          ...proposeArtistPaymentAddressesAndSplitsArgs
+        );
+
+      // check for expected values
+      const viewData = await this.genArt721Core
+        .connect(this.accounts.user)
+        .projectIdToAdditionalPayeeSecondarySalesPercentage(this.projectOne);
+      expect(viewData).to.be.equal(51);
+    });
+  });
+
   describe("numHistoricalRandomizers", function () {
     it("returns value of one upon initial configuration", async function () {
       const numHistoricalRandomizers = await this.genArt721Core

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
@@ -149,7 +149,7 @@ describe("MinterDAExpV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.014297")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0140976")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
@@ -149,7 +149,7 @@ describe("MinterDALinV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0143046")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0141052")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/MinterHolder/MinterHolderV1.test.ts
+++ b/test/minter-suite-minters/MinterHolder/MinterHolderV1.test.ts
@@ -236,7 +236,7 @@ describe("MinterHolderV1", async function () {
         ethers.utils.formatUnits(txCost.toString(), "ether").toString(),
         "ETH"
       );
-      expect(compareBN(txCost, ethers.utils.parseEther("0.01204"), 1)).to.be
+      expect(compareBN(txCost, ethers.utils.parseEther("0.0118406"), 1)).to.be
         .true;
     });
   });

--- a/test/minter-suite-minters/MinterMerkle/MinterMerkleV1.test.ts
+++ b/test/minter-suite-minters/MinterMerkle/MinterMerkleV1.test.ts
@@ -244,7 +244,7 @@ describe("MinterMerkleV1", async function () {
         ethers.utils.formatUnits(txCost.toString(), "ether").toString(),
         "ETH"
       );
-      expect(compareBN(txCost, ethers.utils.parseEther("0.0159238"), 1)).to.be
+      expect(compareBN(txCost, ethers.utils.parseEther("0.0157244"), 1)).to.be
         .true;
     });
 
@@ -286,7 +286,7 @@ describe("MinterMerkleV1", async function () {
         "ETH"
       );
       // the following is not much more than the gas cost with a very small allowlist
-      expect(compareBN(txCost, ethers.utils.parseEther("0.0167494"), 1)).to.be
+      expect(compareBN(txCost, ethers.utils.parseEther("0.0165514"), 1)).to.be
         .true;
     });
   });

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
@@ -177,7 +177,7 @@ describe("MinterSetPriceV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.013346")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0131466")); // assuming a cost of 100 GWEI
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
@@ -206,7 +206,7 @@ describe("MinterSetPriceERC20V2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0133675"));
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0131681"));
     });
   });
 


### PR DESCRIPTION
Pack financial data on V3 core to improve gas efficiency.

This minimizes the qty of cold storage slots accessed by packing primary and royalty percentages with addresses. This is an improved version of #250, based on things I've learned in the last week.

The percentages quoted below assume no additional payee for primary sales is set up. There would be slightly more benefit if our benchmark included additional payee payments (so this is a conservative estimate of the benefit).

## Gas impacts
Mint costs are reduced. Representative minter cost updates are shown in the table below.

_All gas costs assume project 3 mints avg(501-516) of 1000_
| Gas Test | Previous gas used to purchase | New gas used to purchase | % change |
| --- | --- | --- | --- |
| MinterSetPriceV2_V3Core | 116106 | 114112 | -1.7% |
| MinterDAExpV2_V3Core | 125506 | 123512 | -1.6% |

## TESTS

- [x] Gas tests updated
- [x] 100% coverage on V3 core

## Audit
This should be included in third party audits of the V3 core contract.