### PR TITLE
Enable indexing of AdminACL superAdmin

### DIFF
--- a/contracts/AdminACLV0.sol
+++ b/contracts/AdminACLV0.sol
@@ -22,12 +22,23 @@ contract AdminACLV0 is IAdminACLV0, ERC165 {
 
     /**
      * @notice Allows superAdmin change the superAdmin address.
+     * @param _newSuperAdmin The new superAdmin address.
+     * @param _genArt721CoreAddressesToUpdate Array of genArt721Core
+     * addresses to update to the new superAdmin, for indexing purposes only.
+     * @dev this function is gated to only superAdmin address.
      */
-    function changeSuperAdmin(address _newSuperAdmin) external {
+    function changeSuperAdmin(
+        address _newSuperAdmin,
+        address[] calldata _genArt721CoreAddressesToUpdate
+    ) external {
         require(msg.sender == superAdmin, "Only superAdmin");
         address previousSuperAdmin = superAdmin;
         superAdmin = _newSuperAdmin;
-        emit SuperAdminTransferred(previousSuperAdmin, _newSuperAdmin);
+        emit SuperAdminTransferred(
+            previousSuperAdmin,
+            _newSuperAdmin,
+            _genArt721CoreAddressesToUpdate
+        );
     }
 
     /**

--- a/contracts/AdminACLV0.sol
+++ b/contracts/AdminACLV0.sol
@@ -25,7 +25,9 @@ contract AdminACLV0 is IAdminACLV0, ERC165 {
      */
     function changeSuperAdmin(address _newSuperAdmin) external {
         require(msg.sender == superAdmin, "Only superAdmin");
+        address previousSuperAdmin = superAdmin;
         superAdmin = _newSuperAdmin;
+        emit SuperAdminTransferred(previousSuperAdmin, _newSuperAdmin);
     }
 
     /**

--- a/contracts/interfaces/0.8.x/IAdminACLV0.sol
+++ b/contracts/interfaces/0.8.x/IAdminACLV0.sol
@@ -4,8 +4,19 @@
 pragma solidity ^0.8.0;
 
 interface IAdminACLV0 {
+    /**
+     * @notice Token ID `_tokenId` minted to `_to`.
+     */
+    event SuperAdminTransferred(
+        address indexed previousSuperAdmin,
+        address indexed newSuperAdmin
+    );
+
     /// Type of the Admin ACL contract, e.g. "AdminACLV0"
     function AdminACLType() external view returns (string memory);
+
+    /// super admin address
+    function superAdmin() external view returns (address);
 
     /**
      * @notice Calls transferOwnership on other contract from this contract.

--- a/contracts/interfaces/0.8.x/IAdminACLV0.sol
+++ b/contracts/interfaces/0.8.x/IAdminACLV0.sol
@@ -6,10 +6,15 @@ pragma solidity ^0.8.0;
 interface IAdminACLV0 {
     /**
      * @notice Token ID `_tokenId` minted to `_to`.
+     * @param previousSuperAdmin The previous superAdmin address.
+     * @param newSuperAdmin The new superAdmin address.
+     * @param genArt721CoreAddressesToUpdate Array of genArt721Core
+     * addresses to update to the new superAdmin, for indexing purposes only.
      */
     event SuperAdminTransferred(
         address indexed previousSuperAdmin,
-        address indexed newSuperAdmin
+        address indexed newSuperAdmin,
+        address[] genArt721CoreAddressesToUpdate
     );
 
     /// Type of the Admin ACL contract, e.g. "AdminACLV0"

--- a/scripts/core-suite-testnet-deployments/1_reference_goerli_flagship_dev_V3Core_deployer.ts
+++ b/scripts/core-suite-testnet-deployments/1_reference_goerli_flagship_dev_V3Core_deployer.ts
@@ -231,7 +231,9 @@ async function main() {
 
   // update super admin address
   if (superAdminAddress) {
-    await adminACL.connect(deployer).changeSuperAdmin(superAdminAddress);
+    await adminACL
+      .connect(deployer)
+      .changeSuperAdmin(superAdminAddress, [genArt721Core.address]);
   }
 
   // Output instructions for manual Etherscan verification.

--- a/test/admin-acl/AdminACLV0/AdminACLV0.test.ts
+++ b/test/admin-acl/AdminACLV0/AdminACLV0.test.ts
@@ -83,17 +83,22 @@ describe("AdminACLV0", async function () {
   describe("changeSuperAdmin", function () {
     it("emits an event", async function () {
       expect(
-        await this.adminACL.changeSuperAdmin(this.accounts.deployer2.address)
+        await this.adminACL.changeSuperAdmin(this.accounts.deployer2.address, [
+          this.genArt721Core.address,
+        ])
       )
         .to.emit(this.adminACL, "SuperAdminTransferred")
         .withArgs(
           this.accounts.deployer.address,
-          this.accounts.deployer2.address
+          this.accounts.deployer2.address,
+          [this.genArt721Core.address]
         );
     });
 
     it("updates superAdmin", async function () {
-      await this.adminACL.changeSuperAdmin(this.accounts.deployer2.address);
+      await this.adminACL.changeSuperAdmin(this.accounts.deployer2.address, [
+        this.genArt721Core.address,
+      ]);
       expect(await this.adminACL.superAdmin()).to.equal(
         this.accounts.deployer2.address
       );

--- a/test/admin-acl/AdminACLV0/AdminACLV0.test.ts
+++ b/test/admin-acl/AdminACLV0/AdminACLV0.test.ts
@@ -21,9 +21,9 @@ import {
 import { FOUR_WEEKS } from "../../util/constants";
 
 /**
- * Tests for transferring ownership to new AdminACL on AdminACLV0.
+ * Tests for functionality of AdminACLV0.
  */
-describe("AdminACLV0 Transfer Ownership", async function () {
+describe("AdminACLV0", async function () {
   beforeEach(async function () {
     // standard accounts and constants
     this.accounts = await getAccounts();
@@ -76,6 +76,26 @@ describe("AdminACLV0 Transfer Ownership", async function () {
       await this.adminACL.transferOwnershipOn(
         this.genArt721Core.address,
         this.adminACL_InterfaceBroadcast.address
+      );
+    });
+  });
+
+  describe("changeSuperAdmin", function () {
+    it("emits an event", async function () {
+      expect(
+        await this.adminACL.changeSuperAdmin(this.accounts.deployer2.address)
+      )
+        .to.emit(this.adminACL, "SuperAdminTransferred")
+        .withArgs(
+          this.accounts.deployer.address,
+          this.accounts.deployer2.address
+        );
+    });
+
+    it("updates superAdmin", async function () {
+      await this.adminACL.changeSuperAdmin(this.accounts.deployer2.address);
+      expect(await this.adminACL.superAdmin()).to.equal(
+        this.accounts.deployer2.address
       );
     });
   });


### PR DESCRIPTION
Update AdminACLV0 to enable subgraph indexing of its `superAdmin` address.

Adds:
- event emitted when superAdmin is changed
- includes superAdmin in `IAdminACLV0`
  - Allows subgraph to use only `IAdminACLV0` ABI, minimizing subgraph code bloat if we roll versions of this in the future.
- tests for new event

## Design Choices
- `New SuperAdminTransferred` event includes an `address[] genArt721CoreAddressesToUpdate` for indexing purposes only. This is because when the subgraph views the new event, it needs to know which contracts it should attempt to the new superAdmin. It seemed most straightforward to include the addresses in the call to transfer ownership and the event.

## Audit Impacts
This change is straightforward and should not impact audit results.