### PR TITLE
Hotfix: Sending correct dependencyType uint with the UpdatedGateway event

### DIFF
--- a/contracts/PBAB+Collabs/GenArt721CoreV2_ENGINE_FLEX.sol
+++ b/contracts/PBAB+Collabs/GenArt721CoreV2_ENGINE_FLEX.sol
@@ -242,7 +242,7 @@ contract GenArt721CoreV2_ENGINE_FLEX is ERC721, IGenArt721CoreV2_PBAB {
         onlyWhitelisted
     {
         preferredIPFSGateway = _gateway;
-        emit GatewayUpdated(ExternalAssetDependencyType.ARWEAVE, _gateway);
+        emit GatewayUpdated(ExternalAssetDependencyType.IPFS, _gateway);
     }
 
     /**
@@ -253,7 +253,7 @@ contract GenArt721CoreV2_ENGINE_FLEX is ERC721, IGenArt721CoreV2_PBAB {
         onlyWhitelisted
     {
         preferredArweaveGateway = _gateway;
-        emit GatewayUpdated(ExternalAssetDependencyType.IPFS, _gateway);
+        emit GatewayUpdated(ExternalAssetDependencyType.ARWEAVE, _gateway);
     }
 
     /**

--- a/test/core/GenArt721CoreV2_ENGINE_FLEX_Integration.tests.ts
+++ b/test/core/GenArt721CoreV2_ENGINE_FLEX_Integration.tests.ts
@@ -237,5 +237,25 @@ describe("GenArt721CoreV2_PBAB_FLEX_Integration", async function () {
         .projectExternalAssetDependencyCount(0);
       expect(externalAssetDependencyCountB).to.equal(1);
     });
+
+    it("can update contract preferred IPFS & Arweave gateways", async function () {
+      // setting IPFS gateway
+      await expect(
+        this.genArt721Core
+          .connect(this.accounts.deployer)
+          .updateIPFSGateway("https://ipfs.io/ipfs/")
+      )
+        .to.emit(this.genArt721Core, "GatewayUpdated")
+        .withArgs(0, "https://ipfs.io/ipfs/");
+
+      // setting Arweave gateway
+      await expect(
+        this.genArt721Core
+          .connect(this.accounts.deployer)
+          .updateArweaveGateway("https://arweave.net/")
+      )
+        .to.emit(this.genArt721Core, "GatewayUpdated")
+        .withArgs(1, "https://arweave.net/");
+    });
   });
 });


### PR DESCRIPTION
The dependencyType being sent by the GatewayUpdated event was mistakenly swapped. Also added tests specifically around the gateway updates (should've been there anyway).