### PR TITLE
V3/Expose project completed timestamp

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -1052,6 +1052,8 @@ contract GenArt721CoreV3 is
      * @return maxInvocations Maximum allowed invocations
      * @return active Boolean representing if project is currently active
      * @return paused Boolean representing if project is paused
+     * @return completedTimestamp zero if project not complete, otherwise
+     * timestamp of project completion.
      * @return locked Boolean representing if project is locked
      * @dev price and currency info are located on minter contracts
      */
@@ -1063,6 +1065,7 @@ contract GenArt721CoreV3 is
             uint256 maxInvocations,
             bool active,
             bool paused,
+            uint256 completedTimestamp,
             bool locked
         )
     {
@@ -1071,6 +1074,7 @@ contract GenArt721CoreV3 is
         maxInvocations = project.maxInvocations;
         active = project.active;
         paused = project.paused;
+        completedTimestamp = project.completedTimestamp;
         locked = !_projectUnlocked(_projectId);
     }
 

--- a/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
+++ b/contracts/interfaces/0.8.x/IGenArt721CoreContractV3.sol
@@ -118,6 +118,7 @@ interface IGenArt721CoreContractV3 is IManifold {
             uint256 maxInvocations,
             bool active,
             bool paused,
+            uint256 completedTimestamp,
             bool locked
         );
 

--- a/contracts/minter-suite/Minters/MinterDAExp/MinterDAExpV2.sol
+++ b/contracts/minter-suite/Minters/MinterDAExp/MinterDAExpV2.sol
@@ -127,7 +127,7 @@ contract MinterDAExpV2 is ReentrancyGuard, IFilteredMinterV0 {
      */
     function setProjectMaxInvocations(uint256 _projectId) external {
         uint256 maxInvocations;
-        (, maxInvocations, , , ) = genArtCoreContract.projectStateData(
+        (, maxInvocations, , , , ) = genArtCoreContract.projectStateData(
             _projectId
         );
         // update storage with results

--- a/contracts/minter-suite/Minters/MinterDALin/MinterDALinV2.sol
+++ b/contracts/minter-suite/Minters/MinterDALin/MinterDALinV2.sol
@@ -122,7 +122,7 @@ contract MinterDALinV2 is ReentrancyGuard, IFilteredMinterV0 {
      */
     function setProjectMaxInvocations(uint256 _projectId) external {
         uint256 maxInvocations;
-        (, maxInvocations, , , ) = genArtCoreContract.projectStateData(
+        (, maxInvocations, , , , ) = genArtCoreContract.projectStateData(
             _projectId
         );
         // update storage with results

--- a/contracts/minter-suite/Minters/MinterHolder/MinterHolderV1.sol
+++ b/contracts/minter-suite/Minters/MinterHolder/MinterHolderV1.sol
@@ -334,7 +334,7 @@ contract MinterHolderV1 is ReentrancyGuard, IFilteredMinterHolderV0 {
      */
     function setProjectMaxInvocations(uint256 _projectId) external {
         uint256 maxInvocations;
-        (, maxInvocations, , , ) = genArtCoreContract.projectStateData(
+        (, maxInvocations, , , , ) = genArtCoreContract.projectStateData(
             _projectId
         );
         // update storage with results

--- a/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
+++ b/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
@@ -164,7 +164,7 @@ contract MinterMerkleV1 is ReentrancyGuard, IFilteredMinterMerkleV0 {
      */
     function setProjectMaxInvocations(uint256 _projectId) external {
         uint256 maxInvocations;
-        (, maxInvocations, , , ) = genArtCoreContract.projectStateData(
+        (, maxInvocations, , , , ) = genArtCoreContract.projectStateData(
             _projectId
         );
         // update storage with results

--- a/contracts/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
+++ b/contracts/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
@@ -84,7 +84,7 @@ contract MinterSetPriceV2 is ReentrancyGuard, IFilteredMinterV0 {
      */
     function setProjectMaxInvocations(uint256 _projectId) external {
         uint256 maxInvocations;
-        (, maxInvocations, , , ) = genArtCoreContract.projectStateData(
+        (, maxInvocations, , , , ) = genArtCoreContract.projectStateData(
             _projectId
         );
         // update storage with results

--- a/contracts/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V2.sol
+++ b/contracts/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V2.sol
@@ -129,7 +129,7 @@ contract MinterSetPriceERC20V2 is ReentrancyGuard, IFilteredMinterV0 {
      */
     function setProjectMaxInvocations(uint256 _projectId) external {
         uint256 maxInvocations;
-        (, maxInvocations, , , ) = genArtCoreContract.projectStateData(
+        (, maxInvocations, , , , ) = genArtCoreContract.projectStateData(
             _projectId
         );
         // update storage with results

--- a/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
+++ b/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
@@ -143,6 +143,11 @@ describe("GenArt721CoreV3 Project Configure", async function () {
         this.minter.connect(this.accounts.artist).purchase(this.projectZero),
         "Must not exceed max invocations"
       );
+      // confirm project is completed via view function
+      const projectStateData = await this.genArt721Core.projectStateData(
+        this.projectZero
+      );
+      expect(projectStateData.completedTimestamp).to.be.gt(0);
     });
 
     it("project may not mint when is completed due to minting out", async function () {
@@ -157,6 +162,11 @@ describe("GenArt721CoreV3 Project Configure", async function () {
         this.minter.connect(this.accounts.artist).purchase(this.projectZero),
         "Must not exceed max invocations"
       );
+      // confirm project is completed via view function
+      const projectStateData = await this.genArt721Core.projectStateData(
+        this.projectZero
+      );
+      expect(projectStateData.completedTimestamp).to.be.gt(0);
     });
   });
 

--- a/test/core/V3/GenArt721CoreV3_Views.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Views.test.ts
@@ -275,6 +275,7 @@ describe("GenArt721CoreV3 Views", async function () {
       expect(projectStateData.maxInvocations).to.be.equal(15);
       expect(projectStateData.active).to.be.true;
       expect(projectStateData.paused).to.be.true;
+      expect(projectStateData.completedTimestamp).to.be.equal(0);
       expect(projectStateData.locked).to.be.false;
     });
 
@@ -289,6 +290,7 @@ describe("GenArt721CoreV3 Views", async function () {
       expect(projectStateData.maxInvocations).to.be.equal(15);
       expect(projectStateData.active).to.be.true;
       expect(projectStateData.paused).to.be.false;
+      expect(projectStateData.completedTimestamp).to.be.equal(0);
       expect(projectStateData.locked).to.be.false;
     });
   });


### PR DESCRIPTION
Expose V3 core project `completedTimestamp` in `projectStateData` view.

Based off of some discussion a while ago with @yoshiwarab. To be clear, this is a nice-to-have, and not a must have. It does allow us to view the on-chain completedTimestamp value without relying on our subgraph's indexing of the event `ProjectUpdated(_projectId, FIELD_PROJECT_COMPLETED)`.

## Downstream Impacts
I don't think this requires any updates to the subgraph or frontend (since we are only adding more data to the view), other than updating the ABI files for the V3 core contract.

## Audit Impacts
I don't think this needs an audit review - the change is very minimal

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202896474680854