### PR TITLE
Fix typo re: deprecated spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Core contracts use the versioning schema below:
 - Minters have to iteract with (at least one) core contract
 - **Note:** while the whole end-to-end MinterFilter+FilteredMinter architecture is likely not the ideal fit for PBAB partners due to the infrastructure complexity required for partners integrating with it, any of the individual minters from within the minter suite can readily be adapted to work with PBAB core contracts–if you are a PBAB partner and there is a minter in the suite that this would be appealing for, please contact your account manager!
 
-| Core Contract Version(s) | Recommended Minters                                                                                             | deprecated Minters                                                         |
+| Core Contract Version(s) | Recommended Minters                                                                                             | Deprecated Minters                                                         |
 | ------------------------ | --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
 | V0                       | (legacy minter)                                                                                                 | -                                                                           |
 | V1, V1_PRTNR             | MinterSetPriceV1<br>MinterSetPriceERC20V1<br>MinterDAExpV1<br>MinterDALinV1<br>MinterMerkleV0<br>MinterHolderV0 | MinterSetPriceV0<br>MinterSetPriceERC20V0<br>MinterDAExpV0<br>MinterDALinV0 |

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Core contracts use the versioning schema below:
 - Minters have to iteract with (at least one) core contract
 - **Note:** while the whole end-to-end MinterFilter+FilteredMinter architecture is likely not the ideal fit for PBAB partners due to the infrastructure complexity required for partners integrating with it, any of the individual minters from within the minter suite can readily be adapted to work with PBAB core contracts–if you are a PBAB partner and there is a minter in the suite that this would be appealing for, please contact your account manager!
 
-| Core Contract Version(s) | Recommended Minters                                                                                             | Depreciated Minters                                                         |
+| Core Contract Version(s) | Recommended Minters                                                                                             | deprecated Minters                                                         |
 | ------------------------ | --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
 | V0                       | (legacy minter)                                                                                                 | -                                                                           |
 | V1, V1_PRTNR             | MinterSetPriceV1<br>MinterSetPriceERC20V1<br>MinterDAExpV1<br>MinterDALinV1<br>MinterMerkleV0<br>MinterHolderV0 | MinterSetPriceV0<br>MinterSetPriceERC20V0<br>MinterDAExpV0<br>MinterDALinV0 |

--- a/contracts/PBAB+Collabs/art-blocks-x-pace/DEPLOYMENTS.md
+++ b/contracts/PBAB+Collabs/art-blocks-x-pace/DEPLOYMENTS.md
@@ -68,7 +68,7 @@ https://goerli.etherscan.io/address/0xe25D9B8F5Cd8E8E8ccb68F26fc70E6AD4e0C7845#c
 
 `0x2246475beddf9333b6a6D9217194576E7617Afd1` set as minter owner, whitelisted on core contract, and admin of core contract. (contact Ryley if you need to change this)
 
-# Depreciated
+# deprecated
 ## Ropsten
 
 ### Upload 0

--- a/contracts/PBAB+Collabs/artcode/DEPLOYMENTS.md
+++ b/contracts/PBAB+Collabs/artcode/DEPLOYMENTS.md
@@ -16,7 +16,7 @@
 
 `0x0a690b298f84d12414f5c8db7de1ece5a4605877.` set as minter owner, whitelisted on core contract, and admin of core contract.
 
-## Ropsten (depreciated)
+## Ropsten (deprecated)
 
 ### Upload 0
 

--- a/contracts/PBAB+Collabs/bright-moments/DEPLOYMENTS.md
+++ b/contracts/PBAB+Collabs/bright-moments/DEPLOYMENTS.md
@@ -14,7 +14,7 @@
 
 `0x18B7511938FBe2EE08ADf3d4A24edB00A5C9B783` set as minter owner, whitelisted on core contract, and admin of core contract.
 
-## Ropsten (depreciated)
+## Ropsten (deprecated)
 
 ### Upload 0
 

