### PR TITLE
QSP-11-Fixed - Lock MockAdminACLV0 to explicit Solidiy pragma

### DIFF
--- a/contracts/mock/MockAdminACLV0.sol
+++ b/contracts/mock/MockAdminACLV0.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.16;
 
 import "../interfaces/0.8.x/IAdminACLV0.sol";
 import "@openzeppelin-4.7/contracts/access/Ownable.sol";


### PR DESCRIPTION
Update `MockAdminACLV0` to use locked pragma Solidity version.