### PR TITLE
bump V3 related contracts to sol 0.8.16

### DIFF
--- a/contracts/BasicRandomizerV2.sol
+++ b/contracts/BasicRandomizerV2.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Creatd By: Art Blocks Inc.
 
-pragma solidity 0.8.9;
+pragma solidity 0.8.16;
 
 import "./interfaces/0.8.x/IRandomizerV2.sol";
 import "./interfaces/0.8.x/IGenArt721CoreContractV3.sol";

--- a/contracts/minter-suite/MinterFilter/MinterFilterV1.sol
+++ b/contracts/minter-suite/MinterFilter/MinterFilterV1.sol
@@ -8,7 +8,7 @@ import "../../interfaces/0.8.x/IGenArt721CoreContractV3.sol";
 
 import "@openzeppelin-4.5/contracts/utils/structs/EnumerableMap.sol";
 
-pragma solidity 0.8.9;
+pragma solidity 0.8.16;
 
 /**
  * @title Minter filter contract that allows filtered minters to be set

--- a/contracts/minter-suite/Minters/MinterDAExp/MinterDAExpV2.sol
+++ b/contracts/minter-suite/Minters/MinterDAExp/MinterDAExpV2.sol
@@ -8,7 +8,7 @@ import "../../../interfaces/0.8.x/IFilteredMinterV0.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/math/SafeCast.sol";
 
-pragma solidity 0.8.9;
+pragma solidity 0.8.16;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/minter-suite/Minters/MinterDALin/MinterDALinV2.sol
+++ b/contracts/minter-suite/Minters/MinterDALin/MinterDALinV2.sol
@@ -8,7 +8,7 @@ import "../../../interfaces/0.8.x/IFilteredMinterV0.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/math/SafeCast.sol";
 
-pragma solidity 0.8.9;
+pragma solidity 0.8.16;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/minter-suite/Minters/MinterHolder/MinterHolderV1.sol
+++ b/contracts/minter-suite/Minters/MinterHolder/MinterHolderV1.sol
@@ -11,7 +11,7 @@ import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/structs/EnumerableSet.sol";
 import "@openzeppelin-4.5/contracts/utils/structs/EnumerableMap.sol";
 
-pragma solidity 0.8.9;
+pragma solidity 0.8.16;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
+++ b/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
@@ -9,7 +9,7 @@ import "@openzeppelin-4.7/contracts/utils/cryptography/MerkleProof.sol";
 import "@openzeppelin-4.7/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin-4.7/contracts/security/ReentrancyGuard.sol";
 
-pragma solidity 0.8.9;
+pragma solidity 0.8.16;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
+++ b/contracts/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
@@ -7,7 +7,7 @@ import "../../../interfaces/0.8.x/IFilteredMinterV0.sol";
 
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 
-pragma solidity 0.8.9;
+pragma solidity 0.8.16;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V2.sol
+++ b/contracts/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V2.sol
@@ -8,7 +8,7 @@ import "../../../interfaces/0.8.x/IFilteredMinterV0.sol";
 import "@openzeppelin-4.5/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 
-pragma solidity 0.8.9;
+pragma solidity 0.8.16;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/mock/RandomizerV2_NoAssignMock.sol
+++ b/contracts/mock/RandomizerV2_NoAssignMock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Creatd By: Art Blocks Inc.
 
-pragma solidity 0.8.9;
+pragma solidity 0.8.16;
 
 import "../BasicRandomizerV2.sol";
 

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
@@ -172,7 +172,7 @@ describe("MinterDAExpV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0138786")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0138417")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
@@ -173,7 +173,7 @@ describe("MinterDALinV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0138862")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0138501")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/MinterHolder/MinterHolderV1.test.ts
+++ b/test/minter-suite-minters/MinterHolder/MinterHolderV1.test.ts
@@ -367,7 +367,7 @@ describe("MinterHolderV1", async function () {
         ethers.utils.formatUnits(txCost.toString(), "ether").toString(),
         "ETH"
       );
-      expect(compareBN(txCost, ethers.utils.parseEther("0.0118406"), 1)).to.be
+      expect(compareBN(txCost, ethers.utils.parseEther("0.0115697"), 1)).to.be
         .true;
     });
   });

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
@@ -177,7 +177,7 @@ describe("MinterSetPriceV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0129276")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0128907")); // assuming a cost of 100 GWEI
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
@@ -279,7 +279,7 @@ describe("MinterSetPriceERC20V2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0129491"));
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0129122"));
     });
   });
 


### PR DESCRIPTION
Update everything related to V3 core contract from 0.8.9 to 0.8.16.

This does not bump any contracts related to prior core contract versions.