### PR TITLE
Broadcast Merkle minter defaults

### DIFF
--- a/contracts/interfaces/0.8.x/IFilteredMinterMerkleV0.sol
+++ b/contracts/interfaces/0.8.x/IFilteredMinterMerkleV0.sol
@@ -11,6 +11,15 @@ pragma solidity ^0.8.0;
  * @author Art Blocks Inc.
  */
 interface IFilteredMinterMerkleV0 is IFilteredMinterV1 {
+    /**
+     * @notice Notifies of the contract's default maximum mints allowed per
+     * user for a given project, on this minter. This value can be overridden
+     * by the artist of any project at any time.
+     */
+    event DefaultMaxInvocationsPerAddress(
+        uint256 defaultMaxInvocationsPerAddress
+    );
+
     // Triggers a purchase of a token from the desired project, to the
     // TX-sending address. Requires Merkle proof.
     function purchase(uint256 _projectId, bytes32[] memory _proof)

--- a/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV0.sol
+++ b/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV0.sol
@@ -102,6 +102,10 @@ contract MinterMerkleV0 is ReentrancyGuard, IFilteredMinterMerkleV0 {
             minterFilter.genArt721CoreAddress() == _genArt721Address,
             "Illegal contract pairing"
         );
+        // broadcast default max invocations per address for this minter
+        emit DefaultMaxInvocationsPerAddress(
+            DEFAULT_MAX_INVOCATIONS_PER_ADDRESS
+        );
     }
 
     /**

--- a/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
+++ b/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
@@ -112,6 +112,10 @@ contract MinterMerkleV1 is ReentrancyGuard, IFilteredMinterMerkleV0 {
             minterFilter.genArt721CoreAddress() == _genArt721Address,
             "Illegal contract pairing"
         );
+        // broadcast default max invocations per address for this minter
+        emit DefaultMaxInvocationsPerAddress(
+            DEFAULT_MAX_INVOCATIONS_PER_ADDRESS
+        );
     }
 
     /**


### PR DESCRIPTION
Update Merkle minters to broadcast default maximum invocations per user during deployment.

If we ever want to use indexed data to determine how many mints each user has remaining, the minter contract's default value must be known. It is likely that it can be hard-coded to 1 (since it is unlikely to change), but it makes sense to broadcast this value in case we want to index it in our subgraph at a later time.