### PR TITLE
Allow for cleanup of unused contract bytecode for script storage

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -877,7 +877,10 @@ contract GenArt721CoreV3 is
     {
         Project storage project = projects[_projectId];
         require(_scriptId < project.scriptCount, "scriptId out of range");
-        // store script in contract bytecode
+        // purge old contract bytecode contract from the blockchain state
+        project.scriptBytecodeAddresses[_scriptId].purgeBytecode();
+        // store script in contract bytecode, replacing reference address from
+        // the contract that no longer exists with the newly created one
         project.scriptBytecodeAddresses[_scriptId] = _script.writeToBytecode();
         emit ProjectUpdated(_projectId, FIELD_PROJECT_SCRIPT);
     }
@@ -892,6 +895,9 @@ contract GenArt721CoreV3 is
     {
         Project storage project = projects[_projectId];
         require(project.scriptCount > 0, "there are no scripts to remove");
+        // purge old contract bytecode contract from the blockchain state
+        project.scriptBytecodeAddresses[project.scriptCount - 1].purgeBytecode();
+        // delete reference to contract address that no longer exists
         delete project.scriptBytecodeAddresses[project.scriptCount - 1];
         project.scriptCount = project.scriptCount - 1;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_SCRIPT);

--- a/contracts/libs/0.8.x/BytecodeStorage.sol
+++ b/contracts/libs/0.8.x/BytecodeStorage.sol
@@ -12,7 +12,13 @@ pragma solidity ^0.8.0;
  */
 library BytecodeStorage {
     /// always set first byte to 0x00 (STOP) to ensure created contracts cannot be called
-    uint256 internal constant DATA_OFFSET = 1;
+    //---------------------------------------------------------------------------------------------------------------//
+    // Offset Amount | Offset Aggregate | Description                                                                //
+    //---------------------------------------------------------------------------------------------------------------//
+    // 1             | 1                | set first byte to 0x00 (STOP) to ensure created contracts cannot be called //
+    // 20            | 20               | reserve 20 bytes for deploying-contract's address                          //
+    //---------------------------------------------------------------------------------------------------------------//
+    uint256 internal constant DATA_OFFSET = 21;
 
     /**
      * @notice Write a string to contract bytecode
@@ -41,6 +47,7 @@ library BytecodeStorage {
             //---------------------------------------------------------------------------------------------------------------//
             hex"60_0B_59_81_38_03_80_92_59_39_F3", // returns all code in the contract except for the first 11 (0B in hex) bytes
             hex"00", // prefix bytecode with 0x00 to ensure contract cannot be called
+            msg.sender, // store the deploying-contract's address (to be used to gate `selfdestruct`)
             _data
         );
 

--- a/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
+++ b/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
@@ -754,6 +754,40 @@ describe("GenArt721CoreV3 Project Configure", async function () {
       expect(script).to.equal(SQUIGGLE_SCRIPT);
     });
 
+    it("uploads chromie squiggle script, and then purges it", async function () {
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .addProjectScript(this.projectZero, SQUIGGLE_SCRIPT);
+      const script = await this.genArt721Core.projectScriptByIndex(
+        this.projectZero,
+        0
+      );
+      expect(script).to.equal(SQUIGGLE_SCRIPT);
+
+      const scriptAddress =
+        await this.genArt721Core.projectScriptBytecodeAddressByIndex(
+          this.projectZero,
+          0
+        );
+
+      const scriptByteCode = await ethers.provider.getCode(scriptAddress);
+      expect(scriptByteCode).to.not.equal("0x");
+
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .removeProjectLastScript(this.projectZero);
+      const removedScript = await this.genArt721Core.projectScriptByIndex(
+        this.projectZero,
+        0
+      );
+      expect(removedScript).to.equal("");
+
+      const removedScriptByteCode = await ethers.provider.getCode(
+        scriptAddress
+      );
+      expect(removedScriptByteCode).to.equal("0x");
+    });
+
     it("uploads and recalls different script", async function () {
       await this.genArt721Core
         .connect(this.accounts.artist)

--- a/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
+++ b/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
@@ -930,6 +930,38 @@ describe("GenArt721CoreV3 Project Configure", async function () {
         "scriptId out of range"
       );
     });
+
+    it("bytecode contracts deployed and purged as expected in updates", async function () {
+      const originalScriptAddress =
+        await this.genArt721Core.projectScriptBytecodeAddressByIndex(
+          this.projectZero,
+          0
+        );
+
+      const scriptByteCode = await ethers.provider.getCode(
+        originalScriptAddress
+      );
+      expect(scriptByteCode).to.not.equal("0x");
+
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .updateProjectScript(this.projectZero, 0, "// script 0.1");
+
+      const oldAddressByteCode = await ethers.provider.getCode(
+        originalScriptAddress
+      );
+      expect(oldAddressByteCode).to.equal("0x");
+
+      const newScriptAddress =
+        await this.genArt721Core.projectScriptBytecodeAddressByIndex(
+          this.projectZero,
+          0
+        );
+      const newScriptByteCode = await ethers.provider.getCode(newScriptAddress);
+      expect(newScriptByteCode).to.not.equal("0x");
+      expect(newScriptByteCode).to.not.equal(scriptByteCode);
+      expect(newScriptByteCode).to.not.equal(oldAddressByteCode);
+    });
   });
 
   describe("removeProjectLastScript", function () {


### PR DESCRIPTION
Co-authored w/ @ryley-o, this PR builds off of #299 (incorporating #306) in order to support the ability to purge from blockchain state bytecode storage contracts deployed by the `BytecodeStorage.sol` class introduced in #299 when they are no longer used.

This is done by using triggering the deployed bytecode contract to itself call [`SELFDESTRUCT`](https://www.evm.codes/#ff) op-code, which will self-delete the bytecode storage contract and remove it entirely from blockchain state. This is beneficial from the perspective of being responsible custodians of EVM state bloat.

Note: this functionality of executing [`SELFDESTRUCT`](https://www.evm.codes/#ff) is being added in such a way that it is gated to only be call-able by the contract that deployed the bytecode storage contract, any other caller who attempts to trigger this logic by direct interaction with the bytecode storage contract will have their call reverted with the [`INVALID`](https://www.evm.codes/#fe) op-code.A

Unit tests have been added that cover the functionality here to cover: a) the delete-script flow, b) the update-script flow, and c) the attempt of directly triggering [`SELFDESTRUCT`](https://www.evm.codes/#ff) via a non-deployer address (which is not possible). 