--- a/contracts/PBAB+Collabs/colors-and-shapes/DEPLOYMENTS.md
+++ b/contracts/PBAB+Collabs/colors-and-shapes/DEPLOYMENTS.md
@@ -13,7 +13,7 @@ TBD
 
 `0x7f5a0A6847fD0FA05C13CBC02f435047b429E37C.` set as minter owner, whitelisted on core contract, and admin of core contract.
 
-## Ropsten (depreciated)
+## Ropsten (deprecated)
 
 ### Upload 0
 

--- a/contracts/PBAB+Collabs/crypto-citizens/DEPLOYMENTS.md
+++ b/contracts/PBAB+Collabs/crypto-citizens/DEPLOYMENTS.md
@@ -17,7 +17,7 @@
 
 `0x1040259f6Fe4f1C6ed1044b9Df6a8A4eBD2d3511` set as minter owner, whitelisted on core contract, and admin of core contract.
 
-## Ropsten (depreciated)
+## Ropsten (deprecated)
 
 ### Upload 0
 

--- a/contracts/PBAB+Collabs/doodle-labs/DEPLOYMENTS.md
+++ b/contracts/PBAB+Collabs/doodle-labs/DEPLOYMENTS.md
@@ -31,7 +31,7 @@ Additionally due to complexity of `.transfer()` out of gas errors caused by the 
 
 `0x95DcB7b8e99B7B8FCb1DCb9e82Bb12183b2bbE02.` set as minter owner, whitelisted on core contract, and admin of core contract.
 
-## Ropsten (depreciated)
+## Ropsten (deprecated)
 
 ### Upload 0
 

--- a/contracts/PBAB+Collabs/flutter/DEPLOYMENTS.md
+++ b/contracts/PBAB+Collabs/flutter/DEPLOYMENTS.md
@@ -17,7 +17,7 @@
 
 `0xcA04E939A0Ac0626C4a4299735e353E8DC5eF3eC` set as minter owner, whitelisted on core contract, and admin of core contract.
 
-## Ropsten (depreciated)
+## Ropsten (deprecated)
 
 ### Upload 0
 

--- a/contracts/PBAB+Collabs/legends-of-metaterra/DEPLOYMENTS.md
+++ b/contracts/PBAB+Collabs/legends-of-metaterra/DEPLOYMENTS.md
@@ -17,7 +17,7 @@
 
 `0xe18Fc96ba325Ef22746aDA9A82d521845a2c16f8.` set as minter owner, whitelisted on core contract, and admin of core contract.
 
-## Ropsten (depreciated)
+## Ropsten (deprecated)
 
 ### Upload 0
 

--- a/contracts/PBAB+Collabs/mechsuit/DEPLOYMENTS.md
+++ b/contracts/PBAB+Collabs/mechsuit/DEPLOYMENTS.md
@@ -14,7 +14,7 @@ TBD
 
 `0x5343bFA1BBe40456f890354a39fAE17Ac4A7B95B.` set as minter owner, whitelisted on core contract, and admin of core contract.
 
-## Ropsten (depreciated)
+## Ropsten (deprecated)
 
 ### Upload 0
 

--- a/contracts/PBAB+Collabs/plottables/DEPLOYMENTS.md
+++ b/contracts/PBAB+Collabs/plottables/DEPLOYMENTS.md
@@ -17,7 +17,7 @@
 
 `0xC9604821E25E162452157c932380984F7c1f6402.` set as minter owner, whitelisted on core contract, and admin of core contract.
 
-## Ropsten (depreciated)
+## Ropsten (deprecated)
 
 ### Upload 0
 

--- a/contracts/PBAB+Collabs/tboa/DEPLOYMENTS.md
+++ b/contracts/PBAB+Collabs/tboa/DEPLOYMENTS.md
@@ -17,7 +17,7 @@
 
 `0x382882e09915375F9Ddd92c677b53AB031671282` set as minter owner, whitelisted on core contract, and admin of core contract.
 
-## Ropsten (depreciated)
+## Ropsten (deprecated)
 
 ### Upload 0
 


### PR DESCRIPTION
Just fixing `.md` typos, this is a no-op.