### PR TITLE
QSP Audit Follow-On

### DIFF
--- a/contracts/AdminACLV0.sol
+++ b/contracts/AdminACLV0.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.17;
 
 import "./interfaces/0.8.x/IAdminACLV0.sol";
 import "@openzeppelin-4.7/contracts/access/Ownable.sol";

--- a/contracts/BasicRandomizerV2.sol
+++ b/contracts/BasicRandomizerV2.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Creatd By: Art Blocks Inc.
 
-pragma solidity 0.8.9;
+pragma solidity 0.8.17;
 
 import "./interfaces/0.8.x/IRandomizerV2.sol";
 import "./interfaces/0.8.x/IGenArt721CoreContractV3.sol";

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -38,8 +38,6 @@ import "./libs/0.8.x/Bytes32Strings.sol";
  * - updateMinterContract
  * - updateRandomizerAddress
  * - toggleProjectIsActive
- * - updateProjectArtistAddress (ultimately controlling the project and its
- *   and-on revenue)
  * - addProject
  * - forbidNewProjects (forever forbidding new projects)
  * - updateDefaultBaseURI (used to initialize new project base URIs)
@@ -71,6 +69,8 @@ import "./libs/0.8.x/Bytes32Strings.sol";
  * The following function is restricted to either the Admin ACL contract, or
  * the Artist address if the core contract owner has renounced ownership:
  * - adminAcceptArtistAddressesAndSplits
+ * - updateProjectArtistAddress (owner ultimately controlling the project and
+ *   its and-on revenue, unless owner has renounced ownership)
  * ----------------------------------------------------------------------------
  * The following function is restricted to the artist when a project is
  * unlocked, and only callable by Admin ACL contract when a project is locked:
@@ -1866,7 +1866,6 @@ contract GenArt721CoreV3 is
      * maximum number of times.
      * @param _projectId Project ID to be queried.
      * @return bool true if project is unlocked, false otherwise.
-     * @param _projectId Project ID to check.
      * @dev This also enforces that the `_projectId` passed in is valid.
      */
     function _projectUnlocked(uint256 _projectId)

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity 0.8.16;
+pragma solidity 0.8.17;
 
 // Created By: Art Blocks Inc.
 

--- a/contracts/minter-suite/MinterFilter/MinterFilterV1.sol
+++ b/contracts/minter-suite/MinterFilter/MinterFilterV1.sol
@@ -8,7 +8,7 @@ import "../../interfaces/0.8.x/IGenArt721CoreContractV3.sol";
 
 import "@openzeppelin-4.5/contracts/utils/structs/EnumerableMap.sol";
 
