### PR TITLE
Add royalty percentage to `projectArtistPaymentInfo` view

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -1079,7 +1079,10 @@ contract GenArt721CoreV3 is
      * sales royalties
      * @return additionalPayeeSecondarySalesPercentage Percentage of artist revenue
      * to be sent to the additional payee address for secondary sales royalties
-
+     * @return secondaryMarketRoyaltyPercentage Royalty percentage to be sent to
+     * combination of artist and additional payee. This does not include the
+     * platform's percentage of secondary sales royalties, which is defined by
+     * `artblocksSecondarySalesBPS`.
      */
     function projectArtistPaymentInfo(uint256 _projectId)
         external
@@ -1089,7 +1092,8 @@ contract GenArt721CoreV3 is
             address additionalPayeePrimarySales,
             uint256 additionalPayeePrimarySalesPercentage,
             address additionalPayeeSecondarySales,
-            uint256 additionalPayeeSecondarySalesPercentage
+            uint256 additionalPayeeSecondarySalesPercentage,
+            uint256 secondaryMarketRoyaltyPercentage
         )
     {
         ProjectFinance storage projectFinance = projectIdToFinancials[
@@ -1104,6 +1108,8 @@ contract GenArt721CoreV3 is
             .additionalPayeeSecondarySales;
         additionalPayeeSecondarySalesPercentage = projectFinance
             .additionalPayeeSecondarySalesPercentage;
+        secondaryMarketRoyaltyPercentage = projectFinance
+            .secondaryMarketRoyaltyPercentage;
     }
 
     /**

--- a/test/core/V3/GenArt721CoreV3_Views.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Views.test.ts
@@ -352,9 +352,12 @@ describe("GenArt721CoreV3 Views", async function () {
       expect(
         projectArtistPaymentInfo.additionalPayeeSecondarySalesPercentage
       ).to.be.equal(0);
+      expect(
+        projectArtistPaymentInfo.secondaryMarketRoyaltyPercentage
+      ).to.be.equal(0);
     });
 
-    it("returns expected values after updating artist payment addresses and splits", async function () {
+    it("returns expected values after updating artist payment addresses and splits, and secondary royalty percentage", async function () {
       const valuesToUpdateTo = [
         this.projectZero,
         this.accounts.artist2.address,
@@ -370,6 +373,10 @@ describe("GenArt721CoreV3 Views", async function () {
       await this.genArt721Core
         .connect(this.accounts.deployer)
         .adminAcceptArtistAddressesAndSplits(...valuesToUpdateTo);
+      // new artist sets new secondary royalty percentage
+      await this.genArt721Core
+        .connect(this.accounts.artist2)
+        .updateProjectSecondaryMarketRoyaltyPercentage(this.projectZero, 5);
       // check for expected values
       const projectArtistPaymentInfo = await this.genArt721Core
         .connect(this.accounts.deployer)
@@ -389,6 +396,9 @@ describe("GenArt721CoreV3 Views", async function () {
       expect(
         projectArtistPaymentInfo.additionalPayeeSecondarySalesPercentage
       ).to.be.equal(valuesToUpdateTo[5]);
+      expect(
+        projectArtistPaymentInfo.secondaryMarketRoyaltyPercentage
+      ).to.be.equal(5);
     });
   });
 


### PR DESCRIPTION
Add royalty percentage to `projectArtistPaymentInfo` view.

Per discussion w/ @yoshiwarab, seems like a good idea to add secondary market royalty percentage to the new `projectArtistPaymentInfo` view.

## Audit Impacts
In my opinion, this is a very simple change to a view function, and should not be required to be in the audit. Definitely open to discuss if others dissagree!

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202896474680856