### PR TITLE
pack smarter

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -112,14 +112,14 @@ contract GenArt721CoreV3 is
     /// packed struct containing project financial information
     struct ProjectFinance {
         address payable additionalPayeePrimarySales;
-        // packed uint: max of 100, max uint8 = 255
-        uint8 additionalPayeePrimarySalesPercentage;
+        // packed uint: max of 95, max uint8 = 255
+        uint8 secondaryMarketRoyaltyPercentage;
         address payable additionalPayeeSecondarySales;
         // packed uint: max of 100, max uint8 = 255
         uint8 additionalPayeeSecondarySalesPercentage;
         address payable artistAddress;
-        // packed uint: max of 95, max uint8 = 255
-        uint8 secondaryMarketRoyaltyPercentage;
+        // packed uint: max of 100, max uint8 = 255
+        uint8 additionalPayeePrimarySalesPercentage;
     }
     // Project financials mapping
     mapping(uint256 => ProjectFinance) projectIdToFinancials;

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
@@ -149,7 +149,7 @@ describe("MinterDAExpV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.014078")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0138786")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
@@ -149,7 +149,7 @@ describe("MinterDALinV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0140856")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0138862")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
@@ -177,7 +177,7 @@ describe("MinterSetPriceV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.013127")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0129276")); // assuming a cost of 100 GWEI
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
@@ -206,7 +206,7 @@ describe("MinterSetPriceERC20V2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0131485"));
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0129491"));
     });
   });
 


### PR DESCRIPTION
Shuffle packing so artist additional payee percentage for primary sales is packed with artist address.

This eliminates 2k gas in the case where an artist's additional payee percentage is zero.