### PR TITLE
Add public immutable startingProjectId to V3 core

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -143,6 +143,9 @@ contract GenArt721CoreV3 is
     /// single minter allowed for this core contract
     address public minterContract;
 
+    /// starting (initial) project ID on this contract
+    uint256 public immutable startingProjectId;
+
     /// next project ID to be created
     uint248 private _nextProjectId;
 
@@ -230,6 +233,8 @@ contract GenArt721CoreV3 is
         address _adminACLContract,
         uint256 _startingProjectId
     ) ERC721_PackedHashSeed(_tokenName, _tokenSymbol) {
+        // record contracts starting project ID
+        startingProjectId = _startingProjectId;
         _updateArtblocksPrimarySalesAddress(msg.sender);
         _updateArtblocksSecondarySalesAddress(msg.sender);
         _updateRandomizerAddress(_randomizerContract);

--- a/test/core/V3/GenArt721CoreV3_Integration.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Integration.test.ts
@@ -274,6 +274,28 @@ describe("GenArt721CoreV3 Integration", async function () {
     });
   });
 
+  describe("startingProjectId", function () {
+    it("returns zero when initialized to zero nextProjectId", async function () {
+      // one project has already been added, so should be one
+      expect(await this.genArt721Core.startingProjectId()).to.be.equal(1);
+    });
+
+    it("returns >0 when initialized to >0 nextProjectId", async function () {
+      const differentGenArt721Core = await deployAndGet.call(
+        this,
+        "GenArt721CoreV3",
+        [
+          this.name,
+          this.symbol,
+          this.randomizer.address,
+          this.adminACL.address,
+          365,
+        ]
+      );
+      expect(await differentGenArt721Core.startingProjectId()).to.be.equal(365);
+    });
+  });
+
   describe("mint_ECF", function () {
     it("reverts if not called by the minter contract", async function () {
       await expectRevert(

--- a/test/core/V3/GenArt721CoreV3_Integration.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Integration.test.ts
@@ -276,8 +276,8 @@ describe("GenArt721CoreV3 Integration", async function () {
 
   describe("startingProjectId", function () {
     it("returns zero when initialized to zero nextProjectId", async function () {
-      // one project has already been added, so should be one
-      expect(await this.genArt721Core.startingProjectId()).to.be.equal(1);
+      // one project has already been added, but starting project ID should remain at 0
+      expect(await this.genArt721Core.startingProjectId()).to.be.equal(0);
     });
 
     it("returns >0 when initialized to >0 nextProjectId", async function () {

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
@@ -149,7 +149,7 @@ describe("MinterDAExpV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0138791")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0138769")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
@@ -149,7 +149,7 @@ describe("MinterDALinV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0138867")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0138845")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
@@ -177,7 +177,7 @@ describe("MinterSetPriceV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0129281")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0129259")); // assuming a cost of 100 GWEI
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
@@ -206,7 +206,7 @@ describe("MinterSetPriceERC20V2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0129496"));
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0129474"));
     });
   });
 


### PR DESCRIPTION
Add public immutable `startingProjectId` to the V3 core.

This defines a "project starting point" for a given core contract. Aside from this being a generally useful thing to know for a contract, it enables our subgraph to more easily be able to begin iterations over all projects on a contract from the first project on a contract. This is important as we add more and more projects to our contracts.

## Design Choices
- use immutable variable so we can populate in constructor, but can never be altered after that.

## Audit impacts
This is a very simple metadata variable that does not impact any interfaces. I do not feel needs to be included in our audit (happy to discuss if others disagree!)