### PR TITLE
BytecodeStorage - Require intentional selfdestruct

### DIFF
--- a/contracts/libs/0.8.x/BytecodeStorage.sol
+++ b/contracts/libs/0.8.x/BytecodeStorage.sol
@@ -26,11 +26,11 @@ library BytecodeStorage {
     //---------------------------------------------------------------------------------------------------------------//
     // Offset Amount | Offset Aggregate | Description                                                                //
     //---------------------------------------------------------------------------------------------------------------//
-    // 27            | 27               | allow contract to be `selfdestruct`-able via gated-cleanup-logic           //
-    // 20            | 47               | reserve 20 bytes for storing deploying-contract's address                  //
+    // 53            | 53               | allow contract to be `selfdestruct`-able via gated-cleanup-logic           //
+    // 20            | 73               | reserve 20 bytes for storing deploying-contract's address                  //
     //---------------------------------------------------------------------------------------------------------------//
     // define the offset for where the "logic bytes" end, and the "data bytes" begin
-    uint256 internal constant DATA_OFFSET = 47;
+    uint256 internal constant DATA_OFFSET = 73;
 
     /*//////////////////////////////////////////////////////////////
                            WRITE LOGIC
@@ -50,6 +50,8 @@ library BytecodeStorage {
             //---------------------------------------------------------------------------------------------------------------//
             // Opcode  | Opcode + Arguments  | Description  | Stack View                                                     //
             //---------------------------------------------------------------------------------------------------------------//
+            // (0) creation code returns all code in the contract except for the first 11 (0B in hex) bytes
+            //---------------------------------------------------------------------------------------------------------------//
             // 0x60    |  0x60_0B            | PUSH1 11     | codeOffset                                                     //
             // 0x59    |  0x59               | MSIZE        | 0 codeOffset                                                   //
             // 0x81    |  0x81               | DUP2         | codeOffset 0 codeOffset                                        //
@@ -61,16 +63,15 @@ library BytecodeStorage {
             // 0x39    |  0x39               | CODECOPY     | 0 (codeSize - codeOffset)                                      //
             // 0xf3    |  0xf3               | RETURN       |                                                                //
             //---------------------------------------------------------------------------------------------------------------//
-            // returns all code in the contract except for the first 11 (0B in hex) bytes
             hex"60_0B_59_81_38_03_80_92_59_39_F3",
             //---------------------------------------------------------------------------------------------------------------//
             // Opcode  | Opcode + Arguments  | Description  | Stack View                                                     //
             //---------------------------------------------------------------------------------------------------------------//
-            // (1) conditional logic for determing purge-gate (only the bytecode contract deployer can `selfdestruct`)
+            // (1a) conditional logic for determing purge-gate (only the bytecode contract deployer can `selfdestruct`)
             //---------------------------------------------------------------------------------------------------------------//
             // 0x60    |  0x60_14            | PUSH1 20     | 20                                                             //
-            // 0x60    |  0x60_1B            | PUSH1 27 (*) | contractOffset 20                                              //
-            // 0x60    |  0x60_0C            | PUSH1 12     | 12 contractOffset 20                                            //
+            // 0x60    |  0x60_35            | PUSH1 53 (*) | contractOffset 20                                              //
+            // 0x60    |  0x60_0C            | PUSH1 12     | 12 contractOffset 20                                           //
             // 0x39    |  0x39               | CODECOPY     |                                                                //
             // 0x33    |  0x33               | CALLER       | msg.sender                                                     //
             // 0x60    |  0x60_20            | PUSH1 32     | 32 msg.sender                                                  //
@@ -80,39 +81,65 @@ library BytecodeStorage {
             // 0x60    |  0x60_20            | PUSH1 32     | 32 byteDeployerAddress                                         //
             // 0x51    |  0x51               | MLOAD        | msg.sender byteDeployerAddress                                 //
             // 0x14    |  0x14               | EQ           | (msg.sender == byteDeployerAddress)                            //
+            hex"60_14_60_35_60_0C_39_33_60_20_52_60_00_51_60_20_51_14",
             //---------------------------------------------------------------------------------------------------------------//
-            // (2) load up the destination jump address for `selfdestruct` logic
+            // (1b) load up the destination jump address for `(2a) calldata length check` logic, jump or raise `invalid` op-code
             //---------------------------------------------------------------------------------------------------------------//
             // 0x60    |  0x60_16            | PUSH1 22 (^) | jumpDestination (msg.sender == byteDeployerAddress)            //
-            //---------------------------------------------------------------------------------------------------------------//
-            // (3) jump if the conditional logic above succeeds, otherwise revert with `invalid` op-code
-            //---------------------------------------------------------------------------------------------------------------//
             // 0x57    |  0x57               | JUMPI        |                                                                //
             // 0xFE    |  0xFE               | INVALID      |                                                                //
+            hex"60_16_57_FE",
+            //---------------------------------------------------------------------------------------------------------------//
+            // (2a) conditional logic for determing purge-gate (only if calldata length is 1 byte)
+            //---------------------------------------------------------------------------------------------------------------//
+            // 0x5B    |  0x5B               | JUMPDEST (22)|                                                                //
+            // 0x60    |  0x60_01            | PUSH1 1      | 1                                                              //
+            // 0x36    |  0x36               | CALLDATASIZE | calldataSize 1                                                 //
+            // 0x14    |  0x14               | EQ           | (calldataSize == 1)                                            //
+            hex"5B_60_01_36_14",
+            //---------------------------------------------------------------------------------------------------------------//
+            // (2b) load up the destination jump address for `(3a) calldata value check` logic, jump or raise `invalid` op-code
+            //---------------------------------------------------------------------------------------------------------------//
+            // 0x60    |  0x60_1F            | PUSH1 31 (^) | jumpDestination (calldataSize == 1)                            //
+            // 0x57    |  0x57               | JUMPI        |                                                                //
+            // 0xFE    |  0xFE               | INVALID      |                                                                //
+            hex"60_1F_57_FE",
+            //---------------------------------------------------------------------------------------------------------------//
+            // (3a) conditional logic for determing purge-gate (only if calldata is `0xFF`)
+            //---------------------------------------------------------------------------------------------------------------//
+            // 0x5B    |  0x5B               | JUMPDEST (31)|                                                                //
+            // 0x60    |  0x60_FF            | PUSH1 0xFF   | 0xFF                                                           //
+            // 0x60    |  0x60_41            | PUSH1 65     | (64+1) 0xFF                                                    //
+            // 0x52    |  0x52               | MSTORE       |                                                                //
+            // 0x60    |  0x60_00            | PUSH1 0      | 0                                                              //
+            // 0x35    |  0x35               | CALLDATALOAD | calldata                                                       //
+            // 0x60    |  0x60_60            | PUSH1 96     | 96 calldata                                                    //
+            // 0x51    |  0x51               | MLOAD        | 0xFF00...00 calldata                                           //
+            // 0x14    |  0x14               | EQ           | (0xFF00...00 == calldata)                                      //
+            hex"5B_60_FF_60_41_52_60_00_35_60_60_51_14",
+            //---------------------------------------------------------------------------------------------------------------//
+            // (3b) load up the destination jump address for actual purging (4), jump or raise `invalid` op-code
+            //---------------------------------------------------------------------------------------------------------------//
+            // 0x60    |  0x60_30            | PUSH1 48 (^) | jumpDestination (0xFF00...00 == calldata)                      //
+            // 0x57    |  0x57               | JUMPI        |                                                                //
+            // 0xFE    |  0xFE               | INVALID      |                                                                //
+            hex"60_30_57_FE",
+            //---------------------------------------------------------------------------------------------------------------//
             //---------------------------------------------------------------------------------------------------------------//
             // (4) perform actual purging
             //---------------------------------------------------------------------------------------------------------------//
-            // 0x5B    |  0x5B               | JUMPDEST     |                                                                //
+            // 0x5B    |  0x5B               | JUMPDEST (48)|                                                                //
             // 0x60    |  0x60_00            | PUSH1 0      | 0                                                              //
             // 0x51    |  0x51               | MLOAD        | byteDeployerAddress                                            //
             // 0xFF    |  0xFF               | SELFDESTRUCT |                                                                //
+            hex"5B_60_00_51_FF",
             //---------------------------------------------------------------------------------------------------------------//
             // (*) Note: this value must be adjusted if selfdestruct purge logic is adjusted, to refer to the correct start  //
             //           offset for where the `msg.sender` address was stored in deplyed bytecode.                           //
             //                                                                                                               //
-            // (^) Note: this value must be adjusted if selfdestruct purge logic is adjusted, to refer to the purge logic    //
-            //           entry point jump desination.                                                                        //
+            // (^) Note: this value must be adjusted if portions of the selfdestruct purge logic are adjusted.               //
             //---------------------------------------------------------------------------------------------------------------//
-            // allow contract to be `selfdestruct`-able for cleanup purposes, gated to deploying-contract's address
             //
-            // (1) conditional logic for determing purge-gate (only the bytecode contract deployer can `selfdestruct`)
-            hex"60_14_60_1B_60_0C_39_33_60_20_52_60_00_51_60_20_51_14",
-            // (2) load up the destination jump address for `selfdestruct` logic
-            hex"60_16",
-            // (3) jump if the conditional logic above succeeds, otherwise revert with `invalid` op-code
-            hex"57_FE",
-            // (4) perform actual purging
-            hex"5B_60_00_51_FF",
             // store the deploying-contract's address (to be used to gate and call `selfdestruct`)
             //
             // note: it is important that this address is the executing contract's address
@@ -192,8 +219,10 @@ library BytecodeStorage {
     /**
      * @notice Purge contract bytecode for cleanup purposes
      * @param _address address of deployed contract with bytecode containing concat(gated-cleanup-logic, data)
-     * @dev This method is only callable by the address of the contract that originally deployed the bytecode
+     * @dev This contract is only callable by the address of the contract that originally deployed the bytecode
      *      being purged. If this method is called by any other address, it will revert with the `INVALID` op-code.
+     *      Additionally, for security purposes, the contract must be called with calldata `0xFF` to ensure that
+     *      the `selfdestruct` op-code is intentionally being invoked, otherwise the `INVALID` op-code will be raised.
      */
     function purgeBytecode(address _address) internal {
         // deployed bytecode (above) handles all logic for purging state, so no
@@ -201,7 +230,7 @@ library BytecodeStorage {
         (
             bool success, /*` data` not needed */
 
-        ) = _address.call("");
+        ) = _address.call(hex"FF");
         if (!success) {
             revert();
         }

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExp.common.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExp.common.ts
@@ -32,7 +32,6 @@ export const MinterDAExp_Common = async () => {
       await expectRevert(
         this.minter.connect(this.accounts.user).purchase(this.projectZero, {
           value: this.startingPrice.toString(),
-          gasPrice: 0,
         }),
         "Auction not yet started"
       );
@@ -51,6 +50,9 @@ export const MinterDAExp_Common = async () => {
             this.auctionStartTimeOffset +
             i * this.defaultHalfLife,
         ]);
+        await ethers.provider.send("hardhat_setNextBlockBaseFeePerGas", [
+          "0x0",
+        ]);
         await this.minter
           .connect(this.accounts.user)
           .purchase(this.projectZero, {
@@ -58,7 +60,9 @@ export const MinterDAExp_Common = async () => {
             gasPrice: 0,
           });
         // Test that price isn't too low
-
+        await ethers.provider.send("hardhat_setNextBlockBaseFeePerGas", [
+          "0x0",
+        ]);
         await expectRevert(
           this.minter.connect(this.accounts.user).purchase(this.projectZero, {
             value: ((price.toBigInt() * BigInt(100)) / BigInt(101)).toString(),

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALin.common.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALin.common.ts
@@ -32,7 +32,6 @@ export const MinterDALin_Common = async () => {
       await expectRevert(
         this.minter.connect(this.accounts.user).purchase(this.projectZero, {
           value: this.startingPrice.toString(),
-          gasPrice: 0,
         }),
         "Auction not yet started"
       );
@@ -58,6 +57,9 @@ export const MinterDALin_Common = async () => {
         await ethers.provider.send("evm_mine", [
           this.startTime + this.auctionStartTimeOffset + i * step,
         ]);
+        await ethers.provider.send("hardhat_setNextBlockBaseFeePerGas", [
+          "0x0",
+        ]);
         await this.minter
           .connect(this.accounts.user)
           .purchase(this.projectZero, {
@@ -65,7 +67,9 @@ export const MinterDALin_Common = async () => {
             gasPrice: 0,
           });
         // Test that price isn't too low
-
+        await ethers.provider.send("hardhat_setNextBlockBaseFeePerGas", [
+          "0x0",
+        ]);
         await expectRevert(
           this.minter.connect(this.accounts.user).purchase(this.projectZero, {
             value: ((price.toBigInt() * BigInt(100)) / BigInt(101)).toString(),


### PR DESCRIPTION
Update BytecodeStorage.sol to only selfdestruct if deploying address calls with calldata equal to `0xFF`.

This is a security improvement because the deployed bytecode storage contracts must intentionally be called with specific calldata to invoke a selfdestruct. Without this added logic, if the deployed bytecode were to send funds to a deployed bytecode storage contract, the bytecode storage contract would selfdestruct.

Note that this does not patch any existing hole in the Art Blocks GenArt721CoreV3 contract security model, but it is intended to help encourage security best practices across the Ethereum developer community.