### PR TITLE
Codify last project ID on V1 core in V3 comments

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -151,7 +151,7 @@ contract GenArt721CoreV3 is
     /// Art Blocks Project ID range: [0-2]
     address public constant ART_BLOCKS_ERC721TOKEN_ADDRESS_V0 =
         0x059EDD72Cd353dF5106D2B9cC5ab83a52287aC3a;
-    /// Art Blocks Project ID range: [3-TODO: add V1 final project ID before deploying]
+    /// Art Blocks Project ID range: [3-373]
     address public constant ART_BLOCKS_ERC721TOKEN_ADDRESS_V1 =
         0xa7d8d9ef8D8Ce8992Df33D8b8CF4Aebabd5bD270;
 


### PR DESCRIPTION
Update V3 core's comments to codify last project ID that is on the V1 core.

Cc @sarahrossien - please approve this if you agree with the last project ID on V1 core 😄 