### PR TITLE
Merkle minter - Configurable qty per wallet address

### DIFF
--- a/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV0.sol
+++ b/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV0.sol
@@ -106,6 +106,7 @@ contract MinterMerkleV0 is ReentrancyGuard, IFilteredMinterMerkleV0 {
         external
         onlyArtist(_projectId)
     {
+        require(_root != bytes32(0), "Root must be provided");
         projectMerkleRoot[_projectId] = _root;
         emit ConfigValueSet(_projectId, CONFIG_MERKLE_ROOT, _root);
     }

--- a/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
+++ b/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
@@ -27,6 +27,7 @@ pragma solidity 0.8.9;
  * The following functions are restricted to a project's artist:
  * - updateMerkleRoot
  * - updatePricePerTokenInWei
+ * - setProjectInvocationsPerAddress
  * ----------------------------------------------------------------------------
  * Additional admin and artist privileged roles may be described on other
  * contracts that this minter integrates with.
@@ -51,15 +52,24 @@ contract MinterMerkleV1 is ReentrancyGuard, IFilteredMinterMerkleV0 {
 
     /// project minter configuration keys used by this minter
     bytes32 private constant CONFIG_MERKLE_ROOT = "merkleRoot";
-    bytes32 private constant CONFIG_MINT_LIMITER_DISABLED =
-        "mintLimiterDisabled";
+    bytes32 private constant CONFIG_USE_MAX_INVOCATIONS_PER_ADDRESS_OVERRIDE =
+        "useMaxMintsPerAddrOverride"; // shortened to fit in 32 bytes
+    bytes32 private constant CONFIG_MAX_INVOCATIONS_OVERRIDE =
+        "maxMintsPerAddrOverride"; // shortened to match format of previous key
 
     uint256 constant ONE_MILLION = 1_000_000;
+
+    uint256 public constant DEFAULT_MAX_INVOCATIONS_PER_ADDRESS = 1;
 
     struct ProjectConfig {
         bool maxHasBeenInvoked;
         bool priceIsConfigured;
-        bool mintLimiterDisabled;
+        // initial value is false, so by default, projects limit allowlisted
+        // addresses to a mint qty of `DEFAULT_MAX_INVOCATIONS_PER_ADDRESS`
+        bool useMaxInvocationsPerAddressOverride;
+        // a value of 0 means no limit
+        // (only used if `useMaxInvocationsPerAddressOverride` is true)
+        uint24 maxInvocationsPerAddressOverride;
         uint24 maxInvocations;
         uint256 pricePerTokenInWei;
     }
@@ -68,8 +78,10 @@ contract MinterMerkleV1 is ReentrancyGuard, IFilteredMinterMerkleV0 {
 
     /// projectId => merkle root
     mapping(uint256 => bytes32) public projectMerkleRoot;
-    /// projectId => purchaser address => has purchased one or more mints
-    mapping(uint256 => mapping(address => bool)) public projectMintedBy;
+
+    /// projectId => purchaser address => qty of mints purchased for project
+    mapping(uint256 => mapping(address => uint256))
+        public projectUserInvocations;
 
     modifier onlyArtist(uint256 _projectId) {
         require(
@@ -149,21 +161,36 @@ contract MinterMerkleV1 is ReentrancyGuard, IFilteredMinterMerkleV0 {
     }
 
     /**
-     * @notice Toggles mint limit of one per address for project `_projectId`.
-     * If mint limit is disabled, unlimited mints per address are allowed.
+     * @notice Sets maximum allowed invocations per allowlisted address for
+     * project `_project` to `limit`. If `limit` is set to 0, infinite mints
+     * will be allowed.
+     * Default is a value of 1 if never configured by artist.
      * @param _projectId Project ID to toggle the mint limit.
+     * @param _maxInvocationsPerAddress Maximum allowed invocations per
+     * allowlisted address.
+     * @dev default value stated above must be updated if the value of
+     * CONFIG_USE_MAX_INVOCATIONS_PER_ADDRESS_OVERRIDE is changed.
      */
-    function toggleProjectMintLimiter(uint256 _projectId)
-        external
-        onlyArtist(_projectId)
-    {
+    function setProjectInvocationsPerAddress(
+        uint256 _projectId,
+        uint24 _maxInvocationsPerAddress
+    ) external onlyArtist(_projectId) {
         ProjectConfig storage _projectConfig = projectConfig[_projectId];
-        _projectConfig.mintLimiterDisabled = !_projectConfig
-            .mintLimiterDisabled;
+        // use override value instead of the contract's default
+        _projectConfig.useMaxInvocationsPerAddressOverride = true;
+        // update the override value
+        _projectConfig
+            .maxInvocationsPerAddressOverride = _maxInvocationsPerAddress;
+        // generic events
         emit ConfigValueSet(
             _projectId,
-            CONFIG_MINT_LIMITER_DISABLED,
-            _projectConfig.mintLimiterDisabled
+            CONFIG_USE_MAX_INVOCATIONS_PER_ADDRESS_OVERRIDE,
+            true
+        );
+        emit ConfigValueSet(
+            _projectId,
+            CONFIG_MAX_INVOCATIONS_OVERRIDE,
+            uint256(_maxInvocationsPerAddress)
         );
     }
 
@@ -243,18 +270,6 @@ contract MinterMerkleV1 is ReentrancyGuard, IFilteredMinterMerkleV0 {
         returns (uint256)
     {
         return uint256(projectConfig[_projectId].maxInvocations);
-    }
-
-    /**
-     * @notice projectId => may a single address mint multiple times?
-     * (default behavior is limit one mint per address)
-     */
-    function projectMintLimiterDisabled(uint256 _projectId)
-        external
-        view
-        returns (bool)
-    {
-        return projectConfig[_projectId].mintLimiterDisabled;
     }
 
     /**
@@ -372,15 +387,19 @@ contract MinterMerkleV1 is ReentrancyGuard, IFilteredMinterMerkleV0 {
         );
 
         // limit mints per address by project
-        if (projectMintedBy[_projectId][msg.sender]) {
-            require(
-                _projectConfig.mintLimiterDisabled,
-                "Limit 1 mint per address"
-            );
-        } else {
-            // EFFECTS
-            projectMintedBy[_projectId][msg.sender] = true;
-        }
+        uint256 _maxProjectInvocationsPerAddress = _projectConfig
+            .useMaxInvocationsPerAddressOverride
+            ? _projectConfig.maxInvocationsPerAddressOverride
+            : DEFAULT_MAX_INVOCATIONS_PER_ADDRESS;
+
+        // FINAL CHECK, WITH FOLLOW-ON EFFECTS
+        require(
+            // _++ returns current invocations, then increments
+            projectUserInvocations[_projectId][msg.sender]++ <
+                _maxProjectInvocationsPerAddress ||
+                _maxProjectInvocationsPerAddress == 0,
+            "Maximum number of invocations per address reached"
+        );
 
         tokenId = minterFilter.mint(_to, _projectId, msg.sender);
 
@@ -449,6 +468,28 @@ contract MinterMerkleV1 is ReentrancyGuard, IFilteredMinterMerkleV0 {
                 }("");
                 require(success_, "Additional Payee payment failed");
             }
+        }
+    }
+
+    /**
+     * @notice projectId => maximum invocations per allowlisted address. If a
+     * a value of 0 is returned, there is no limit on the number of mints per
+     * allowlisted address.
+     * Default behavior is limit 1 mint per address.
+     * This value can be changed at any time by the artist.
+     * @dev default value stated above must be updated if the value of
+     * CONFIG_USE_MAX_INVOCATIONS_PER_ADDRESS_OVERRIDE is changed.
+     */
+    function projectMaxInvocationsPerAddress(uint256 _projectId)
+        external
+        view
+        returns (uint256)
+    {
+        ProjectConfig storage _projectConfig = projectConfig[_projectId];
+        if (_projectConfig.useMaxInvocationsPerAddressOverride) {
+            return uint256(_projectConfig.maxInvocationsPerAddressOverride);
+        } else {
+            return DEFAULT_MAX_INVOCATIONS_PER_ADDRESS;
         }
     }
 

--- a/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
+++ b/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
@@ -81,7 +81,7 @@ contract MinterMerkleV1 is ReentrancyGuard, IFilteredMinterMerkleV0 {
 
     /// projectId => purchaser address => qty of mints purchased for project
     mapping(uint256 => mapping(address => uint256))
-        public projectUserInvocations;
+        public projectUserMintInvocations;
 
     modifier onlyArtist(uint256 _projectId) {
         require(
@@ -162,8 +162,9 @@ contract MinterMerkleV1 is ReentrancyGuard, IFilteredMinterMerkleV0 {
 
     /**
      * @notice Sets maximum allowed invocations per allowlisted address for
-     * project `_project` to `limit`. If `limit` is set to 0, infinite mints
-     * will be allowed.
+     * project `_project` to `limit`. If `limit` is set to 0, allowlisted
+     * addresses will be able to mint as many times as desired, until the
+     * project reaches its maximum invocations.
      * Default is a value of 1 if never configured by artist.
      * @param _projectId Project ID to toggle the mint limit.
      * @param _maxInvocationsPerAddress Maximum allowed invocations per
@@ -177,6 +178,8 @@ contract MinterMerkleV1 is ReentrancyGuard, IFilteredMinterMerkleV0 {
     ) external onlyArtist(_projectId) {
         ProjectConfig storage _projectConfig = projectConfig[_projectId];
         // use override value instead of the contract's default
+        // @dev this never changes from true to false; default value is only
+        // used if artist has never configured project invocations per address
         _projectConfig.useMaxInvocationsPerAddressOverride = true;
         // update the override value
         _projectConfig
@@ -392,15 +395,22 @@ contract MinterMerkleV1 is ReentrancyGuard, IFilteredMinterMerkleV0 {
             ? _projectConfig.maxInvocationsPerAddressOverride
             : DEFAULT_MAX_INVOCATIONS_PER_ADDRESS;
 
-        // FINAL CHECK, WITH FOLLOW-ON EFFECTS
         require(
-            // _++ returns current invocations, then increments
-            projectUserInvocations[_projectId][msg.sender]++ <
+            projectUserMintInvocations[_projectId][msg.sender] <
                 _maxProjectInvocationsPerAddress ||
                 _maxProjectInvocationsPerAddress == 0,
             "Maximum number of invocations per address reached"
         );
 
+        // EFFECTS
+        // increment user's invocations for this project
+        unchecked {
+            // this will never overflow since user's invocations on a project
+            // are limited by the project's max invocations
+            projectUserMintInvocations[_projectId][msg.sender]++;
+        }
+
+        // mint token
         tokenId = minterFilter.mint(_to, _projectId, msg.sender);
 
         // okay if this underflows because if statement will always eval false.
@@ -481,7 +491,7 @@ contract MinterMerkleV1 is ReentrancyGuard, IFilteredMinterMerkleV0 {
      * CONFIG_USE_MAX_INVOCATIONS_PER_ADDRESS_OVERRIDE is changed.
      */
     function projectMaxInvocationsPerAddress(uint256 _projectId)
-        external
+        public
         view
         returns (uint256)
     {
@@ -490,6 +500,60 @@ contract MinterMerkleV1 is ReentrancyGuard, IFilteredMinterMerkleV0 {
             return uint256(_projectConfig.maxInvocationsPerAddressOverride);
         } else {
             return DEFAULT_MAX_INVOCATIONS_PER_ADDRESS;
+        }
+    }
+
+    /**
+     * @notice Returns remaining invocations for a given address.
+     * If `projectLimitsMintInvocationsPerAddress` is false, individual
+     * addresses are only limited by the project's maximum invocations, and a
+     * dummy value of zero is returned for `mintInvocationsRemaining`.
+     * If `projectLimitsMintInvocationsPerAddress` is true, the quantity of
+     * remaining mint invocations for address `_address` is returned as
+     * `mintInvocationsRemaining`.
+     * Note that mint invocations per address can be changed at any time by the
+     * artist of a project.
+     * Also note that all mint invocations are limited by a project's maximum
+     * invocations as defined on the core contract. This function may return
+     * a value greater than the project's remaining invocations.
+     */
+    function projectRemainingInvocationsForAddress(
+        uint256 _projectId,
+        address _address
+    )
+        external
+        view
+        returns (
+            bool projectLimitsMintInvocationsPerAddress,
+            uint256 mintInvocationsRemaining
+        )
+    {
+        uint256 maxInvocationsPerAddress = projectMaxInvocationsPerAddress(
+            _projectId
+        );
+        if (maxInvocationsPerAddress == 0) {
+            // project does not limit mint invocations per address, so leave
+            // `projectLimitsMintInvocationsPerAddress` at solitiy initial
+            // value of false. Also leave `mintInvocationsRemaining` at
+            // solidity initial value of zero, as indicated in this function's
+            // documentation.
+        } else {
+            projectLimitsMintInvocationsPerAddress = true;
+            uint256 userMintInvocations = projectUserMintInvocations[
+                _projectId
+            ][_address];
+            // if user has not reached max invocations per address, return
+            // remaining invocations
+            if (maxInvocationsPerAddress > userMintInvocations) {
+                unchecked {
+                    // will never underflow due to the check above
+                    mintInvocationsRemaining =
+                        maxInvocationsPerAddress -
+                        userMintInvocations;
+                }
+            }
+            // else user has reached their maximum invocations, so leave
+            // `mintInvocationsRemaining` at solidity initial value of zero
         }
     }
 

--- a/test/core/gas-tests/GenArt721CoreV3_GasTests.test.ts
+++ b/test/core/gas-tests/GenArt721CoreV3_GasTests.test.ts
@@ -350,10 +350,10 @@ describe("GenArt721CoreV3 Gas Tests", async function () {
       await this.minterMerkle
         .connect(this.accounts.artist)
         .updateMerkleRoot(this.projectThree, _merkleTree.getRoot());
-      // toggle disable mint limiter to allow for taking an average
+      // allow unlimited mints to enable taking an average
       await this.minterMerkle
         .connect(this.accounts.artist)
-        .toggleProjectMintLimiter(this.projectThree);
+        .setProjectInvocationsPerAddress(this.projectThree, 0);
       await this.minterMerkle
         .connect(this.accounts.artist)
         .updateMerkleRoot(this.projectThree, _merkleTree.getRoot());

--- a/test/minter-suite-minters/MinterMerkle/MinterMerkle.common.ts
+++ b/test/minter-suite-minters/MinterMerkle/MinterMerkle.common.ts
@@ -220,6 +220,17 @@ export const MinterMerkle_Common = async () => {
         .updateMerkleRoot(this.projectZero, newMerkleRoot);
     });
 
+    it("does not allow Merkle root of zero", async function () {
+      const newMerkleRoot = constants.ZERO_BYTES32;
+      // artist allowed
+      await expectRevert(
+        this.minter
+          .connect(this.accounts.artist)
+          .updateMerkleRoot(this.projectZero, newMerkleRoot),
+        "Root must be provided"
+      );
+    });
+
     it("emits event when update merkle root", async function () {
       const newMerkleRoot = this.merkleTreeZero.getHexRoot();
       await expect(

--- a/test/minter-suite-minters/MinterMerkle/MinterMerkle.common.ts
+++ b/test/minter-suite-minters/MinterMerkle/MinterMerkle.common.ts
@@ -20,7 +20,11 @@ import Safe from "@gnosis.pm/safe-core-sdk";
 import { SafeTransactionDataPartial } from "@gnosis.pm/safe-core-sdk-types";
 import { getGnosisSafe } from "../../util/GnosisSafeNetwork";
 
-import { CONFIG_MERKLE_ROOT, CONFIG_MINT_LIMITER_DISABLED } from "./constants";
+import {
+  CONFIG_MERKLE_ROOT,
+  CONFIG_USE_MAX_INVOCATIONS_PER_ADDRESS_OVERRIDE,
+  CONFIG_MAX_INVOCATIONS_OVERRIDE,
+} from "./constants";
 
 /**
  * @notice This returns the same result as solidity:
@@ -170,26 +174,26 @@ export const MinterMerkle_Common = async () => {
     });
   });
 
-  describe("toggleProjectMintLimiter", async function () {
-    it("only allows artist to toggle mint limiter", async function () {
+  describe("setProjectInvocationsPerAddress", async function () {
+    it("only allows artist to set", async function () {
       // user not allowed
       await expectRevert(
         this.minter
           .connect(this.accounts.user)
-          .toggleProjectMintLimiter(this.projectZero),
+          .setProjectInvocationsPerAddress(this.projectZero, 0),
         "Only Artist"
       );
       // additional not allowed
       await expectRevert(
         this.minter
           .connect(this.accounts.additional)
-          .toggleProjectMintLimiter(this.projectZero),
+          .setProjectInvocationsPerAddress(this.projectZero, 0),
         "Only Artist"
       );
       // artist allowed
       await this.minter
         .connect(this.accounts.artist)
-        .toggleProjectMintLimiter(this.projectZero);
+        .setProjectInvocationsPerAddress(this.projectZero, 0);
     });
   });
 
@@ -228,44 +232,69 @@ export const MinterMerkle_Common = async () => {
     });
   });
 
-  describe("toggleProjectMintLimiter", async function () {
-    it("only allows artist to toggle mint limiter", async function () {
+  describe("setProjectInvocationsPerAddress", async function () {
+    it("only allows artist to setProjectInvocationsPerAddress", async function () {
       const newMerkleRoot = this.merkleTreeZero.getHexRoot();
       // user not allowed
       await expectRevert(
         this.minter
           .connect(this.accounts.user)
-          .toggleProjectMintLimiter(this.projectZero),
+          .setProjectInvocationsPerAddress(this.projectZero, 0),
         "Only Artist"
       );
       // additional not allowed
       await expectRevert(
         this.minter
           .connect(this.accounts.additional)
-          .toggleProjectMintLimiter(this.projectZero),
+          .setProjectInvocationsPerAddress(this.projectZero, 0),
         "Only Artist"
       );
       // artist allowed
       await this.minter
         .connect(this.accounts.artist)
-        .toggleProjectMintLimiter(this.projectZero);
+        .setProjectInvocationsPerAddress(this.projectZero, 0);
     });
 
-    it("emits event when toggling mint limiter", async function () {
+    it("emits events when setting project max invocations per address", async function () {
       await expect(
         this.minter
           .connect(this.accounts.artist)
-          .toggleProjectMintLimiter(this.projectZero)
+          .setProjectInvocationsPerAddress(this.projectZero, 0)
       )
         .to.emit(this.minter, "ConfigValueSet(uint256,bytes32,bool)")
-        .withArgs(this.projectZero, CONFIG_MINT_LIMITER_DISABLED, true);
+        .withArgs(
+          this.projectZero,
+          CONFIG_USE_MAX_INVOCATIONS_PER_ADDRESS_OVERRIDE,
+          true
+        );
+      // expect zero value when set to zero
       await expect(
         this.minter
           .connect(this.accounts.artist)
-          .toggleProjectMintLimiter(this.projectZero)
+          .setProjectInvocationsPerAddress(this.projectZero, 0)
+      )
+        .to.emit(this.minter, "ConfigValueSet(uint256,bytes32,uint256)")
+        .withArgs(this.projectZero, CONFIG_MAX_INVOCATIONS_OVERRIDE, 0);
+      // expect true again
+      await expect(
+        this.minter
+          .connect(this.accounts.artist)
+          .setProjectInvocationsPerAddress(this.projectZero, 0)
       )
         .to.emit(this.minter, "ConfigValueSet(uint256,bytes32,bool)")
-        .withArgs(this.projectZero, CONFIG_MINT_LIMITER_DISABLED, false);
+        .withArgs(
+          this.projectZero,
+          CONFIG_USE_MAX_INVOCATIONS_PER_ADDRESS_OVERRIDE,
+          true
+        );
+      // expect 999 value when set to 999
+      await expect(
+        this.minter
+          .connect(this.accounts.artist)
+          .setProjectInvocationsPerAddress(this.projectZero, 999)
+      )
+        .to.emit(this.minter, "ConfigValueSet(uint256,bytes32,uint256)")
+        .withArgs(this.projectZero, CONFIG_MAX_INVOCATIONS_OVERRIDE, 999);
     });
   });
 
@@ -358,7 +387,7 @@ export const MinterMerkle_Common = async () => {
         );
     });
 
-    it("enforces mint limiter when limiter on", async function () {
+    it("enforces mint limit per address when default limit of one is used", async function () {
       await this.minter
         .connect(this.accounts.user)
         ["purchase(uint256,bytes32[])"](
@@ -368,7 +397,7 @@ export const MinterMerkle_Common = async () => {
             value: this.pricePerTokenInWei,
           }
         );
-      // expect revert after account hits minting limit
+      // expect revert after account hits default invocations per address limit of one
       await expectRevert(
         this.minter
           .connect(this.accounts.user)
@@ -379,15 +408,15 @@ export const MinterMerkle_Common = async () => {
               value: this.pricePerTokenInWei,
             }
           ),
-        "Limit 1 mint per address"
+        "Maximum number of invocations per address reached"
       );
     });
 
-    it("allows multiple mints when limiter off", async function () {
+    it("allows multiple mints when override is set to unlimited", async function () {
       // toggle mint limiter to be off
       await this.minter
         .connect(this.accounts.artist)
-        .toggleProjectMintLimiter(this.projectZero);
+        .setProjectInvocationsPerAddress(this.projectZero, 0);
       // mint 15 times from a single address without failure
       for (let i = 0; i < 15; i++) {
         await this.minter
@@ -400,6 +429,110 @@ export const MinterMerkle_Common = async () => {
             }
           );
       }
+    });
+
+    it("allows only five mints when override is set to five", async function () {
+      // toggle mint limiter to be off
+      await this.minter
+        .connect(this.accounts.artist)
+        .setProjectInvocationsPerAddress(this.projectZero, 5);
+      // mint 5 times from a single address without failure
+      for (let i = 0; i < 5; i++) {
+        await this.minter
+          .connect(this.accounts.user)
+          ["purchase(uint256,bytes32[])"](
+            this.projectZero,
+            this.userMerkleProofZero,
+            {
+              value: this.pricePerTokenInWei,
+            }
+          );
+      }
+      // expect revert after account hits >5 invocations
+      await expectRevert(
+        this.minter
+          .connect(this.accounts.user)
+          ["purchase(uint256,bytes32[])"](
+            this.projectZero,
+            this.userMerkleProofZero,
+            {
+              value: this.pricePerTokenInWei,
+            }
+          ),
+        "Maximum number of invocations per address reached"
+      );
+    });
+
+    it("stops allowing mints if artist reduces max invocations per address = current user's project invocations", async function () {
+      // artist allows unlimited mints per address
+      await this.minter
+        .connect(this.accounts.artist)
+        .setProjectInvocationsPerAddress(this.projectZero, 0);
+      // mint 5 times from a single address without failure
+      for (let i = 0; i < 5; i++) {
+        await this.minter
+          .connect(this.accounts.user)
+          ["purchase(uint256,bytes32[])"](
+            this.projectZero,
+            this.userMerkleProofZero,
+            {
+              value: this.pricePerTokenInWei,
+            }
+          );
+      }
+      // artist allows five mints per address
+      await this.minter
+        .connect(this.accounts.artist)
+        .setProjectInvocationsPerAddress(this.projectZero, 5);
+      // expect revert because account already has 5 invocations
+      await expectRevert(
+        this.minter
+          .connect(this.accounts.user)
+          ["purchase(uint256,bytes32[])"](
+            this.projectZero,
+            this.userMerkleProofZero,
+            {
+              value: this.pricePerTokenInWei,
+            }
+          ),
+        "Maximum number of invocations per address reached"
+      );
+    });
+
+    it("stops allowing mints if artist reduces max invocations per address < current user's project invocations", async function () {
+      // artist allows unlimited mints per address
+      await this.minter
+        .connect(this.accounts.artist)
+        .setProjectInvocationsPerAddress(this.projectZero, 0);
+      // mint 5 times from a single address without failure
+      for (let i = 0; i < 5; i++) {
+        await this.minter
+          .connect(this.accounts.user)
+          ["purchase(uint256,bytes32[])"](
+            this.projectZero,
+            this.userMerkleProofZero,
+            {
+              value: this.pricePerTokenInWei,
+            }
+          );
+      }
+      // artist allows one mint per address
+      await this.minter
+        .connect(this.accounts.artist)
+        .setProjectInvocationsPerAddress(this.projectZero, 1);
+      // expect revert because account already has >1 invocation
+      await expectRevert(
+        this.minter
+          .connect(this.accounts.user)
+          ["purchase(uint256,bytes32[])"](
+            this.projectZero,
+            this.userMerkleProofZero,
+            {
+              value: this.pricePerTokenInWei,
+            }
+          ),
+        "Maximum number of invocations per address reached"
+      );
     });
 
     it("rejects invalid merkle proofs", async function () {
@@ -422,7 +555,7 @@ export const MinterMerkle_Common = async () => {
     it("does nothing if setProjectMaxInvocations is not called (fails correctly)", async function () {
       await this.minter
         .connect(this.accounts.artist)
-        .toggleProjectMintLimiter(this.projectZero);
+        .setProjectInvocationsPerAddress(this.projectZero, 0);
       for (let i = 0; i < 15; i++) {
         await this.minter
           .connect(this.accounts.user)
@@ -512,7 +645,7 @@ export const MinterMerkle_Common = async () => {
     it("fails more cheaply if setProjectMaxInvocations is set", async function () {
       await this.minter
         .connect(this.accounts.artist)
-        .toggleProjectMintLimiter(this.projectZero);
+        .setProjectInvocationsPerAddress(this.projectZero, 0);
       // Try without setProjectMaxInvocations, store gas cost
       for (let i = 0; i < 15; i++) {
         await this.minter
@@ -548,7 +681,7 @@ export const MinterMerkle_Common = async () => {
         .setProjectMaxInvocations(this.projectOne);
       await this.minter
         .connect(this.accounts.artist)
-        .toggleProjectMintLimiter(this.projectOne);
+        .setProjectInvocationsPerAddress(this.projectOne, 0);
       for (let i = 0; i < 15; i++) {
         await this.minter
           .connect(this.accounts.user)
@@ -703,40 +836,63 @@ export const MinterMerkle_Common = async () => {
     });
   });
 
-  describe("projectMintLimiterDisabled", async function () {
-    it("is false by default", async function () {
-      const projectMintLimiterDisabled = await this.minter
+  describe("projectMaxInvocationsPerAddress", async function () {
+    it("is 1 by default", async function () {
+      const projectMaxInvocationsPerAddress_ = await this.minter
         .connect(this.accounts.user)
-        .projectMintLimiterDisabled(this.projectZero);
-      expect(projectMintLimiterDisabled).to.be.false;
+        .projectMaxInvocationsPerAddress(this.projectZero);
+      expect(projectMaxInvocationsPerAddress_).to.equal(1);
     });
 
-    it("is true by when toggled", async function () {
+    it("is 0 by when set to 0", async function () {
       await this.minter
         .connect(this.accounts.artist)
-        .toggleProjectMintLimiter(this.projectZero);
-      const projectMintLimiterDisabled = await this.minter
+        .setProjectInvocationsPerAddress(this.projectZero, 0);
+      const projectMaxInvocationsPerAddress_ = await this.minter
         .connect(this.accounts.user)
-        .projectMintLimiterDisabled(this.projectZero);
-      expect(projectMintLimiterDisabled).to.be.true;
+        .projectMaxInvocationsPerAddress(this.projectZero);
+      expect(projectMaxInvocationsPerAddress_).to.equal(0);
     });
 
-    it("is false by when toggled twice", async function () {
+    it("is 999 by when set to 999", async function () {
       await this.minter
         .connect(this.accounts.artist)
-        .toggleProjectMintLimiter(this.projectZero);
-      await this.minter
-        .connect(this.accounts.artist)
-        .toggleProjectMintLimiter(this.projectZero);
-      const projectMintLimiterDisabled = await this.minter
+        .setProjectInvocationsPerAddress(this.projectZero, 999);
+      const projectMaxInvocationsPerAddress_ = await this.minter
         .connect(this.accounts.user)
-        .projectMintLimiterDisabled(this.projectZero);
-      expect(projectMintLimiterDisabled).to.be.false;
+        .projectMaxInvocationsPerAddress(this.projectZero);
+      expect(projectMaxInvocationsPerAddress_).to.equal(999);
+    });
+
+    it("is 999 by when set to 0 then changed to 999", async function () {
+      await this.minter
+        .connect(this.accounts.artist)
+        .setProjectInvocationsPerAddress(this.projectZero, 0);
+      await this.minter
+        .connect(this.accounts.artist)
+        .setProjectInvocationsPerAddress(this.projectZero, 999);
+      const projectMaxInvocationsPerAddress_ = await this.minter
+        .connect(this.accounts.user)
+        .projectMaxInvocationsPerAddress(this.projectZero);
+      expect(projectMaxInvocationsPerAddress_).to.equal(999);
+    });
+
+    it("is 1 by when set to 0 then changed to 1", async function () {
+      await this.minter
+        .connect(this.accounts.artist)
+        .setProjectInvocationsPerAddress(this.projectZero, 0);
+      await this.minter
+        .connect(this.accounts.artist)
+        .setProjectInvocationsPerAddress(this.projectZero, 1);
+      const projectMaxInvocationsPerAddress_ = await this.minter
+        .connect(this.accounts.user)
+        .projectMaxInvocationsPerAddress(this.projectZero);
+      expect(projectMaxInvocationsPerAddress_).to.equal(1);
     });
   });
 
   describe("reentrancy attack", async function () {
-    it("does not allow reentrant purchaseTo, when mint limiter on", async function () {
+    it("does not allow reentrant purchaseTo, when invocations per address is default value", async function () {
       // contract buys are always allowed by default if in merkle tree
       // attacker deploys reentrancy contract specifically for Merkle minter(s)
       const reentrancyMockFactory = await ethers.getContractFactory(
@@ -817,10 +973,10 @@ export const MinterMerkle_Common = async () => {
       }
     });
 
-    it("does not allow reentrant purchaseTo, when mint limiter off", async function () {
+    it("does not allow reentrant purchaseTo, when mint limiter invocations per address set to 0 (unlimited)", async function () {
       await this.minter
         .connect(this.accounts.artist)
-        .toggleProjectMintLimiter(this.projectOne);
+        .setProjectInvocationsPerAddress(this.projectOne, 0);
       // contract buys are always allowed by default if in merkle tree
       // attacker deploys reentrancy contract specifically for Merkle minter(s)
       const reentrancyMockFactory = await ethers.getContractFactory(

--- a/test/minter-suite-minters/MinterMerkle/MinterMerkleV1.test.ts
+++ b/test/minter-suite-minters/MinterMerkle/MinterMerkleV1.test.ts
@@ -171,19 +171,6 @@ describe("MinterMerkleV1", async function () {
     MinterMerkle_Common();
   });
 
-  describe("updateMerkleRoot", async function () {
-    it("does not allow Merkle root of zero", async function () {
-      const newMerkleRoot = constants.ZERO_BYTES32;
-      // artist allowed
-      await expectRevert(
-        this.minter
-          .connect(this.accounts.artist)
-          .updateMerkleRoot(this.projectZero, newMerkleRoot),
-        "Root must be provided"
-      );
-    });
-  });
-
   describe("setProjectMaxInvocations", async function () {
     it("allows artist to call setProjectMaxInvocations", async function () {
       await this.minter

--- a/test/minter-suite-minters/MinterMerkle/constants.ts
+++ b/test/minter-suite-minters/MinterMerkle/constants.ts
@@ -2,6 +2,8 @@ import { ethers } from "hardhat";
 
 export const CONFIG_MERKLE_ROOT =
   ethers.utils.formatBytes32String("merkleRoot");
-export const CONFIG_MINT_LIMITER_DISABLED = ethers.utils.formatBytes32String(
-  "mintLimiterDisabled"
+export const CONFIG_USE_MAX_INVOCATIONS_PER_ADDRESS_OVERRIDE =
+  ethers.utils.formatBytes32String("useMaxMintsPerAddrOverride");
+export const CONFIG_MAX_INVOCATIONS_OVERRIDE = ethers.utils.formatBytes32String(
+  "maxMintsPerAddrOverride"
 );


### PR DESCRIPTION
Update V0 and V1 of our Merkle minters to allow the artist to define a qty of allowed mints per address.

Values on the V1 minter are packed to keep gas impacts of this change minimal.

## Tests
Tests are updated for equivalent coverage of the new functionality:
- **MinterMerkleV1**: 100% statement, 100% branches, 100% functions, 100% lines
- **MinterMerkleV0**: 95% statement, 79% branches, 100% functions, 95% lines
>MinterMerkleV0 not planned to be used in production environment

## Other
V0 minter pulls an update from the V1 minter that validates a Merkle root != zero when artist is assigning.

## Follow-on
- Subgraph should be updated with the new MerkleMinter ABIs, and additional routing for generic event emitting a single uint256 should be added to the subgraph config.
  - see https://github.com/ArtBlocks/artblocks-subgraph/pull/113
- Frontend updates:
  - New MerkleMinter ABIs
  - Display qty of mints used and allowed for connected user
    - see `projectUserMintInvocations ` and `projectMaxInvocationsPerAddress` view functions
  - Update artist project configure to allow artists to configure the new mint limit per address value