### PR TITLE
Lock AdminACLV0 to solidity version

### DIFF
--- a/contracts/AdminACLV0.sol
+++ b/contracts/AdminACLV0.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.16;
 
 import "./interfaces/0.8.x/IAdminACLV0.sol";
 import "@openzeppelin-4.7/contracts/access/Ownable.sol";


### PR DESCRIPTION
Lock AdminACLV0 to specific solidity version.

Follow-on from #294 