### PR TITLE
Update V3 deployment script reference

### DIFF
--- a/scripts/core-suite-testnet-deployments/1_reference_goerli_flagship_dev_V3Core_deployer.ts
+++ b/scripts/core-suite-testnet-deployments/1_reference_goerli_flagship_dev_V3Core_deployer.ts
@@ -145,6 +145,9 @@ async function main() {
   // SETUP BEGINS HERE
   //////////////////////////////////////////////////////////////////////////////
 
+  // Assign randomizer to core and renounce ownership
+  await randomizer.assignCoreAndRenounce(genArt721Core.address);
+
   // Allowlist the Minter on the Core contract.
   await genArt721Core
     .connect(deployer)
@@ -242,6 +245,8 @@ async function main() {
   console.log(
     `${standardVerify} --network ${networkName} ${genArt721Core.address} "${tokenName}" "${tokenTicker}" ${randomizerAddress} ${adminACLAddress} ${startingProjectId}`
   );
+  console.log(`Verify Admin ACL contract deployment with:`);
+  console.log(`${standardVerify} --network ${networkName} ${adminACL.address}`);
   console.log(`Verify MinterFilter deployment with:`);
   console.log(
     `${standardVerify} --network ${networkName} ${minterFilter.address} ${genArt721Core.address}`


### PR DESCRIPTION
Update V3 deployment script to include a couple of missing steps.

Includes:
- Renounce and set core contract on randomizer
- Prompt for verification of AdminACL source code