### PR TITLE
QSP-6 - Mitigated, local minter max invocation cache docs

### DIFF
--- a/contracts/minter-suite/Minters/MinterDAExp/MinterDAExpV2.sol
+++ b/contracts/minter-suite/Minters/MinterDAExp/MinterDAExpV2.sol
@@ -180,7 +180,15 @@ contract MinterDAExpV2 is ReentrancyGuard, IFilteredMinterV0 {
 
     /**
      * @notice projectId => has project reached its maximum number of
-     * invocations?
+     * invocations? Note that this returns a local cache of the core contract's
+     * state, and may be out of sync with the core contract. This is
+     * intentional, as it only enables gas optimization of mints after a
+     * project's maximum invocations has been reached. A false negative will
+     * only result in a gas cost increase, since the core contract will still
+     * enforce a maxInvocation check during minting. A false positive is not
+     * possible because the V3 core contract only allows maximum invocations
+     * to be reduced, not increased.
+     *
      */
     function projectMaxHasBeenInvoked(uint256 _projectId)
         external
@@ -193,8 +201,18 @@ contract MinterDAExpV2 is ReentrancyGuard, IFilteredMinterV0 {
     /**
      * @notice projectId => project's maximum number of invocations.
      * Optionally synced with core contract value, for gas optimization.
-     * @dev this value my be out-of-sync with the core contract's value, and is
-     * used for gas-minimization of failed mint transactions only.
+     * Note that this returns a local cache of the core contract's
+     * state, and may be out of sync with the core contract. This is
+     * intentional, as it only enables gas optimization of mints after a
+     * project's maximum invocations has been reached.
+     * @dev A number greater than the core contract's project max invocations
+     * will only result in a gas cost increase, since the core contract will
+     * still enforce a maxInvocation check during minting. A number less than
+     * the core contract's project max invocations is only possible when the
+     * project's max invocations have not been synced on this minter, since the
+     * V3 core contract only allows maximum invocations to be reduced, not
+     * increased. When this happens, the minter will enable minting, allowing
+     * the core contract to enforce the max invocations check.
      */
     function projectMaxInvocations(uint256 _projectId)
         external
@@ -386,6 +404,13 @@ contract MinterDAExpV2 is ReentrancyGuard, IFilteredMinterV0 {
     {
         // CHECKS
         ProjectConfig storage _projectConfig = projectConfig[_projectId];
+
+        // Note that `maxHasBeenInvoked` is only checked here to reduce gas
+        // consumption after a project has been fully minted.
+        // `_projectConfig.maxHasBeenInvoked` is locally cached to reduce
+        // gas consumption, but if not in sync with the core contract's value,
+        // the core contract also enforces its own max invocation check during
+        // minting.
         require(
             !_projectConfig.maxHasBeenInvoked,
             "Maximum number of invocations reached"

--- a/contracts/minter-suite/Minters/MinterDALin/MinterDALinV2.sol
+++ b/contracts/minter-suite/Minters/MinterDALin/MinterDALinV2.sol
@@ -175,7 +175,14 @@ contract MinterDALinV2 is ReentrancyGuard, IFilteredMinterV0 {
 
     /**
      * @notice projectId => has project reached its maximum number of
-     * invocations?
+     * invocations? Note that this returns a local cache of the core contract's
+     * state, and may be out of sync with the core contract. This is
+     * intentional, as it only enables gas optimization of mints after a
+     * project's maximum invocations has been reached. A false negative will
+     * only result in a gas cost increase, since the core contract will still
+     * enforce a maxInvocation check during minting. A false positive is not
+     * possible because the V3 core contract only allows maximum invocations
+     * to be reduced, not increased.
      */
     function projectMaxHasBeenInvoked(uint256 _projectId)
         external
@@ -188,8 +195,18 @@ contract MinterDALinV2 is ReentrancyGuard, IFilteredMinterV0 {
     /**
      * @notice projectId => project's maximum number of invocations.
      * Optionally synced with core contract value, for gas optimization.
-     * @dev this value my be out-of-sync with the core contract's value, and is
-     * used for gas-minimization of failed mint transactions only.
+     * Note that this returns a local cache of the core contract's
+     * state, and may be out of sync with the core contract. This is
+     * intentional, as it only enables gas optimization of mints after a
+     * project's maximum invocations has been reached.
+     * @dev A number greater than the core contract's project max invocations
+     * will only result in a gas cost increase, since the core contract will
+     * still enforce a maxInvocation check during minting. A number less than
+     * the core contract's project max invocations is only possible when the
+     * project's max invocations have not been synced on this minter, since the
+     * V3 core contract only allows maximum invocations to be reduced, not
+     * increased. When this happens, the minter will enable minting, allowing
+     * the core contract to enforce the max invocations check.
      */
     function projectMaxInvocations(uint256 _projectId)
         external
@@ -359,6 +376,13 @@ contract MinterDALinV2 is ReentrancyGuard, IFilteredMinterV0 {
     {
         // CHECKS
         ProjectConfig storage _projectConfig = projectConfig[_projectId];
+
+        // Note that `maxHasBeenInvoked` is only checked here to reduce gas
+        // consumption after a project has been fully minted.
+        // `_projectConfig.maxHasBeenInvoked` is locally cached to reduce
+        // gas consumption, but if not in sync with the core contract's value,
+        // the core contract also enforces its own max invocation check during
+        // minting.
         require(
             !_projectConfig.maxHasBeenInvoked,
             "Maximum number of invocations reached"

--- a/contracts/minter-suite/Minters/MinterHolder/MinterHolderV1.sol
+++ b/contracts/minter-suite/Minters/MinterHolder/MinterHolderV1.sol
@@ -376,7 +376,14 @@ contract MinterHolderV1 is ReentrancyGuard, IFilteredMinterHolderV0 {
 
     /**
      * @notice projectId => has project reached its maximum number of
-     * invocations?
+     * invocations? Note that this returns a local cache of the core contract's
+     * state, and may be out of sync with the core contract. This is
+     * intentional, as it only enables gas optimization of mints after a
+     * project's maximum invocations has been reached. A false negative will
+     * only result in a gas cost increase, since the core contract will still
+     * enforce a maxInvocation check during minting. A false positive is not
+     * possible because the V3 core contract only allows maximum invocations
+     * to be reduced, not increased.
      */
     function projectMaxHasBeenInvoked(uint256 _projectId)
         external
@@ -389,8 +396,18 @@ contract MinterHolderV1 is ReentrancyGuard, IFilteredMinterHolderV0 {
     /**
      * @notice projectId => project's maximum number of invocations.
      * Optionally synced with core contract value, for gas optimization.
-     * @dev this value my be out-of-sync with the core contract's value, and is
-     * used for gas-minimization of failed mint transactions only.
+     * Note that this returns a local cache of the core contract's
+     * state, and may be out of sync with the core contract. This is
+     * intentional, as it only enables gas optimization of mints after a
+     * project's maximum invocations has been reached.
+     * @dev A number greater than the core contract's project max invocations
+     * will only result in a gas cost increase, since the core contract will
+     * still enforce a maxInvocation check during minting. A number less than
+     * the core contract's project max invocations is only possible when the
+     * project's max invocations have not been synced on this minter, since the
+     * V3 core contract only allows maximum invocations to be reduced, not
+     * increased. When this happens, the minter will enable minting, allowing
+     * the core contract to enforce the max invocations check.
      */
     function projectMaxInvocations(uint256 _projectId)
         external
@@ -500,6 +517,13 @@ contract MinterHolderV1 is ReentrancyGuard, IFilteredMinterHolderV0 {
     ) public payable nonReentrant returns (uint256 tokenId) {
         // CHECKS
         ProjectConfig storage _projectConfig = projectConfig[_projectId];
+
+        // Note that `maxHasBeenInvoked` is only checked here to reduce gas
+        // consumption after a project has been fully minted.
+        // `_projectConfig.maxHasBeenInvoked` is locally cached to reduce
+        // gas consumption, but if not in sync with the core contract's value,
+        // the core contract also enforces its own max invocation check during
+        // minting.
         require(
             !_projectConfig.maxHasBeenInvoked,
             "Maximum number of invocations reached"

--- a/contracts/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
+++ b/contracts/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
@@ -118,7 +118,14 @@ contract MinterSetPriceV2 is ReentrancyGuard, IFilteredMinterV0 {
 
     /**
      * @notice projectId => has project reached its maximum number of
-     * invocations?
+     * invocations? Note that this returns a local cache of the core contract's
+     * state, and may be out of sync with the core contract. This is
+     * intentional, as it only enables gas optimization of mints after a
+     * project's maximum invocations has been reached. A false negative will
+     * only result in a gas cost increase, since the core contract will still
+     * enforce a maxInvocation check during minting. A false positive is not
+     * possible because the V3 core contract only allows maximum invocations
+     * to be reduced, not increased.
      */
     function projectMaxHasBeenInvoked(uint256 _projectId)
         external
@@ -131,8 +138,18 @@ contract MinterSetPriceV2 is ReentrancyGuard, IFilteredMinterV0 {
     /**
      * @notice projectId => project's maximum number of invocations.
      * Optionally synced with core contract value, for gas optimization.
-     * @dev this value my be out-of-sync with the core contract's value, and is
-     * used for gas-minimization of failed mint transactions only.
+     * Note that this returns a local cache of the core contract's
+     * state, and may be out of sync with the core contract. This is
+     * intentional, as it only enables gas optimization of mints after a
+     * project's maximum invocations has been reached.
+     * @dev A number greater than the core contract's project max invocations
+     * will only result in a gas cost increase, since the core contract will
+     * still enforce a maxInvocation check during minting. A number less than
+     * the core contract's project max invocations is only possible when the
+     * project's max invocations have not been synced on this minter, since the
+     * V3 core contract only allows maximum invocations to be reduced, not
+     * increased. When this happens, the minter will enable minting, allowing
+     * the core contract to enforce the max invocations check.
      */
     function projectMaxInvocations(uint256 _projectId)
         external
@@ -209,6 +226,13 @@ contract MinterSetPriceV2 is ReentrancyGuard, IFilteredMinterV0 {
     {
         // CHECKS
         ProjectConfig storage _projectConfig = projectConfig[_projectId];
+
+        // Note that `maxHasBeenInvoked` is only checked here to reduce gas
+        // consumption after a project has been fully minted.
+        // `_projectConfig.maxHasBeenInvoked` is locally cached to reduce
+        // gas consumption, but if not in sync with the core contract's value,
+        // the core contract also enforces its own max invocation check during
+        // minting.
         require(
             !_projectConfig.maxHasBeenInvoked,
             "Maximum number of invocations reached"

--- a/contracts/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V2.sol
+++ b/contracts/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V2.sol
@@ -164,7 +164,14 @@ contract MinterSetPriceERC20V2 is ReentrancyGuard, IFilteredMinterV0 {
 
     /**
      * @notice projectId => has project reached its maximum number of
-     * invocations?
+     * invocations? Note that this returns a local cache of the core contract's
+     * state, and may be out of sync with the core contract. This is
+     * intentional, as it only enables gas optimization of mints after a
+     * project's maximum invocations has been reached. A false negative will
+     * only result in a gas cost increase, since the core contract will still
+     * enforce a maxInvocation check during minting. A false positive is not
+     * possible because the V3 core contract only allows maximum invocations
+     * to be reduced, not increased.
      */
     function projectMaxHasBeenInvoked(uint256 _projectId)
         external
@@ -177,8 +184,18 @@ contract MinterSetPriceERC20V2 is ReentrancyGuard, IFilteredMinterV0 {
     /**
      * @notice projectId => project's maximum number of invocations.
      * Optionally synced with core contract value, for gas optimization.
-     * @dev this value my be out-of-sync with the core contract's value, and is
-     * used for gas-minimization of failed mint transactions only.
+     * Note that this returns a local cache of the core contract's
+     * state, and may be out of sync with the core contract. This is
+     * intentional, as it only enables gas optimization of mints after a
+     * project's maximum invocations has been reached.
+     * @dev A number greater than the core contract's project max invocations
+     * will only result in a gas cost increase, since the core contract will
+     * still enforce a maxInvocation check during minting. A number less than
+     * the core contract's project max invocations is only possible when the
+     * project's max invocations have not been synced on this minter, since the
+     * V3 core contract only allows maximum invocations to be reduced, not
+     * increased. When this happens, the minter will enable minting, allowing
+     * the core contract to enforce the max invocations check.
      */
     function projectMaxInvocations(uint256 _projectId)
         external
@@ -282,6 +299,13 @@ contract MinterSetPriceERC20V2 is ReentrancyGuard, IFilteredMinterV0 {
     {
         // CHECKS
         ProjectConfig storage _projectConfig = projectConfig[_projectId];
+
+        // Note that `maxHasBeenInvoked` is only checked here to reduce gas
+        // consumption after a project has been fully minted.
+        // `_projectConfig.maxHasBeenInvoked` is locally cached to reduce
+        // gas consumption, but if not in sync with the core contract's value,
+        // the core contract also enforces its own max invocation check during
+        // minting.
         require(
             !_projectConfig.maxHasBeenInvoked,
             "Maximum number of invocations reached"


### PR DESCRIPTION
Update minter natspec comments to clarify local project max invocations is intentional.

## Audit
Response to QSP-6 - For minters, see changes to `MinterDAExpV2.sol` and `MinterMerkleV1.sol` minters only.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203034890733936