### PR TITLE
Clear proposals upon acceptance, encode instead of encodePacked

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -497,7 +497,7 @@ contract GenArt721CoreV3 is
         );
         // effects
         proposedArtistAddressesAndSplitsHash[_projectId] = keccak256(
-            abi.encodePacked(
+            abi.encode(
                 _artistAddress,
                 _additionalPayeePrimarySales,
                 _additionalPayeePrimarySalesPercentage,
@@ -556,7 +556,7 @@ contract GenArt721CoreV3 is
         require(
             proposedArtistAddressesAndSplitsHash[_projectId] ==
                 keccak256(
-                    abi.encodePacked(
+                    abi.encode(
                         _artistAddress,
                         _additionalPayeePrimarySales,
                         _additionalPayeePrimarySalesPercentage,

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -581,6 +581,8 @@ contract GenArt721CoreV3 is
         projectFinance.additionalPayeeSecondarySalesPercentage = uint8(
             _additionalPayeeSecondarySalesPercentage
         );
+        // clear proposed values
+        proposedArtistAddressesAndSplitsHash[_projectId] = bytes32(0);
         // emit event for off-chain indexing
         emit AcceptedArtistAddressesAndSplits(_projectId);
     }

--- a/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
+++ b/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
@@ -635,6 +635,38 @@ describe("GenArt721CoreV3 Project Configure", async function () {
         "Must match artist proposal"
       );
     });
+
+    it("only allows adminACL-allowed account to accept updates once (i.e. proposal is cleared upon acceptance)", async function () {
+      // artist proposes new values
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .proposeArtistPaymentAddressesAndSplits(...this.valuesToUpdateTo);
+      // rejects artist as an acceptor of updates
+      await expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.artist)
+          .adminAcceptArtistAddressesAndSplits(...this.valuesToUpdateTo),
+        "Only Admin ACL allowed"
+      );
+      // rejects user as an acceptor of updates
+      await expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.user)
+          .adminAcceptArtistAddressesAndSplits(...this.valuesToUpdateTo),
+        "Only Admin ACL allowed"
+      );
+      // allows deployer to accept new values
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .adminAcceptArtistAddressesAndSplits(...this.valuesToUpdateTo);
+      // reverts if deployer tries to accept again
+      await expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.deployer)
+          .adminAcceptArtistAddressesAndSplits(...this.valuesToUpdateTo),
+        "Must match artist proposal"
+      );
+    });
   });
 
   describe("updateProjectSecondaryMarketRoyaltyPercentage", function () {

--- a/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
+++ b/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
@@ -641,20 +641,6 @@ describe("GenArt721CoreV3 Project Configure", async function () {
       await this.genArt721Core
         .connect(this.accounts.artist)
         .proposeArtistPaymentAddressesAndSplits(...this.valuesToUpdateTo);
-      // rejects artist as an acceptor of updates
-      await expectRevert(
-        this.genArt721Core
-          .connect(this.accounts.artist)
-          .adminAcceptArtistAddressesAndSplits(...this.valuesToUpdateTo),
-        "Only Admin ACL allowed"
-      );
-      // rejects user as an acceptor of updates
-      await expectRevert(
-        this.genArt721Core
-          .connect(this.accounts.user)
-          .adminAcceptArtistAddressesAndSplits(...this.valuesToUpdateTo),
-        "Only Admin ACL allowed"
-      );
       // allows deployer to accept new values
       await this.genArt721Core
         .connect(this.accounts.deployer)


### PR DESCRIPTION
Update V3 core logic to clear artist proposed addresses and payment splits upon admin acceptance, and improve edge case by using `abi.encode` (instead of `abi.encodePacked`) when calculating/verifying `proposedArtistAddressesAndSplitsHash`.

Two main updates in this PR:
- Clear artist proposed addresses and payment splits upon admin acceptance
  - This is more intuitive from a process perspective, and prevents stale approvals from remaining valid
- Calculates `proposedArtistAddressesAndSplitsHash` via `abi.encode` of the values, instead of `abi.encodePacked`
  - This prevents a low-severity bug where admin moves decimals between addresses and values, potentially resulting in unexpected splits percentages and/or payment addresses
  - This bug would only happen if admin behaved somewhat maliciously, or our frontend did some really crazy stuff.

## Audit Impacts
Recommend Cc'ing audit team on this PR. They will probably identify these details, and will appreciate us letting them know we have some sort of solution already in-place.