### PR TITLE
Version bump from sol 0.8.16 to 0.8.17

### DIFF
--- a/contracts/AdminACLV0.sol
+++ b/contracts/AdminACLV0.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.17;
 
 import "./interfaces/0.8.x/IAdminACLV0.sol";
 import "@openzeppelin-4.7/contracts/access/Ownable.sol";

--- a/contracts/BasicRandomizerV2.sol
+++ b/contracts/BasicRandomizerV2.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Creatd By: Art Blocks Inc.
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.17;
 
 import "./interfaces/0.8.x/IRandomizerV2.sol";
 import "./interfaces/0.8.x/IGenArt721CoreContractV3.sol";

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity 0.8.16;
+pragma solidity 0.8.17;
 
 // Created By: Art Blocks Inc.
 

--- a/contracts/minter-suite/MinterFilter/MinterFilterV1.sol
+++ b/contracts/minter-suite/MinterFilter/MinterFilterV1.sol
@@ -8,7 +8,7 @@ import "../../interfaces/0.8.x/IGenArt721CoreContractV3.sol";
 
 import "@openzeppelin-4.5/contracts/utils/structs/EnumerableMap.sol";
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.17;
 
 /**
  * @title Minter filter contract that allows filtered minters to be set

--- a/contracts/minter-suite/Minters/MinterDAExp/MinterDAExpV2.sol
+++ b/contracts/minter-suite/Minters/MinterDAExp/MinterDAExpV2.sol
@@ -8,7 +8,7 @@ import "../../../interfaces/0.8.x/IFilteredMinterV0.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/math/SafeCast.sol";
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.17;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/minter-suite/Minters/MinterDALin/MinterDALinV2.sol
+++ b/contracts/minter-suite/Minters/MinterDALin/MinterDALinV2.sol
@@ -8,7 +8,7 @@ import "../../../interfaces/0.8.x/IFilteredMinterV0.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/math/SafeCast.sol";
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.17;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/minter-suite/Minters/MinterHolder/MinterHolderV1.sol
+++ b/contracts/minter-suite/Minters/MinterHolder/MinterHolderV1.sol
@@ -11,7 +11,7 @@ import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/structs/EnumerableSet.sol";
 import "@openzeppelin-4.5/contracts/utils/structs/EnumerableMap.sol";
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.17;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
+++ b/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
@@ -9,7 +9,7 @@ import "@openzeppelin-4.7/contracts/utils/cryptography/MerkleProof.sol";
 import "@openzeppelin-4.7/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin-4.7/contracts/security/ReentrancyGuard.sol";
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.17;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
+++ b/contracts/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
@@ -7,7 +7,7 @@ import "../../../interfaces/0.8.x/IFilteredMinterV0.sol";
 
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.17;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V2.sol
+++ b/contracts/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V2.sol
@@ -8,7 +8,7 @@ import "../../../interfaces/0.8.x/IFilteredMinterV0.sol";
 import "@openzeppelin-4.5/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.17;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/mock/DeadReceiverMock.sol
+++ b/contracts/mock/DeadReceiverMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.17;
 
 /**
  * @notice This reverts when receiving Ether

--- a/contracts/mock/MockAdminACLV0.sol
+++ b/contracts/mock/MockAdminACLV0.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.17;
 
 import "../interfaces/0.8.x/IAdminACLV0.sol";
 import "@openzeppelin-4.7/contracts/access/Ownable.sol";

--- a/contracts/mock/RandomizerV2_NoAssignMock.sol
+++ b/contracts/mock/RandomizerV2_NoAssignMock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Creatd By: Art Blocks Inc.
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.17;
 
 import "../BasicRandomizerV2.sol";
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -46,7 +46,7 @@ module.exports = {
         },
       },
       {
-        version: "0.8.16",
+        version: "0.8.17",
         settings: {
           optimizer: {
             enabled: true,

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
@@ -172,7 +172,7 @@ describe("MinterDAExpV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0138417")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0138415")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
@@ -173,7 +173,7 @@ describe("MinterDALinV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0138501")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0138498")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
@@ -177,7 +177,7 @@ describe("MinterSetPriceV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0128907")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0128905")); // assuming a cost of 100 GWEI
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
@@ -279,7 +279,7 @@ describe("MinterSetPriceERC20V2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0129122"));
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.012912"));
     });
   });
 


### PR DESCRIPTION
Update solidity version of everything that integrates with our V3 core contract to solidity 0.8.17, as recommended by QSP audit.