-pragma solidity 0.8.9;
+pragma solidity 0.8.17;
 
 /**
  * @title Minter filter contract that allows filtered minters to be set

--- a/contracts/minter-suite/Minters/MinterDAExp/MinterDAExpV2.sol
+++ b/contracts/minter-suite/Minters/MinterDAExp/MinterDAExpV2.sol
@@ -8,7 +8,7 @@ import "../../../interfaces/0.8.x/IFilteredMinterV0.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/math/SafeCast.sol";
 
-pragma solidity 0.8.9;
+pragma solidity 0.8.17;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/minter-suite/Minters/MinterDALin/MinterDALinV2.sol
+++ b/contracts/minter-suite/Minters/MinterDALin/MinterDALinV2.sol
@@ -8,7 +8,7 @@ import "../../../interfaces/0.8.x/IFilteredMinterV0.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/math/SafeCast.sol";
 
-pragma solidity 0.8.9;
+pragma solidity 0.8.17;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/minter-suite/Minters/MinterHolder/MinterHolderV1.sol
+++ b/contracts/minter-suite/Minters/MinterHolder/MinterHolderV1.sol
@@ -11,7 +11,7 @@ import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/structs/EnumerableSet.sol";
 import "@openzeppelin-4.5/contracts/utils/structs/EnumerableMap.sol";
 
-pragma solidity 0.8.9;
+pragma solidity 0.8.17;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
+++ b/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
@@ -9,7 +9,7 @@ import "@openzeppelin-4.7/contracts/utils/cryptography/MerkleProof.sol";
 import "@openzeppelin-4.7/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin-4.7/contracts/security/ReentrancyGuard.sol";
 
-pragma solidity 0.8.9;
+pragma solidity 0.8.17;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
+++ b/contracts/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
@@ -7,7 +7,7 @@ import "../../../interfaces/0.8.x/IFilteredMinterV0.sol";
 
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 
-pragma solidity 0.8.9;
+pragma solidity 0.8.17;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V2.sol
+++ b/contracts/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V2.sol
@@ -8,7 +8,7 @@ import "../../../interfaces/0.8.x/IFilteredMinterV0.sol";
 import "@openzeppelin-4.5/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 
-pragma solidity 0.8.9;
+pragma solidity 0.8.17;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/mock/DeadReceiverMock.sol
+++ b/contracts/mock/DeadReceiverMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.17;
 
 /**
  * @notice This reverts when receiving Ether

--- a/contracts/mock/MockAdminACLV0.sol
+++ b/contracts/mock/MockAdminACLV0.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.16;
+pragma solidity 0.8.17;
 
 import "../interfaces/0.8.x/IAdminACLV0.sol";
 import "@openzeppelin-4.7/contracts/access/Ownable.sol";

--- a/contracts/mock/RandomizerV2_NoAssignMock.sol
+++ b/contracts/mock/RandomizerV2_NoAssignMock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Creatd By: Art Blocks Inc.
 
-pragma solidity 0.8.9;
+pragma solidity 0.8.17;
 
 import "../BasicRandomizerV2.sol";
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -46,7 +46,7 @@ module.exports = {
         },
       },
       {
-        version: "0.8.16",
+        version: "0.8.17",
         settings: {
           optimizer: {
             enabled: true,

--- a/test/admin-acl/MockAdminACLV0/MockAdminACLV0.test.ts
+++ b/test/admin-acl/MockAdminACLV0/MockAdminACLV0.test.ts
@@ -1,0 +1,112 @@
+import {
+  BN,
+  constants,
+  expectEvent,
+  expectRevert,
+  balance,
+  ether,
+} from "@openzeppelin/test-helpers";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+
+import {
+  getAccounts,
+  assignDefaultConstants,
+  deployAndGet,
+  deployCoreWithMinterFilter,
+  mintProjectUntilRemaining,
+  advanceEVMByTime,
+} from "../../util/common";
+import { FOUR_WEEKS } from "../../util/constants";
+
+/**
+ * Tests for functionality of AdminACLV0.
+ */
+describe("AdminACLV0", async function () {
+  beforeEach(async function () {
+    // standard accounts and constants
+    this.accounts = await getAccounts();
+    await assignDefaultConstants.call(this);
+
+    // deploy and configure minter filter and minter
+    ({
+      genArt721Core: this.genArt721Core,
+      minterFilter: this.minterFilter,
+      randomizer: this.randomizer,
+      adminACL: this.adminACL,
+    } = await deployCoreWithMinterFilter.call(
+      this,
+      "GenArt721CoreV3",
+      "MinterFilterV1",
+      true
+    ));
+
+    this.minter = await deployAndGet.call(this, "MinterSetPriceV2", [
+      this.genArt721Core.address,
+      this.minterFilter.address,
+    ]);
+
+    // deploy alternate admin ACL that does not broadcast support of IAdminACLV0
+    this.adminACL_NoInterfaceBroadcast = await deployAndGet.call(
+      this,
+      "MockAdminACLV0Events",
+      []
+    );
+
+    // deploy another admin ACL that does broadcast support of IAdminACLV0
+    this.adminACL_InterfaceBroadcast = await deployAndGet.call(
+      this,
+      "AdminACLV0",
+      []
+    );
+  });
+
+  describe("transferOwnershipOn", function () {
+    it("allows transfer to new AdminACL when called by superAdmin", async function () {
+      await this.adminACL.transferOwnershipOn(
+        this.genArt721Core.address,
+        this.adminACL_InterfaceBroadcast.address
+      );
+      // ensure admin was changed
+      const coreAdmin = await this.genArt721Core.owner();
+      expect(coreAdmin).to.equal(this.adminACL_InterfaceBroadcast.address);
+    });
+
+    it("not callable by non-superAdmin", async function () {
+      await expectRevert(
+        this.adminACL
+          .connect(this.accounts.user)
+          .transferOwnershipOn(
+            this.genArt721Core.address,
+            this.adminACL_InterfaceBroadcast.address
+          ),
+        "Only superAdmin"
+      );
+      // ensure admin was not changed
+      const coreAdmin = await this.genArt721Core.owner();
+      expect(coreAdmin).to.equal(this.adminACL.address);
+    });
+  });
+
+  describe("renounceOwnershipOn", function () {
+    it("allows transfer to new AdminACL when called by superAdmin", async function () {
+      await this.adminACL.renounceOwnershipOn(this.genArt721Core.address);
+      // ensure admin was changed
+      const coreAdmin = await this.genArt721Core.owner();
+      expect(coreAdmin).to.equal(constants.ZERO_ADDRESS);
+    });
+
+    it("not callable by non-superAdmin", async function () {
+      await expectRevert(
+        this.adminACL
+          .connect(this.accounts.user)
+          .renounceOwnershipOn(this.genArt721Core.address),
+        "Only superAdmin"
+      );
+      // ensure admin was not changed
+      const coreAdmin = await this.genArt721Core.owner();
+      expect(coreAdmin).to.equal(this.adminACL.address);
+    });
+  });
+});

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
@@ -172,7 +172,7 @@ describe("MinterDAExpV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0138786")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0138415")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
@@ -173,7 +173,7 @@ describe("MinterDALinV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0138862")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0138498")); // assuming a cost of 100 GWEI
     });
   });
 });

