### PR TITLE
QSP-10 - Fixed - expanded input validation. 

### DIFF
--- a/.github/workflows/do-not-merge.yml
+++ b/.github/workflows/do-not-merge.yml
@@ -1,0 +1,13 @@
+name: Do Not Merge
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v2
+        with:
+          mode: exactly
+          count: 0
+          labels: 'do not merge'

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -463,6 +463,7 @@ contract GenArt721CoreV3 is
     )
         external
         onlyAdminACL(this.updateArtblocksSecondarySalesAddress.selector)
+        onlyNonZeroAddress(_artblocksSecondarySalesAddress)
     {
         _updateArtblocksSecondarySalesAddress(_artblocksSecondarySalesAddress);
     }

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -1632,9 +1632,9 @@ contract GenArt721CoreV3 is
 
     /**
      * @notice Updates Art Blocks payment address to `_artblocksPrimarySalesAddress`.
-     * @dev Note that this message does not check that the input address is
-     * not `address(0)` as it is expected that callers of this method should
-     * perform input validation.
+     * @dev Note that this method does not check that the input address is
+     * not `address(0)`, as it is expected that callers of this method should
+     * perform input validation where applicable.
      */
     function _updateArtblocksPrimarySalesAddress(
         address _artblocksPrimarySalesAddress
@@ -1646,9 +1646,9 @@ contract GenArt721CoreV3 is
     /**
      * @notice Updates Art Blocks secondary sales royalty payment address to
      * `_artblocksSecondarySalesAddress`.
-     * @dev Note that this message does not check that the input address is
-     * not `address(0)` as it is expected that callers of this method should
-     * perform input validation.
+     * @dev Note that this method does not check that the input address is
+     * not `address(0)`, as it is expected that callers of this method should
+     * perform input validation where applicable.
      */
     function _updateArtblocksSecondarySalesAddress(
         address _artblocksSecondarySalesAddress
@@ -1661,9 +1661,9 @@ contract GenArt721CoreV3 is
 
     /**
      * @notice Updates randomizer address to `_randomizerAddress`.
-     * @dev Note that this message does not check that the input address is
-     * not `address(0)` as it is expected that callers of this method should
-     * perform input validation.
+     * @dev Note that this method does not check that the input address is
+     * not `address(0)`, as it is expected that callers of this method should
+     * perform input validation where applicable.
      */
     function _updateRandomizerAddress(address _randomizerAddress) internal {
         randomizerContract = IRandomizerV2(_randomizerAddress);

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -446,7 +446,11 @@ contract GenArt721CoreV3 is
      */
     function updateArtblocksPrimarySalesAddress(
         address payable _artblocksPrimarySalesAddress
-    ) external onlyAdminACL(this.updateArtblocksPrimarySalesAddress.selector) {
+    )
+        external
+        onlyAdminACL(this.updateArtblocksPrimarySalesAddress.selector)
+        onlyNonZeroAddress(_artblocksPrimarySalesAddress)
+    {
         _updateArtblocksPrimarySalesAddress(_artblocksPrimarySalesAddress);
     }
 

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -1676,6 +1676,9 @@ contract GenArt721CoreV3 is
      * @notice Updates default base URI to `_defaultBaseURI`.
      * When new projects are added, their `projectBaseURI` is automatically
      * initialized to `_defaultBaseURI`.
+     * @dev Note that this method does not check that the input string is not
+     * the empty string, as it is expected that callers of this method should
+     * perform input validation where applicable.
      */
     function _updateDefaultBaseURI(string memory _defaultBaseURI) internal {
         defaultBaseURI = _defaultBaseURI;

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -508,6 +508,7 @@ contract GenArt721CoreV3 is
     function updateMinterContract(address _address)
         external
         onlyAdminACL(this.updateMinterContract.selector)
+        onlyNonZeroAddress(_address)
     {
         minterContract = _address;
         emit MinterUpdated(_address);

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -856,6 +856,7 @@ contract GenArt721CoreV3 is
         external
         onlyUnlocked(_projectId)
         onlyArtistOrAdminACL(_projectId, this.updateProjectLicense.selector)
+        onlyNonEmptyString(_projectLicense)
     {
         projects[_projectId].license = _projectLicense;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_LICENSE);

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -688,7 +688,15 @@ contract GenArt721CoreV3 is
     function updateProjectArtistAddress(
         uint256 _projectId,
         address payable _artistAddress
-    ) external onlyAdminACL(this.updateProjectArtistAddress.selector) {
+    )
+        external
+        onlyValidProjectId(_projectId)
+        onlyAdminACLOrRenouncedArtist(
+            _projectID,
+            this.updateProjectArtistAddress.selector
+        )
+        onlyNonZeroAddress(_artistAddress)
+    {
         projectIdToFinancials[_projectId].artistAddress = _artistAddress;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_ARTIST_ADDRESS);
     }

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -925,6 +925,7 @@ contract GenArt721CoreV3 is
         external
         onlyUnlocked(_projectId)
         onlyArtistOrAdminACL(_projectId, this.updateProjectScript.selector)
+        onlyNonEmptyString(_script)
     {
         Project storage project = projects[_projectId];
         require(_scriptId < project.scriptCount, "scriptId out of range");

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -431,7 +431,7 @@ contract GenArt721CoreV3 is
             ownerAndHashSeed.hashSeed == bytes12(0),
             "Token hash already set"
         );
-        require(_hashSeed != bytes12(0), "No seed re-setting");
+        require(_hashSeed != bytes12(0), "No zero hash seed");
         ownerAndHashSeed.hashSeed = bytes12(_hashSeed);
     }
 

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -1037,16 +1037,19 @@ contract GenArt721CoreV3 is
         uint256 bytesLength = aspectRatioBytes.length;
         require(bytesLength <= 11, "Aspect ratio format too long");
         bool hasSeenDecimalSeparator = false;
+        bool hasSeenNumber = false;
         for (uint256 i; i < bytesLength; i++) {
             bytes1 character = aspectRatioBytes[i];
             // Allow as many #s as desired.
             if (character >= 0x30 && character <= 0x39) {
                 // 9-0
+                // We need to ensure there is at least 1 `9-0` occurrence.
+                hasSeenNumber = true;
                 continue;
             }
             if (character == 0x2E) {
                 // .
-                // Allow no more than 1 `.` occurance.
+                // Allow no more than 1 `.` occurrence.
                 if (!hasSeenDecimalSeparator) {
                     hasSeenDecimalSeparator = true;
                     continue;
@@ -1054,6 +1057,7 @@ contract GenArt721CoreV3 is
             }
             revert("Improperly formatted aspect ratio");
         }
+        require(hasSeenNumber, "Aspect ratio has no numbers");
 
         projects[_projectId].aspectRatio = _aspectRatio;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_ASPECT_RATIO);

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -229,6 +229,11 @@ contract GenArt721CoreV3 is
         _;
     }
 
+    modifier onlyValidProjectId(uint256 _projectId) {
+        require(_projectId < _nextProjectId, "Project ID does not exist");
+        _;
+    }
+
     modifier onlyUnlocked(uint256 _projectId) {
         require(_projectUnlocked(_projectId), "Only if unlocked");
         _;
@@ -531,6 +536,7 @@ contract GenArt721CoreV3 is
     function toggleProjectIsActive(uint256 _projectId)
         external
         onlyAdminACL(this.toggleProjectIsActive.selector)
+        onlyValidProjectId(_projectId)
     {
         projects[_projectId].active = !projects[_projectId].active;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_ACTIVE);

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -560,6 +560,9 @@ contract GenArt721CoreV3 is
      * @param _additionalPayeeSecondarySalesPercentage Percent of artist's portion
      * of secondary sale royalties that will be split to address
      * `_additionalPayeeSecondarySales`.
+     * @dev `_artistAddress` must be a valid address (non-zero-address), but it
+     * is intentionally allowable for `_additionalPayee{Primary,Secondaary}Sales`
+     * and their associated percentages to be zero'd out by the controlling artist.
      */
     function proposeArtistPaymentAddressesAndSplits(
         uint256 _projectId,
@@ -568,7 +571,12 @@ contract GenArt721CoreV3 is
         uint256 _additionalPayeePrimarySalesPercentage,
         address payable _additionalPayeeSecondarySales,
         uint256 _additionalPayeeSecondarySalesPercentage
-    ) external onlyArtist(_projectId) {
+    )
+        external
+        onlyValidProjectId(_projectId)
+        onlyArtist(_projectId)
+        onlyNonZeroAddress(_artistAddress)
+    {
         // checks
         require(
             _additionalPayeePrimarySalesPercentage <= 100 &&

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -404,6 +404,7 @@ contract GenArt721CoreV3 is
             ownerAndHashSeed.hashSeed == bytes12(0),
             "Token hash already set"
         );
+        require(_hashSeed != bytes12(0), "No seed re-setting");
         ownerAndHashSeed.hashSeed = bytes12(_hashSeed);
     }
 

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -520,6 +520,7 @@ contract GenArt721CoreV3 is
     function updateRandomizerAddress(address _randomizerAddress)
         external
         onlyAdminACL(this.updateRandomizerAddress.selector)
+        onlyNonZeroAddress(_randomizerAddress)
     {
         _updateRandomizerAddress(_randomizerAddress);
     }

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -780,6 +780,7 @@ contract GenArt721CoreV3 is
         external
         onlyUnlocked(_projectId)
         onlyArtistOrAdminACL(_projectId, this.updateProjectArtistName.selector)
+        onlyNonEmptyString(_projectArtistName)
     {
         projects[_projectId].artist = _projectArtistName;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_ARTIST_NAME);

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -89,6 +89,7 @@ contract GenArt721CoreV3 is
     uint24 constant ONE_MILLION_UINT24 = 1_000_000;
     uint256 constant FOUR_WEEKS_IN_SECONDS = 2_419_200;
     uint8 constant AT_CHARACTER_CODE = uint8(bytes1("@")); // 0x40
+    string constant NON_ZERO_ADDRESS_MSG = "Must use non-zero address";
 
     // generic platform event fields
     bytes32 constant FIELD_NEXT_PROJECT_ID = "nextProjectId";
@@ -419,7 +420,7 @@ contract GenArt721CoreV3 is
     {
         require(
             _artblocksCurationRegistryAddress != address(0),
-            "Must set registry to valid address"
+            NON_ZERO_ADDRESS_MSG
         );
         artblocksCurationRegistryAddress = _artblocksCurationRegistryAddress;
         emit PlatformUpdated(FIELD_ARTBLOCKS_CURATION_REGISTRY_ADDRESS);
@@ -435,8 +436,8 @@ contract GenArt721CoreV3 is
         onlyAdminACL(this.updateArtblocksDependencyRegistryAddress.selector)
     {
         require(
-            _artblocksCurationRegistryAddress != address(0),
-            "Must set registry to valid address"
+            _artblocksDependencyRegistryAddress != address(0),
+            NON_ZERO_ADDRESS_MSG
         );
         artblocksDependencyRegistryAddress = _artblocksDependencyRegistryAddress;
         emit PlatformUpdated(FIELD_ARTBLOCKS_DEPENDENCY_REGISTRY_ADDRESS);

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -244,6 +244,8 @@ contract GenArt721CoreV3 is
     }
 
     modifier onlyUnlocked(uint256 _projectId) {
+        // Note: calling `_projectUnlocked` enforces that the `_projectId`
+        //       passed in is valid.`
         require(_projectUnlocked(_projectId), "Only if unlocked");
         _;
     }
@@ -1744,6 +1746,7 @@ contract GenArt721CoreV3 is
      * Projects are considered completed when they have been invoked the
      * maximum number of times.
      * @param _projectId Project ID to check.
+     * @dev This also enforces that the `_projectId` passed in is valid.
      */
     function _projectUnlocked(uint256 _projectId)
         internal

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -903,6 +903,7 @@ contract GenArt721CoreV3 is
         external
         onlyUnlocked(_projectId)
         onlyArtistOrAdminACL(_projectId, this.addProjectScript.selector)
+        onlyNonEmptyString(_script)
     {
         Project storage project = projects[_projectId];
         project.scripts[project.scriptCount] = _script;

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -1643,6 +1643,9 @@ contract GenArt721CoreV3 is
     /**
      * @notice Updates Art Blocks secondary sales royalty payment address to
      * `_artblocksSecondarySalesAddress`.
+     * @dev Note that this message does not check that the input address is
+     * not `address(0)` as it is expected that callers of this method should
+     * perform input validation.
      */
     function _updateArtblocksSecondarySalesAddress(
         address _artblocksSecondarySalesAddress

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -1044,7 +1044,7 @@ contract GenArt721CoreV3 is
     function updateDefaultBaseURI(string memory _defaultBaseURI)
         external
         onlyAdminACL(this.updateDefaultBaseURI.selector)
-        onlyNonEmptyString(_newBaseURI)
+        onlyNonEmptyString(_defaultBaseURI)
     {
         _updateDefaultBaseURI(_defaultBaseURI);
     }

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -761,6 +761,7 @@ contract GenArt721CoreV3 is
      */
     function updateProjectName(uint256 _projectId, string memory _projectName)
         external
+        onlyValidProjectId(_projectId)
         onlyUnlocked(_projectId)
         onlyArtistOrAdminACL(_projectId, this.updateProjectName.selector)
         onlyNonEmptyString(_projectName)
@@ -778,6 +779,7 @@ contract GenArt721CoreV3 is
         string memory _projectArtistName
     )
         external
+        onlyValidProjectId(_projectId)
         onlyUnlocked(_projectId)
         onlyArtistOrAdminACL(_projectId, this.updateProjectArtistName.selector)
     {
@@ -852,6 +854,7 @@ contract GenArt721CoreV3 is
         string memory _projectLicense
     )
         external
+        onlyValidProjectId(_projectId)
         onlyUnlocked(_projectId)
         onlyArtistOrAdminACL(_projectId, this.updateProjectLicense.selector)
     {
@@ -898,6 +901,7 @@ contract GenArt721CoreV3 is
      */
     function addProjectScript(uint256 _projectId, string memory _script)
         external
+        onlyValidProjectId(_projectId)
         onlyUnlocked(_projectId)
         onlyArtistOrAdminACL(_projectId, this.addProjectScript.selector)
     {
@@ -919,6 +923,7 @@ contract GenArt721CoreV3 is
         string memory _script
     )
         external
+        onlyValidProjectId(_projectId)
         onlyUnlocked(_projectId)
         onlyArtistOrAdminACL(_projectId, this.updateProjectScript.selector)
     {
@@ -933,6 +938,7 @@ contract GenArt721CoreV3 is
      */
     function removeProjectLastScript(uint256 _projectId)
         external
+        onlyValidProjectId(_projectId)
         onlyUnlocked(_projectId)
         onlyArtistOrAdminACL(_projectId, this.removeProjectLastScript.selector)
     {
@@ -954,6 +960,7 @@ contract GenArt721CoreV3 is
         bytes32 _scriptTypeAndVersion
     )
         external
+        onlyValidProjectId(_projectId)
         onlyUnlocked(_projectId)
         onlyArtistOrAdminACL(_projectId, this.updateProjectScriptType.selector)
     {
@@ -981,6 +988,7 @@ contract GenArt721CoreV3 is
         string memory _aspectRatio
     )
         external
+        onlyValidProjectId(_projectId)
         onlyUnlocked(_projectId)
         onlyArtistOrAdminACL(_projectId, this.updateProjectAspectRatio.selector)
     {

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -1629,6 +1629,9 @@ contract GenArt721CoreV3 is
 
     /**
      * @notice Updates Art Blocks payment address to `_artblocksPrimarySalesAddress`.
+     * @dev Note that this message does not check that the input address is
+     * not `address(0)` as it is expected that callers of this method should
+     * perform input validation.
      */
     function _updateArtblocksPrimarySalesAddress(
         address _artblocksPrimarySalesAddress

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -625,6 +625,9 @@ contract GenArt721CoreV3 is
      * @dev this must be called by the Admin ACL contract, and must only accept
      * the most recent proposed values for a given project (validated on-chain
      * by comparing the hash of the proposed and accepted values).
+     * @dev `_artistAddress` must be a valid address (non-zero-address), but it
+     * is intentionally allowable for `_additionalPayee{Primary,Secondaary}Sales`
+     * and their associated percentages to be zero'd out by the controlling artist.
      */
     function adminAcceptArtistAddressesAndSplits(
         uint256 _projectId,
@@ -635,10 +638,12 @@ contract GenArt721CoreV3 is
         uint256 _additionalPayeeSecondarySalesPercentage
     )
         external
+        onlyValidProjectId(_projectId)
         onlyAdminACLOrRenouncedArtist(
             _projectId,
             this.adminAcceptArtistAddressesAndSplits.selector
         )
+        onlyNonZeroAddress(_artistAddress)
     {
         // checks
         require(

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -1041,6 +1041,7 @@ contract GenArt721CoreV3 is
     function updateDefaultBaseURI(string memory _defaultBaseURI)
         external
         onlyAdminACL(this.updateDefaultBaseURI.selector)
+        onlyNonEmptyString(_newBaseURI)
     {
         _updateDefaultBaseURI(_defaultBaseURI);
     }

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -697,7 +697,7 @@ contract GenArt721CoreV3 is
         external
         onlyValidProjectId(_projectId)
         onlyAdminACLOrRenouncedArtist(
-            _projectID,
+            _projectId,
             this.updateProjectArtistAddress.selector
         )
         onlyNonZeroAddress(_artistAddress)

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -306,7 +306,10 @@ contract GenArt721CoreV3 is
         address _randomizerContract,
         address _adminACLContract,
         uint256 _startingProjectId
-    ) ERC721_PackedHashSeed(_tokenName, _tokenSymbol) {
+    )
+        ERC721_PackedHashSeed(_tokenName, _tokenSymbol)
+        onlyNonZeroAddress(_randomizerContract)
+    {
         // record contracts starting project ID
         startingProjectId = _startingProjectId;
         _updateArtblocksPrimarySalesAddress(msg.sender);
@@ -1658,6 +1661,9 @@ contract GenArt721CoreV3 is
 
     /**
      * @notice Updates randomizer address to `_randomizerAddress`.
+     * @dev Note that this message does not check that the input address is
+     * not `address(0)` as it is expected that callers of this method should
+     * perform input validation.
      */
     function _updateRandomizerAddress(address _randomizerAddress) internal {
         randomizerContract = IRandomizerV2(_randomizerAddress);

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -417,6 +417,10 @@ contract GenArt721CoreV3 is
         external
         onlyAdminACL(this.updateArtblocksCurationRegistryAddress.selector)
     {
+        require(
+            _artblocksCurationRegistryAddress != address(0),
+            "Must set registry to valid address"
+        );
         artblocksCurationRegistryAddress = _artblocksCurationRegistryAddress;
         emit PlatformUpdated(FIELD_ARTBLOCKS_CURATION_REGISTRY_ADDRESS);
     }

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -434,6 +434,10 @@ contract GenArt721CoreV3 is
         external
         onlyAdminACL(this.updateArtblocksDependencyRegistryAddress.selector)
     {
+        require(
+            _artblocksCurationRegistryAddress != address(0),
+            "Must set registry to valid address"
+        );
         artblocksDependencyRegistryAddress = _artblocksDependencyRegistryAddress;
         emit PlatformUpdated(FIELD_ARTBLOCKS_DEPENDENCY_REGISTRY_ADDRESS);
     }

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -89,7 +89,6 @@ contract GenArt721CoreV3 is
     uint24 constant ONE_MILLION_UINT24 = 1_000_000;
     uint256 constant FOUR_WEEKS_IN_SECONDS = 2_419_200;
     uint8 constant AT_CHARACTER_CODE = uint8(bytes1("@")); // 0x40
-    string constant NON_ZERO_ADDRESS_MSG = "Must use non-zero address";
 
     // generic platform event fields
     bytes32 constant FIELD_NEXT_PROJECT_ID = "nextProjectId";
@@ -219,6 +218,11 @@ contract GenArt721CoreV3 is
 
     /// default base URI to initialize all new project projectBaseURI values to
     string public defaultBaseURI;
+
+    modifier onlyNonZeroAddress(address _address) {
+        require(_address != address(0), "Must input non-zero address");
+        _;
+    }
 
     modifier onlyValidTokenId(uint256 _tokenId) {
         require(_exists(_tokenId), "Token ID does not exist");
@@ -417,11 +421,8 @@ contract GenArt721CoreV3 is
     )
         external
         onlyAdminACL(this.updateArtblocksCurationRegistryAddress.selector)
+        onlyNonZeroAddress(_artblocksCurationRegistryAddress)
     {
-        require(
-            _artblocksCurationRegistryAddress != address(0),
-            NON_ZERO_ADDRESS_MSG
-        );
         artblocksCurationRegistryAddress = _artblocksCurationRegistryAddress;
         emit PlatformUpdated(FIELD_ARTBLOCKS_CURATION_REGISTRY_ADDRESS);
     }
@@ -434,11 +435,8 @@ contract GenArt721CoreV3 is
     )
         external
         onlyAdminACL(this.updateArtblocksDependencyRegistryAddress.selector)
+        onlyNonZeroAddress(_artblocksDependencyRegistryAddress)
     {
-        require(
-            _artblocksDependencyRegistryAddress != address(0),
-            NON_ZERO_ADDRESS_MSG
-        );
         artblocksDependencyRegistryAddress = _artblocksDependencyRegistryAddress;
         emit PlatformUpdated(FIELD_ARTBLOCKS_DEPENDENCY_REGISTRY_ADDRESS);
     }

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -761,7 +761,6 @@ contract GenArt721CoreV3 is
      */
     function updateProjectName(uint256 _projectId, string memory _projectName)
         external
-        onlyValidProjectId(_projectId)
         onlyUnlocked(_projectId)
         onlyArtistOrAdminACL(_projectId, this.updateProjectName.selector)
         onlyNonEmptyString(_projectName)
@@ -779,7 +778,6 @@ contract GenArt721CoreV3 is
         string memory _projectArtistName
     )
         external
-        onlyValidProjectId(_projectId)
         onlyUnlocked(_projectId)
         onlyArtistOrAdminACL(_projectId, this.updateProjectArtistName.selector)
     {
@@ -854,7 +852,6 @@ contract GenArt721CoreV3 is
         string memory _projectLicense
     )
         external
-        onlyValidProjectId(_projectId)
         onlyUnlocked(_projectId)
         onlyArtistOrAdminACL(_projectId, this.updateProjectLicense.selector)
     {
@@ -901,7 +898,6 @@ contract GenArt721CoreV3 is
      */
     function addProjectScript(uint256 _projectId, string memory _script)
         external
-        onlyValidProjectId(_projectId)
         onlyUnlocked(_projectId)
         onlyArtistOrAdminACL(_projectId, this.addProjectScript.selector)
     {
@@ -923,7 +919,6 @@ contract GenArt721CoreV3 is
         string memory _script
     )
         external
-        onlyValidProjectId(_projectId)
         onlyUnlocked(_projectId)
         onlyArtistOrAdminACL(_projectId, this.updateProjectScript.selector)
     {
@@ -938,7 +933,6 @@ contract GenArt721CoreV3 is
      */
     function removeProjectLastScript(uint256 _projectId)
         external
-        onlyValidProjectId(_projectId)
         onlyUnlocked(_projectId)
         onlyArtistOrAdminACL(_projectId, this.removeProjectLastScript.selector)
     {
@@ -960,7 +954,6 @@ contract GenArt721CoreV3 is
         bytes32 _scriptTypeAndVersion
     )
         external
-        onlyValidProjectId(_projectId)
         onlyUnlocked(_projectId)
         onlyArtistOrAdminACL(_projectId, this.updateProjectScriptType.selector)
     {
@@ -988,7 +981,6 @@ contract GenArt721CoreV3 is
         string memory _aspectRatio
     )
         external
-        onlyValidProjectId(_projectId)
         onlyUnlocked(_projectId)
         onlyArtistOrAdminACL(_projectId, this.updateProjectAspectRatio.selector)
     {
@@ -1661,7 +1653,12 @@ contract GenArt721CoreV3 is
      * maximum number of times.
      * @param _projectId Project ID to check.
      */
-    function _projectUnlocked(uint256 _projectId) internal view returns (bool) {
+    function _projectUnlocked(uint256 _projectId)
+        internal
+        view
+        onlyValidProjectId(_projectId)
+        returns (bool)
+    {
         uint256 projectCompletedTimestamp = projects[_projectId]
             .completedTimestamp;
         bool projectOpen = projectCompletedTimestamp == 0;

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -239,7 +239,10 @@ contract GenArt721CoreV3 is
     }
 
     modifier onlyValidProjectId(uint256 _projectId) {
-        require(_projectId < _nextProjectId, "Project ID does not exist");
+        require(
+            (_projectId >= startingProjectId) && (_projectId < _nextProjectId),
+            "Project ID does not exist"
+        );
         _;
     }
 

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -836,6 +836,7 @@ contract GenArt721CoreV3 is
 
     /**
      * @notice Updates website of project `_projectId` to be `_projectWebsite`.
+     * @dev It is intentionally allowed for this to be set to the empty string.
      */
     function updateProjectWebsite(
         uint256 _projectId,

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -763,6 +763,7 @@ contract GenArt721CoreV3 is
         external
         onlyUnlocked(_projectId)
         onlyArtistOrAdminACL(_projectId, this.updateProjectName.selector)
+        onlyNonEmptyString(_projectName)
     {
         projects[_projectId].name = _projectName;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_NAME);

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -1027,6 +1027,7 @@ contract GenArt721CoreV3 is
     function updateProjectBaseURI(uint256 _projectId, string memory _newBaseURI)
         external
         onlyArtist(_projectId)
+        onlyNonEmptyString(_newBaseURI)
     {
         projects[_projectId].projectBaseURI = _newBaseURI;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_BASE_URI);

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -224,6 +224,11 @@ contract GenArt721CoreV3 is
         _;
     }
 
+    modifier onlyNonEmptyString(string memory _string) {
+        require(bytes(_string).length != 0, "Must input non-empty string");
+        _;
+    }
+
     modifier onlyValidTokenId(uint256 _tokenId) {
         require(_exists(_tokenId), "Token ID does not exist");
         _;
@@ -721,7 +726,12 @@ contract GenArt721CoreV3 is
     function addProject(
         string memory _projectName,
         address payable _artistAddress
-    ) external onlyAdminACL(this.addProject.selector) {
+    )
+        external
+        onlyAdminACL(this.addProject.selector)
+        onlyNonEmptyString(_projectName)
+        onlyNonZeroAddress(_artistAddress)
+    {
         require(!newProjectsForbidden, "New projects forbidden");
         uint256 projectId = _nextProjectId;
         projectIdToFinancials[projectId].artistAddress = _artistAddress;

--- a/contracts/minter-suite/MinterFilter/MinterFilterV1.sol
+++ b/contracts/minter-suite/MinterFilter/MinterFilterV1.sol
@@ -277,7 +277,12 @@ contract MinterFilterV1 is IMinterFilterV0 {
      * @return bool true if project has an assigned minter, else false
      * @dev requires project to have an assigned minter
      */
-    function projectHasMinter(uint256 _projectId) external view returns (bool) {
+    function projectHasMinter(uint256 _projectId)
+        external
+        view
+        onlyValidProjectId(_projectId)
+        returns (bool)
+    {
         (bool _hasMinter, ) = minterForProject.tryGet(_projectId);
         return _hasMinter;
     }

--- a/contracts/minter-suite/MinterFilter/MinterFilterV1.sol
+++ b/contracts/minter-suite/MinterFilter/MinterFilterV1.sol
@@ -80,7 +80,7 @@ contract MinterFilterV1 is IMinterFilterV0 {
         _;
     }
 
-    modifier projectExists(uint256 _projectId) {
+    modifier onlyValidProjectId(uint256 _projectId) {
         require(
             _projectId < genArtCoreContract.nextProjectId(),
             "Only existing projects"
@@ -165,7 +165,7 @@ contract MinterFilterV1 is IMinterFilterV0 {
         external
         onlyCoreAdminACLOrArtist(_projectId, this.setMinterForProject.selector)
         usingApprovedMinter(_minterAddress)
-        projectExists(_projectId)
+        onlyValidProjectId(_projectId)
     {
         // decrement number of projects using a previous minter
         (bool hasPreviousMinter, address previousMinter) = minterForProject
@@ -261,6 +261,7 @@ contract MinterFilterV1 is IMinterFilterV0 {
     function getMinterForProject(uint256 _projectId)
         external
         view
+        onlyValidProjectId(_projectId)
         returns (address)
     {
         (bool _hasMinter, address _currentMinter) = minterForProject.tryGet(

--- a/contracts/minter-suite/MinterFilter/MinterFilterV1.sol
+++ b/contracts/minter-suite/MinterFilter/MinterFilterV1.sol
@@ -55,6 +55,11 @@ contract MinterFilterV1 is IMinterFilterV0 {
     /// minter address => is an approved minter?
     mapping(address => bool) public isApprovedMinter;
 
+    modifier onlyNonZeroAddress(address _address) {
+        require(_address != address(0), "Must input non-zero address");
+        _;
+    }
+
     // modifier to restrict access to only AdminACL allowed calls
     // @dev defers which ACL contract is used to the core contract
     modifier onlyCoreAdminACL(bytes4 _selector) {
@@ -96,7 +101,9 @@ contract MinterFilterV1 is IMinterFilterV0 {
      * @param _genArt721Address Art Blocks core contract address
      * this contract will be a minter for. Can never be updated.
      */
-    constructor(address _genArt721Address) {
+    constructor(address _genArt721Address)
+        onlyNonZeroAddress(_genArt721Address)
+    {
         genArt721CoreAddress = _genArt721Address;
         genArtCoreContract = IGenArt721CoreContractV3(_genArt721Address);
     }
@@ -122,6 +129,7 @@ contract MinterFilterV1 is IMinterFilterV0 {
     function addApprovedMinter(address _minterAddress)
         external
         onlyCoreAdminACL(this.addApprovedMinter.selector)
+        onlyNonZeroAddress(_minterAddress)
     {
         isApprovedMinter[_minterAddress] = true;
         emit MinterApproved(

--- a/contracts/minter-suite/MinterFilter/MinterFilterV1.sol
+++ b/contracts/minter-suite/MinterFilter/MinterFilterV1.sol
@@ -146,6 +146,7 @@ contract MinterFilterV1 is IMinterFilterV0 {
         external
         onlyCoreAdminACL(this.removeApprovedMinter.selector)
     {
+        require(isApprovedMinter[_minterAddress], "Only approved minters");
         require(
             numProjectsUsingMinter[_minterAddress] == 0,
             "Only unused minters"

--- a/contracts/minter-suite/Minters/MinterDAExp/MinterDAExpV2.sol
+++ b/contracts/minter-suite/Minters/MinterDAExp/MinterDAExpV2.sol
@@ -187,7 +187,9 @@ contract MinterDAExpV2 is ReentrancyGuard, IFilteredMinterV0 {
      * only result in a gas cost increase, since the core contract will still
      * enforce a maxInvocation check during minting. A false positive is not
      * possible because the V3 core contract only allows maximum invocations
-     * to be reduced, not increased.
+     * to be reduced, not increased. Based on this rationale, we intentionally
+     * do not do input validation in this method as to whether or not the input
+     * `_projectId` is an existing project ID.
      *
      */
     function projectMaxHasBeenInvoked(uint256 _projectId)

--- a/contracts/minter-suite/Minters/MinterDAExp/MinterDAExpV2.sol
+++ b/contracts/minter-suite/Minters/MinterDAExp/MinterDAExpV2.sol
@@ -214,7 +214,9 @@ contract MinterDAExpV2 is ReentrancyGuard, IFilteredMinterV0 {
      * project's max invocations have not been synced on this minter, since the
      * V3 core contract only allows maximum invocations to be reduced, not
      * increased. When this happens, the minter will enable minting, allowing
-     * the core contract to enforce the max invocations check.
+     * the core contract to enforce the max invocations check. Based on this
+     * rationale, we intentionally do not do input validation in this method as
+     * to whether or not the input `_projectId` is an existing project ID.
      */
     function projectMaxInvocations(uint256 _projectId)
         external

--- a/contracts/minter-suite/Minters/MinterDAExp/MinterDAExpV2.sol
+++ b/contracts/minter-suite/Minters/MinterDAExp/MinterDAExpV2.sol
@@ -291,6 +291,8 @@ contract MinterDAExpV2 is ReentrancyGuard, IFilteredMinterV0 {
      *  price (in seconds).
      * @param _startPrice Price at which to start the auction, in Wei.
      * @param _basePrice Resting price of the auction, in Wei.
+     * @dev Note that it is intentionally supported here that the configured
+     * price may be explicitly set to `0`.
      */
     function setAuctionDetails(
         uint256 _projectId,

--- a/contracts/minter-suite/Minters/MinterDALin/MinterDALinV2.sol
+++ b/contracts/minter-suite/Minters/MinterDALin/MinterDALinV2.sol
@@ -208,7 +208,9 @@ contract MinterDALinV2 is ReentrancyGuard, IFilteredMinterV0 {
      * project's max invocations have not been synced on this minter, since the
      * V3 core contract only allows maximum invocations to be reduced, not
      * increased. When this happens, the minter will enable minting, allowing
-     * the core contract to enforce the max invocations check.
+     * the core contract to enforce the max invocations check. Based on this
+     * rationale, we intentionally do not do input validation in this method as
+     * to whether or not the input `_projectId` is an existing project ID.
      */
     function projectMaxInvocations(uint256 _projectId)
         external

--- a/contracts/minter-suite/Minters/MinterDALin/MinterDALinV2.sol
+++ b/contracts/minter-suite/Minters/MinterDALin/MinterDALinV2.sol
@@ -182,7 +182,9 @@ contract MinterDALinV2 is ReentrancyGuard, IFilteredMinterV0 {
      * only result in a gas cost increase, since the core contract will still
      * enforce a maxInvocation check during minting. A false positive is not
      * possible because the V3 core contract only allows maximum invocations
-     * to be reduced, not increased.
+     * to be reduced, not increased. Based on this rationale, we intentionally
+     * do not do input validation in this method as to whether or not the input
+     * `_projectId` is an existing project ID.
      */
     function projectMaxHasBeenInvoked(uint256 _projectId)
         external

--- a/contracts/minter-suite/Minters/MinterDALin/MinterDALinV2.sol
+++ b/contracts/minter-suite/Minters/MinterDALin/MinterDALinV2.sol
@@ -262,6 +262,8 @@ contract MinterDALinV2 is ReentrancyGuard, IFilteredMinterV0 {
      * @param _auctionTimestampEnd Timestamp at which to end the auction.
      * @param _startPrice Price at which to start the auction, in Wei.
      * @param _basePrice Resting price of the auction, in Wei.
+     * @dev Note that it is intentionally supported here that the configured
+     * price may be explicitly set to `0`.
      */
     function setAuctionDetails(
         uint256 _projectId,

--- a/contracts/minter-suite/Minters/MinterHolder/MinterHolderV1.sol
+++ b/contracts/minter-suite/Minters/MinterHolder/MinterHolderV1.sol
@@ -425,6 +425,8 @@ contract MinterHolderV1 is ReentrancyGuard, IFilteredMinterHolderV0 {
      * @notice Updates this minter's price per token of project `_projectId`
      * to be '_pricePerTokenInWei`, in Wei.
      * This price supersedes any legacy core contract price per token value.
+     * @dev Note that it is intentionally supported here that the configured
+     * price may be explicitly set to `0`.
      */
     function updatePricePerTokenInWei(
         uint256 _projectId,

--- a/contracts/minter-suite/Minters/MinterHolder/MinterHolderV1.sol
+++ b/contracts/minter-suite/Minters/MinterHolder/MinterHolderV1.sol
@@ -409,7 +409,9 @@ contract MinterHolderV1 is ReentrancyGuard, IFilteredMinterHolderV0 {
      * project's max invocations have not been synced on this minter, since the
      * V3 core contract only allows maximum invocations to be reduced, not
      * increased. When this happens, the minter will enable minting, allowing
-     * the core contract to enforce the max invocations check.
+     * the core contract to enforce the max invocations check. Based on this
+     * rationale, we intentionally do not do input validation in this method as
+     * to whether or not the input `_projectId` is an existing project ID.
      */
     function projectMaxInvocations(uint256 _projectId)
         external

--- a/contracts/minter-suite/Minters/MinterHolder/MinterHolderV1.sol
+++ b/contracts/minter-suite/Minters/MinterHolder/MinterHolderV1.sol
@@ -383,7 +383,9 @@ contract MinterHolderV1 is ReentrancyGuard, IFilteredMinterHolderV0 {
      * only result in a gas cost increase, since the core contract will still
      * enforce a maxInvocation check during minting. A false positive is not
      * possible because the V3 core contract only allows maximum invocations
-     * to be reduced, not increased.
+     * to be reduced, not increased. Based on this rationale, we intentionally
+     * do not do input validation in this method as to whether or not the input
+     * `_projectId` is an existing project ID.
      */
     function projectMaxHasBeenInvoked(uint256 _projectId)
         external

--- a/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
+++ b/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
@@ -112,6 +112,7 @@ contract MinterMerkleV1 is ReentrancyGuard, IFilteredMinterMerkleV0 {
         external
         onlyArtist(_projectId)
     {
+        require(_root != bytes32(0), "Root must be provided");
         projectMerkleRoot[_projectId] = _root;
         emit ConfigValueSet(_projectId, CONFIG_MERKLE_ROOT, _root);
     }

--- a/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
+++ b/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
@@ -206,7 +206,9 @@ contract MinterMerkleV1 is ReentrancyGuard, IFilteredMinterMerkleV0 {
      * only result in a gas cost increase, since the core contract will still
      * enforce a maxInvocation check during minting. A false positive is not
      * possible because the V3 core contract only allows maximum invocations
-     * to be reduced, not increased.
+     * to be reduced, not increased. Based on this rationale, we intentionally
+     * do not do input validation in this method as to whether or not the input
+     * `_projectId` is an existing project ID.
      */
     function projectMaxHasBeenInvoked(uint256 _projectId)
         external

--- a/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
+++ b/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
@@ -232,7 +232,9 @@ contract MinterMerkleV1 is ReentrancyGuard, IFilteredMinterMerkleV0 {
      * project's max invocations have not been synced on this minter, since the
      * V3 core contract only allows maximum invocations to be reduced, not
      * increased. When this happens, the minter will enable minting, allowing
-     * the core contract to enforce the max invocations check.
+     * the core contract to enforce the max invocations check. Based on this
+     * rationale, we intentionally do not do input validation in this method as
+     * to whether or not the input `_projectId` is an existing project ID.
      */
     function projectMaxInvocations(uint256 _projectId)
         external

--- a/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
+++ b/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
@@ -260,6 +260,8 @@ contract MinterMerkleV1 is ReentrancyGuard, IFilteredMinterMerkleV0 {
      * @notice Updates this minter's price per token of project `_projectId`
      * to be '_pricePerTokenInWei`, in Wei.
      * This price supersedes any legacy core contract price per token value.
+     * @dev Note that it is intentionally supported here that the configured
+     * price may be explicitly set to `0`.
      */
     function updatePricePerTokenInWei(
         uint256 _projectId,

--- a/contracts/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
+++ b/contracts/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
@@ -151,7 +151,9 @@ contract MinterSetPriceV2 is ReentrancyGuard, IFilteredMinterV0 {
      * project's max invocations have not been synced on this minter, since the
      * V3 core contract only allows maximum invocations to be reduced, not
      * increased. When this happens, the minter will enable minting, allowing
-     * the core contract to enforce the max invocations check.
+     * the core contract to enforce the max invocations check. Based on this
+     * rationale, we intentionally do not do input validation in this method as
+     * to whether or not the input `_projectId` is an existing project ID.
      */
     function projectMaxInvocations(uint256 _projectId)
         external

--- a/contracts/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
+++ b/contracts/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
@@ -125,7 +125,9 @@ contract MinterSetPriceV2 is ReentrancyGuard, IFilteredMinterV0 {
      * only result in a gas cost increase, since the core contract will still
      * enforce a maxInvocation check during minting. A false positive is not
      * possible because the V3 core contract only allows maximum invocations
-     * to be reduced, not increased.
+     * to be reduced, not increased. Based on this rationale, we intentionally
+     * do not do input validation in this method as to whether or not the input
+     * `_projectId` is an existing project ID.
      */
     function projectMaxHasBeenInvoked(uint256 _projectId)
         external

--- a/contracts/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
+++ b/contracts/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
@@ -167,6 +167,8 @@ contract MinterSetPriceV2 is ReentrancyGuard, IFilteredMinterV0 {
      * @notice Updates this minter's price per token of project `_projectId`
      * to be '_pricePerTokenInWei`, in Wei.
      * This price supersedes any legacy core contract price per token value.
+     * @dev Note that it is intentionally supported here that the configured
+     * price may be explicitly set to `0`.
      */
     function updatePricePerTokenInWei(
         uint256 _projectId,

--- a/contracts/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V2.sol
+++ b/contracts/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V2.sol
@@ -171,7 +171,9 @@ contract MinterSetPriceERC20V2 is ReentrancyGuard, IFilteredMinterV0 {
      * only result in a gas cost increase, since the core contract will still
      * enforce a maxInvocation check during minting. A false positive is not
      * possible because the V3 core contract only allows maximum invocations
-     * to be reduced, not increased.
+     * to be reduced, not increased. Based on this rationale, we intentionally
+     * do not do input validation in this method as to whether or not the input
+     * `_projectId` is an existing project ID.
      */
     function projectMaxHasBeenInvoked(uint256 _projectId)
         external

--- a/contracts/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V2.sol
+++ b/contracts/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V2.sol
@@ -197,7 +197,9 @@ contract MinterSetPriceERC20V2 is ReentrancyGuard, IFilteredMinterV0 {
      * project's max invocations have not been synced on this minter, since the
      * V3 core contract only allows maximum invocations to be reduced, not
      * increased. When this happens, the minter will enable minting, allowing
-     * the core contract to enforce the max invocations check.
+     * the core contract to enforce the max invocations check. Based on this
+     * rationale, we intentionally do not do input validation in this method as
+     * to whether or not the input `_projectId` is an existing project ID.
      */
     function projectMaxInvocations(uint256 _projectId)
         external

--- a/contracts/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V2.sol
+++ b/contracts/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V2.sol
@@ -218,6 +218,7 @@ contract MinterSetPriceERC20V2 is ReentrancyGuard, IFilteredMinterV0 {
         uint256 _projectId,
         uint256 _pricePerTokenInWei
     ) external onlyArtist(_projectId) {
+        require(_pricePerTokenInWei > 0, "Price may not be 0");
         projectConfig[_projectId].pricePerTokenInWei = _pricePerTokenInWei;
         projectConfig[_projectId].priceIsConfigured = true;
         emit PricePerTokenInWeiUpdated(_projectId, _pricePerTokenInWei);

--- a/test/core/V3/GenArt721CoreV3_AdminACLRequests.test.ts
+++ b/test/core/V3/GenArt721CoreV3_AdminACLRequests.test.ts
@@ -225,13 +225,6 @@ describe("GenArt721CoreV3 AminACL Requests", async function () {
       ]);
     });
 
-    it("updateProjectIpfsHash", async function () {
-      await validateAdminACLRequest.call(this, "updateProjectAspectRatio", [
-        this.projectZero,
-        "0x",
-      ]);
-    });
-
     it("updateProjectDescription", async function () {
       // admin may only call when in a locked state
       await mintProjectUntilRemaining.call(

--- a/test/core/V3/GenArt721CoreV3_Events.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Events.test.ts
@@ -132,7 +132,7 @@ describe("GenArt721CoreV3 Events", async function () {
         // address for the purposes of this test
         await this.genArt721Core
           .connect(this.accounts.deployer)
-          .updateRandomizerAddress(this.accounts.artist.additional)
+          .updateRandomizerAddress(this.accounts.additional)
       )
         .to.emit(this.genArt721Core, "PlatformUpdated")
         .withArgs(ethers.utils.formatBytes32String("randomizerAddress"));

--- a/test/core/V3/GenArt721CoreV3_Events.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Events.test.ts
@@ -93,7 +93,7 @@ describe("GenArt721CoreV3 Events", async function () {
         .deploy(
           "name",
           "symbol",
-          this.accounts.additional,
+          this.accounts.additional.address,
           constants.ZERO_ADDRESS,
           365
         );
@@ -132,7 +132,7 @@ describe("GenArt721CoreV3 Events", async function () {
         // address for the purposes of this test
         await this.genArt721Core
           .connect(this.accounts.deployer)
-          .updateRandomizerAddress(this.accounts.additional)
+          .updateRandomizerAddress(this.accounts.additional.address)
       )
         .to.emit(this.genArt721Core, "PlatformUpdated")
         .withArgs(ethers.utils.formatBytes32String("randomizerAddress"));

--- a/test/core/V3/GenArt721CoreV3_Events.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Events.test.ts
@@ -86,12 +86,14 @@ describe("GenArt721CoreV3 Events", async function () {
       const contractFactory = await ethers.getContractFactory(
         "GenArt721CoreV3"
       );
+      // it is OK that this randomizer address isn't a particularly valid
+      // address for the purposes of this test
       const tx = await contractFactory
         .connect(this.accounts.deployer)
         .deploy(
           "name",
           "symbol",
-          constants.ZERO_ADDRESS,
+          this.accounts.additional,
           constants.ZERO_ADDRESS,
           365
         );
@@ -126,9 +128,11 @@ describe("GenArt721CoreV3 Events", async function () {
     it("emits 'randomizerAddress'", async function () {
       // emits expected event arg(s)
       expect(
+        // it is OK that this randomizer address isn't a particularly valid
+        // address for the purposes of this test
         await this.genArt721Core
           .connect(this.accounts.deployer)
-          .updateRandomizerAddress(this.accounts.artist.address)
+          .updateRandomizerAddress(this.accounts.artist.additional)
       )
         .to.emit(this.genArt721Core, "PlatformUpdated")
         .withArgs(ethers.utils.formatBytes32String("randomizerAddress"));

--- a/test/core/V3/GenArt721CoreV3_Views.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Views.test.ts
@@ -514,6 +514,92 @@ describe("GenArt721CoreV3 Views", async function () {
       );
     });
 
+    it("reverts on improper address inputs", async function () {
+      // addProject
+      expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.deployer)
+          .addProject("name", constants.ZERO_ADDRESS),
+        "Must input non-zero address"
+      );
+      // updateArtblocksCurationRegistryAddress
+      expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.deployer)
+          .updateArtblocksCurationRegistryAddress(constants.ZERO_ADDRESS),
+        "Must input non-zero address"
+      );
+      // updateArtblocksDependencyRegistryAddress
+      expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.deployer)
+          .updateArtblocksDependencyRegistryAddress(constants.ZERO_ADDRESS),
+        "Must input non-zero address"
+      );
+      // updateArtblocksPrimarySalesAddress
+      expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.deployer)
+          .updateArtblocksPrimarySalesAddress(constants.ZERO_ADDRESS),
+        "Must input non-zero address"
+      );
+      // updateArtblocksSecondarySalesAddress
+      expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.deployer)
+          .updateArtblocksSecondarySalesAddress(constants.ZERO_ADDRESS),
+        "Must input non-zero address"
+      );
+      // updateMinterContract
+      expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.deployer)
+          .updateMinterContract(constants.ZERO_ADDRESS),
+        "Must input non-zero address"
+      );
+      // updateRandomizerAddress
+      expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.deployer)
+          .updateRandomizerAddress(constants.ZERO_ADDRESS),
+        "Must input non-zero address"
+      );
+      // updateProjectArtistAddress
+      expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.deployer)
+          .updateProjectArtistAddress(this.projectZero, constants.ZERO_ADDRESS),
+        "Must input non-zero address"
+      );
+
+      const proposeArtistPaymentAddressesAndSplitsArgs = [
+        this.projectZero,
+        constants.ZERO_ADDRESS,
+        constants.ZERO_ADDRESS,
+        0,
+        constants.ZERO_ADDRESS,
+        0,
+      ];
+      // proposeArtistPaymentAddressesAndSplits
+      expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.artist)
+          .proposeArtistPaymentAddressesAndSplits(
+            ...proposeArtistPaymentAddressesAndSplitsArgs
+          ),
+        "Must input non-zero address"
+      );
+      // adminAcceptArtistAddressesAndSplits
+      expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.deployer)
+          .adminAcceptArtistAddressesAndSplits(
+            ...proposeArtistPaymentAddressesAndSplitsArgs
+          ),
+        "Must input non-zero address"
+      );
+    });
+
     it("returns expected values for projectOne, with updated payment addresses and percentages only to Additional Payee Primary", async function () {
       // add project
       await this.genArt721Core

--- a/test/core/V3/GenArt721CoreV3_Views.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Views.test.ts
@@ -245,7 +245,7 @@ describe("GenArt721CoreV3 Views", async function () {
         );
       await this.genArt721Core
         .connect(this.accounts.artist)
-        .updateProjectAspectRatio(this.projectZero, "1.77777778");
+        .updateProjectAspectRatio(this.projectZero, "1.777777778");
       await this.genArt721Core
         .connect(this.accounts.artist)
         .addProjectScript(this.projectZero, "if(true){}");
@@ -256,8 +256,29 @@ describe("GenArt721CoreV3 Views", async function () {
       expect(projectScriptDetails.scriptTypeAndVersion).to.be.equal(
         "p5js@v1.2.3"
       );
-      expect(projectScriptDetails.aspectRatio).to.be.equal("1.77777778");
+      expect(projectScriptDetails.aspectRatio).to.be.equal("1.777777778");
       expect(projectScriptDetails.scriptCount).to.be.equal(1);
+    });
+
+    it("validates aspect ratio format details", async function () {
+      await expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.artist)
+          .updateProjectAspectRatio(this.projectZero, "1.7777777778"),
+        "Aspect ratio format too long"
+      );
+      await expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.artist)
+          .updateProjectAspectRatio(this.projectZero, "2/3"),
+        "Improperly formatted aspect ratio"
+      );
+      await expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.artist)
+          .updateProjectAspectRatio(this.projectZero, "1.2.3.4"),
+        "Improperly formatted aspect ratio"
+      );
     });
   });
 

--- a/test/core/V3/GenArt721CoreV3_Views.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Views.test.ts
@@ -279,6 +279,12 @@ describe("GenArt721CoreV3 Views", async function () {
           .updateProjectAspectRatio(this.projectZero, "1.2.3.4"),
         "Improperly formatted aspect ratio"
       );
+      await expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.artist)
+          .updateProjectAspectRatio(this.projectZero, "."),
+        "Aspect ratio has no numbers"
+      );
     });
   });
 

--- a/test/core/V3/GenArt721CoreV3_Views.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Views.test.ts
@@ -600,6 +600,72 @@ describe("GenArt721CoreV3 Views", async function () {
       );
     });
 
+    it("reverts on improper string inputs", async function () {
+      // addProject
+      expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.deployer)
+          .addProject("", this.accounts.artist.address),
+        "Must input non-empty string"
+      );
+      // updateProjectName
+      expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.deployer)
+          .updateProjectName(this.projectZero, ""),
+        "Must input non-empty string"
+      );
+      // updateProjectArtistName
+      expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.deployer)
+          .updateProjectArtistName(this.projectZero, ""),
+        "Must input non-empty string"
+      );
+      // updateProjectLicense
+      expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.deployer)
+          .updateProjectLicense(this.projectZero, ""),
+        "Must input non-empty string"
+      );
+      // addProjectScript
+      expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.deployer)
+          .addProjectScript(this.projectZero, ""),
+        "Must input non-empty string"
+      );
+      // updateProjectScript
+      expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.deployer)
+          .updateProjectScript(this.projectZero, 0, ""),
+        "Must input non-empty string"
+      );
+      // updateProjectAspectRatio
+      expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.deployer)
+          .updateProjectAspectRatio(this.projectZero, ""),
+        "Must input non-empty string"
+      );
+      // updateProjectBaseURI
+      expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.artist)
+          .updateProjectBaseURI(this.projectZero, ""),
+        "Must input non-empty string"
+      );
+      // updateDefaultBaseURI
+      expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.deployer)
+          .updateDefaultBaseURI(""),
+        "Must input non-empty string"
+      );
+    });
+
     it("returns expected values for projectOne, with updated payment addresses and percentages only to Additional Payee Primary", async function () {
       // add project
       await this.genArt721Core

--- a/test/minter-filter/views/MinterFilterV1Views.test.ts
+++ b/test/minter-filter/views/MinterFilterV1Views.test.ts
@@ -11,12 +11,6 @@ import { MinterFilterViews_Common } from "./MinterFilterViews.common";
 
 const runForEach = [
   {
-    core: "GenArt721CoreV1",
-    coreFirstProjectNumber: 3,
-    minterFilter: "MinterFilterV0",
-    minter: "MinterSetPriceERC20V0",
-  },
-  {
     core: "GenArt721CoreV3",
     coreFirstProjectNumber: 0,
     minterFilter: "MinterFilterV1",
@@ -56,8 +50,16 @@ runForEach.forEach((params) => {
       );
     });
 
-    describe("common tests", async function () {
-      MinterFilterViews_Common();
+    describe("V1+ specific input checks", async function () {
+      it("reverts on improper address inputs", async function () {
+        // addProject
+        expectRevert(
+          this.minterFilter
+            .connect(this.accounts.deployer)
+            .addApprovedMinter(constants.ZERO_ADDRESS),
+          "Must input non-zero address"
+        );
+      });
     });
   });
 });

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
@@ -56,7 +56,7 @@ describe("MinterDAExpV2_V3Core", async function () {
       this.minterFilter.address,
     ]);
 
-    safeAddProject(
+    await safeAddProject(
       this.genArt721Core,
       this.accounts.deployer,
       this.accounts.artist.address

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
@@ -172,7 +172,7 @@ describe("MinterDAExpV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0138769")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0138786")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
@@ -173,7 +173,7 @@ describe("MinterDALinV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0138845")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0138862")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/MinterHolder/MinterHolder.common.ts
+++ b/test/minter-suite-minters/MinterHolder/MinterHolder.common.ts
@@ -979,15 +979,14 @@ export const MinterHolder_Common = async () => {
         .connect(this.accounts.deployer)
         .projectMaxHasBeenInvoked(this.projectOne);
       expect(hasMaxBeenInvoked).to.be.false;
-      // should also support unconfigured project this.maxInvocations
-      // e.g. project 99, which does not yet exist
-      await this.minter
-        .connect(this.accounts.deployer)
-        .setProjectMaxInvocations(99);
-      maxInvocations = await this.minter
-        .connect(this.accounts.deployer)
-        .projectMaxInvocations(99);
-      expect(maxInvocations).to.be.equal(0);
+      // trying to set this on unconfigured project (e.g. 99) should cause
+      // revert on the underlying CoreContract.
+      expectRevert(
+        await this.minter
+          .connect(this.accounts.deployer)
+          .setProjectMaxInvocations(99),
+        "Project ID does not exist"
+      );
     });
   });
 

--- a/test/minter-suite-minters/MinterHolder/MinterHolder.common.ts
+++ b/test/minter-suite-minters/MinterHolder/MinterHolder.common.ts
@@ -979,10 +979,13 @@ export const MinterHolder_Common = async () => {
         .connect(this.accounts.deployer)
         .projectMaxHasBeenInvoked(this.projectOne);
       expect(hasMaxBeenInvoked).to.be.false;
+    });
+
+    it("reverts for unconfigured/non-existent project", async function () {
       // trying to set this on unconfigured project (e.g. 99) should cause
       // revert on the underlying CoreContract.
       expectRevert(
-        await this.minter
+        this.minter
           .connect(this.accounts.deployer)
           .setProjectMaxInvocations(99),
         "Project ID does not exist"

--- a/test/minter-suite-minters/MinterMerkle/MinterMerkle.common.ts
+++ b/test/minter-suite-minters/MinterMerkle/MinterMerkle.common.ts
@@ -692,15 +692,14 @@ export const MinterMerkle_Common = async () => {
         .connect(this.accounts.deployer)
         .projectMaxHasBeenInvoked(this.projectOne);
       expect(hasMaxBeenInvoked).to.be.false;
-      // should also support unconfigured project projectMaxInvocations
-      // e.g. project 99, which does not yet exist
-      await this.minter
-        .connect(this.accounts.deployer)
-        .setProjectMaxInvocations(99);
-      maxInvocations = await this.minter
-        .connect(this.accounts.deployer)
-        .projectMaxInvocations(99);
-      expect(maxInvocations).to.be.equal(0);
+      // trying to set this on unconfigured project (e.g. 99) should cause
+      // revert on the underlying CoreContract.
+      expectRevert(
+        await this.minter
+          .connect(this.accounts.deployer)
+          .setProjectMaxInvocations(99),
+        "Project ID does not exist"
+      );
     });
   });
 

--- a/test/minter-suite-minters/MinterMerkle/MinterMerkle.common.ts
+++ b/test/minter-suite-minters/MinterMerkle/MinterMerkle.common.ts
@@ -680,9 +680,6 @@ export const MinterMerkle_Common = async () => {
         .connect(this.accounts.deployer)
         .setProjectMaxInvocations(this.projectOne);
       // minter should update storage with accurate projectMaxInvocations
-      await this.minter
-        .connect(this.accounts.deployer)
-        .setProjectMaxInvocations(this.projectOne);
       let maxInvocations = await this.minter
         .connect(this.accounts.deployer)
         .projectMaxInvocations(this.projectOne);
@@ -692,10 +689,13 @@ export const MinterMerkle_Common = async () => {
         .connect(this.accounts.deployer)
         .projectMaxHasBeenInvoked(this.projectOne);
       expect(hasMaxBeenInvoked).to.be.false;
+    });
+
+    it("reverts for unconfigured/non-existent project", async function () {
       // trying to set this on unconfigured project (e.g. 99) should cause
       // revert on the underlying CoreContract.
       expectRevert(
-        await this.minter
+        this.minter
           .connect(this.accounts.deployer)
           .setProjectMaxInvocations(99),
         "Project ID does not exist"

--- a/test/minter-suite-minters/MinterMerkle/MinterMerkleV0.test.ts
+++ b/test/minter-suite-minters/MinterMerkle/MinterMerkleV0.test.ts
@@ -166,7 +166,7 @@ describe("MinterMerkleV0", async function () {
     this.ERC20Mock = await ERC20Factory.deploy(ethers.utils.parseEther("100"));
   });
 
-  describe("common MinterHolder tests", async () => {
+  describe("common MinterMerkle tests", async () => {
     MinterMerkle_Common();
   });
 

--- a/test/minter-suite-minters/MinterMerkle/MinterMerkleV1.test.ts
+++ b/test/minter-suite-minters/MinterMerkle/MinterMerkleV1.test.ts
@@ -166,7 +166,7 @@ describe("MinterMerkleV1", async function () {
     this.ERC20Mock = await ERC20Factory.deploy(ethers.utils.parseEther("100"));
   });
 
-  describe("common MinterHolder tests", async () => {
+  describe("common MinterMerkle tests", async () => {
     MinterMerkle_Common();
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPrice.common.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPrice.common.ts
@@ -126,9 +126,6 @@ export const MinterSetPrice_ETH_Common = async () => {
         .connect(this.accounts.deployer)
         .setProjectMaxInvocations(this.projectZero);
       // minter should update storage with accurate projectMaxInvocations
-      await this.minter1
-        .connect(this.accounts.deployer)
-        .setProjectMaxInvocations(this.projectZero);
       let maxInvocations = await this.minter1
         .connect(this.accounts.deployer)
         .projectMaxInvocations(this.projectZero);
@@ -149,10 +146,13 @@ export const MinterSetPrice_ETH_Common = async () => {
         .connect(this.accounts.deployer)
         .projectMaxInvocations(this.projectOne);
       expect(maxInvocations).to.be.equal(this.maxInvocations);
+    });
+
+    it("reverts for unconfigured/non-existent project", async function () {
       // trying to set this on unconfigured project (e.g. 99) should cause
       // revert on the underlying CoreContract.
       expectRevert(
-        await this.minter
+        this.minter
           .connect(this.accounts.deployer)
           .setProjectMaxInvocations(99),
         "Project ID does not exist"

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPrice.common.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPrice.common.ts
@@ -149,15 +149,14 @@ export const MinterSetPrice_ETH_Common = async () => {
         .connect(this.accounts.deployer)
         .projectMaxInvocations(this.projectOne);
       expect(maxInvocations).to.be.equal(this.maxInvocations);
-      // should also support unconfigured project projectMaxInvocations
-      // e.g. this.projectZero on minter3 - still update to accurate max invocations
-      await this.minter3
-        .connect(this.accounts.deployer)
-        .setProjectMaxInvocations(this.projectZero);
-      maxInvocations = await this.minter3
-        .connect(this.accounts.deployer)
-        .projectMaxInvocations(this.projectZero);
-      expect(maxInvocations).to.be.equal(this.maxInvocations);
+      // trying to set this on unconfigured project (e.g. 99) should cause
+      // revert on the underlying CoreContract.
+      expectRevert(
+        await this.minter
+          .connect(this.accounts.deployer)
+          .setProjectMaxInvocations(99),
+        "Project ID does not exist"
+      );
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
@@ -177,7 +177,7 @@ describe("MinterSetPriceV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0129259")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0129276")); // assuming a cost of 100 GWEI
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20.common.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20.common.ts
@@ -417,15 +417,14 @@ export const MinterSetPriceERC20_Common = async () => {
         .connect(this.accounts.deployer)
         .projectMaxHasBeenInvoked(this.projectOne);
       expect(hasMaxBeenInvoked).to.be.false;
-      // should also support unconfigured project projectMaxInvocations
-      // e.g. project 99, which does not yet exist
-      await this.minter
-        .connect(this.accounts.deployer)
-        .setProjectMaxInvocations(99);
-      maxInvocations = await this.minter
-        .connect(this.accounts.deployer)
-        .projectMaxInvocations(99);
-      expect(maxInvocations).to.be.equal(0);
+      // trying to set this on unconfigured project (e.g. 99) should cause
+      // revert on the underlying CoreContract.
+      expectRevert(
+        await this.minter
+          .connect(this.accounts.deployer)
+          .setProjectMaxInvocations(99),
+        "Project ID does not exist"
+      );
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20.common.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20.common.ts
@@ -405,9 +405,6 @@ export const MinterSetPriceERC20_Common = async () => {
         .connect(this.accounts.deployer)
         .setProjectMaxInvocations(this.projectOne);
       // minter should update storage with accurate projectMaxInvocations
-      await this.minter
-        .connect(this.accounts.deployer)
-        .setProjectMaxInvocations(this.projectOne);
       let maxInvocations = await this.minter
         .connect(this.accounts.deployer)
         .projectMaxInvocations(this.projectOne);
@@ -417,10 +414,13 @@ export const MinterSetPriceERC20_Common = async () => {
         .connect(this.accounts.deployer)
         .projectMaxHasBeenInvoked(this.projectOne);
       expect(hasMaxBeenInvoked).to.be.false;
+    });
+
+    it("reverts for unconfigured/non-existent project", async function () {
       // trying to set this on unconfigured project (e.g. 99) should cause
       // revert on the underlying CoreContract.
       expectRevert(
-        await this.minter
+        this.minter
           .connect(this.accounts.deployer)
           .setProjectMaxInvocations(99),
         "Project ID does not exist"

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
@@ -206,7 +206,7 @@ describe("MinterSetPriceERC20V2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0129474"));
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0129491"));
     });
   });
 


### PR DESCRIPTION
This PR applies all suggested input validation changes, or in some cases (e.g. where empty input is allowed/supported) clarifies method documentation.

Note: this PR is also fixing what I believe to be a very minor bug with the ACL-gating on `updateProjectArtistAddress`, updating it to be in alignment with what is already achievable using `adminAcceptArtistAddressesAndSplits` so this is not functionally a change in terms of _what is possible within the world of CoreV3_, just _how certain functionality is exposed_.

Also note: the audit feedback of "20. GenArt721CoreV3.updateProjectIpfsHash() does not check that parameter _ipfsHash is 46 bytes long." was not explicitly addressed, as IPFS setter/getter functionality was stripped entirely given that it does not actually have an expected usage due to business process reasons.

## Audit
Response to QSP-10 - For minters, see changes to `MinterDAExpV2.sol` and `MinterMerkleV1.sol` minters only.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203034890733940/f