--- a/test/minter-suite-minters/MinterHolder/MinterHolderV1.test.ts
+++ b/test/minter-suite-minters/MinterHolder/MinterHolderV1.test.ts
@@ -367,7 +367,7 @@ describe("MinterHolderV1", async function () {
         ethers.utils.formatUnits(txCost.toString(), "ether").toString(),
         "ETH"
       );
-      expect(compareBN(txCost, ethers.utils.parseEther("0.0118406"), 1)).to.be
+      expect(compareBN(txCost, ethers.utils.parseEther("0.0115695"), 1)).to.be
         .true;
     });
   });

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
@@ -177,7 +177,7 @@ describe("MinterSetPriceV2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0129276")); // assuming a cost of 100 GWEI
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0128905")); // assuming a cost of 100 GWEI
     });
   });
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
@@ -279,7 +279,7 @@ describe("MinterSetPriceERC20V2_V3Core", async function () {
         ethers.utils.formatUnits(txCost, "ether").toString(),
         "ETH"
       );
-      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.0129491"));
+      expect(txCost.toString()).to.equal(ethers.utils.parseEther("0.012912"));
     });
   });
 


### PR DESCRIPTION
This applies the final few updates related to QSP audit feedback.

⚠️ There are four commits applied to commit hash 7604b1b (NOT to branch main):
- ecd4288bd8d4812e573d82d8882815126184beac: additional QSP feedback regarding comments in V3 core contract
  - (cherry-picked from commit 28653717f49fdb915a08e6591f430a8c0b9c5674 in PR #318 
- d9157cfa4b01d384a9cf4ad40f5667d222dc4b73: version bump of everything related to V3 core contract to solidity 0.8.17 (including minter suite)
  - (cherry-picked from commit c20ee43746b67268f6371d4897ebf8a26cc841a0 in PR #329)
- 831710c82532784f227e9ea924771cb3c38e72ae: additional coverage for MockAdminACLV0.sol
  - (commit originally from this branch, follow-on work for AB is to cherry-pick back into main)
- update any failing gas tests due to changes from solidity version
  - commit only applies to this branch, no need to merge into main