### PR TITLE
Auto accept artist proposals that do not change payment addresses

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -712,16 +712,13 @@ contract GenArt721CoreV3 is
             _additionalPayeeSecondarySalesPercentage
         );
         // automatically accept if no proposed addresses modifications
-        bool automaticAccept; // default false
-        if (
+        bool automaticAccept = (
             (_artistAddress == projectFinance.artistAddress) &&
             (_additionalPayeePrimarySales ==
             projectFinance.additionalPayeePrimarySales) &&
             (_additionalPayeeSecondarySales ==
             projectFinance.additionalPayeeSecondarySales)
-        ) {
-            automaticAccept = true;
-        }
+        );
         // automatically accept if no proposed addresses modifications
         // store proposal hash on-chain, only if not automatic accept
         if (automaticAccept) {

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -57,7 +57,8 @@ import "./libs/0.8.x/Bytes32Strings.sol";
  * - proposeArtistPaymentAddressesAndSplits (note that this has to be accepted
  *   by adminAcceptArtistAddressesAndSplits to take effect, which is restricted
  *   to the Admin ACL contract, or the artist if the core contract owner has
- *   renounced ownership)
+ *   renounced ownership. Also note that a proposal will be automatically
+ *   accepted if the artist only proposes changed percentages.)
  * - toggleProjectIsPaused (note the artist can still mint while paused)
  * - updateProjectSecondaryMarketRoyaltyPercentage (up to
      ARTIST_MAX_SECONDARY_ROYALTY_PERCENTAGE percent)
@@ -643,6 +644,11 @@ contract GenArt721CoreV3 is
      * addresses, and percentage splits for project `_projectId`. Addresses and
      * percentages do not have to all be changed, but they must all be defined
      * as a complete set.
+     * Note that if the artist is only proposing a change to the percentage
+     * splits, the proposal will be automatically approved and the new splits
+     * will become active immediately.
+     * Also note that if the artist is proposing sending funds to the zero
+     * address, this function will revert and the proposal will not be created.
      * @param _projectId Project ID.
      * @param _artistAddress Artist address that controls the project, and may
      * receive payments.
@@ -673,22 +679,49 @@ contract GenArt721CoreV3 is
         onlyArtist(_projectId)
         onlyNonZeroAddress(_artistAddress)
     {
+        ProjectFinance storage projectFinance = projectIdToFinancials[
+            _projectId
+        ];
         // checks
         require(
             _additionalPayeePrimarySalesPercentage <= ONE_HUNDRED &&
                 _additionalPayeeSecondarySalesPercentage <= ONE_HUNDRED,
             "Max of 100%"
         );
-        // effects
-        proposedArtistAddressesAndSplitsHash[_projectId] = keccak256(
-            abi.encode(
-                _artistAddress,
-                _additionalPayeePrimarySales,
-                _additionalPayeePrimarySalesPercentage,
-                _additionalPayeeSecondarySales,
-                _additionalPayeeSecondarySalesPercentage
-            )
+        require(
+            _additionalPayeePrimarySalesPercentage == 0 ||
+                _additionalPayeePrimarySales != address(0),
+            "Primary payee is zero address"
         );
+        require(
+            _additionalPayeeSecondarySalesPercentage == 0 ||
+                _additionalPayeeSecondarySales != address(0),
+            "Secondary payee is zero address"
+        );
+        // effects
+        // automatically accept if no new proposed addresses
+        bool automaticAccept; // default false
+        if (
+            _artistAddress == projectFinance.artistAddress &&
+            _additionalPayeePrimarySales ==
+            projectFinance.additionalPayeePrimarySales &&
+            _additionalPayeeSecondarySales ==
+            projectFinance.additionalPayeeSecondarySales
+        ) {
+            automaticAccept = true;
+        }
+        // store proposal hash on-chain, only if not automatic accept
+        if (!automaticAccept) {
+            proposedArtistAddressesAndSplitsHash[_projectId] = keccak256(
+                abi.encode(
+                    _artistAddress,
+                    _additionalPayeePrimarySales,
+                    _additionalPayeePrimarySalesPercentage,
+                    _additionalPayeeSecondarySales,
+                    _additionalPayeeSecondarySalesPercentage
+                )
+            );
+        }
         // emit event for off-chain indexing
         emit ProposedArtistAddressesAndSplits(
             _projectId,
@@ -698,6 +731,22 @@ contract GenArt721CoreV3 is
             _additionalPayeeSecondarySales,
             _additionalPayeeSecondarySalesPercentage
         );
+        // automatically accept if no new proposed addresses
+        if (automaticAccept) {
+            // clear any previously proposed values
+            proposedArtistAddressesAndSplitsHash[_projectId] = bytes32(0);
+            // update storage
+            // (only change to percentages during automatic accept)
+            // (safe to cast as uint8 as max is 100%, max uint8 is 255)
+            projectFinance.additionalPayeePrimarySalesPercentage = uint8(
+                _additionalPayeePrimarySalesPercentage
+            );
+            projectFinance.additionalPayeeSecondarySalesPercentage = uint8(
+                _additionalPayeeSecondarySalesPercentage
+            );
+            // emit event for off-chain indexing
+            emit AcceptedArtistAddressesAndSplits(_projectId);
+        }
     }
 
     /**

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -700,6 +700,17 @@ contract GenArt721CoreV3 is
             "Secondary payee is zero address"
         );
         // effects
+        // emit event for off-chain indexing
+        // note: always emit a proposal event, even in the pathway of
+        // automatic approval, to simplify indexing expectations
+        emit ProposedArtistAddressesAndSplits(
+            _projectId,
+            _artistAddress,
+            _additionalPayeePrimarySales,
+            _additionalPayeePrimarySalesPercentage,
+            _additionalPayeeSecondarySales,
+            _additionalPayeeSecondarySalesPercentage
+        );
         // automatically accept if no proposed addresses modifications
         bool automaticAccept; // default false
         if (
@@ -711,28 +722,8 @@ contract GenArt721CoreV3 is
         ) {
             automaticAccept = true;
         }
-        // store proposal hash on-chain, only if not automatic accept
-        if (!automaticAccept) {
-            proposedArtistAddressesAndSplitsHash[_projectId] = keccak256(
-                abi.encode(
-                    _artistAddress,
-                    _additionalPayeePrimarySales,
-                    _additionalPayeePrimarySalesPercentage,
-                    _additionalPayeeSecondarySales,
-                    _additionalPayeeSecondarySalesPercentage
-                )
-            );
-        }
-        // emit event for off-chain indexing
-        emit ProposedArtistAddressesAndSplits(
-            _projectId,
-            _artistAddress,
-            _additionalPayeePrimarySales,
-            _additionalPayeePrimarySalesPercentage,
-            _additionalPayeeSecondarySales,
-            _additionalPayeeSecondarySalesPercentage
-        );
         // automatically accept if no proposed addresses modifications
+        // store proposal hash on-chain, only if not automatic accept
         if (automaticAccept) {
             // clear any previously proposed values
             proposedArtistAddressesAndSplitsHash[_projectId] = bytes32(0);
@@ -747,6 +738,16 @@ contract GenArt721CoreV3 is
             );
             // emit event for off-chain indexing
             emit AcceptedArtistAddressesAndSplits(_projectId);
+        } else {
+            proposedArtistAddressesAndSplitsHash[_projectId] = keccak256(
+                abi.encode(
+                    _artistAddress,
+                    _additionalPayeePrimarySales,
+                    _additionalPayeePrimarySalesPercentage,
+                    _additionalPayeeSecondarySales,
+                    _additionalPayeeSecondarySalesPercentage
+                )
+            );
         }
     }
 

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -54,11 +54,12 @@ import "./libs/0.8.x/Bytes32Strings.sol";
  * - updateProjectAspectRatio
  * ----------------------------------------------------------------------------
  * The following functions are restricted to only the Artist address:
- * - proposeArtistPaymentAddressesAndSplits (note that this has to be accepted
+ * - proposeArtistPaymentAddressesAndSplits (Note that this has to be accepted
  *   by adminAcceptArtistAddressesAndSplits to take effect, which is restricted
  *   to the Admin ACL contract, or the artist if the core contract owner has
  *   renounced ownership. Also note that a proposal will be automatically
- *   accepted if the artist only proposes changed percentages.)
+ *   accepted if the artist only proposes changed payee percentages without 
+ *   modifying any payee addresses.)
  * - toggleProjectIsPaused (note the artist can still mint while paused)
  * - updateProjectSecondaryMarketRoyaltyPercentage (up to
      ARTIST_MAX_SECONDARY_ROYALTY_PERCENTAGE percent)
@@ -644,9 +645,9 @@ contract GenArt721CoreV3 is
      * addresses, and percentage splits for project `_projectId`. Addresses and
      * percentages do not have to all be changed, but they must all be defined
      * as a complete set.
-     * Note that if the artist is only proposing a change to the percentage
-     * splits, the proposal will be automatically approved and the new splits
-     * will become active immediately.
+     * Note that if the artist is only proposing a change to the payee percentage
+     * splits, without modifying the payee addresses, the proposal will be 
+     * automatically approved and the new splits will become active immediately.
      * Also note that if the artist is proposing sending funds to the zero
      * address, this function will revert and the proposal will not be created.
      * @param _projectId Project ID.

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -58,7 +58,7 @@ import "./libs/0.8.x/Bytes32Strings.sol";
  *   by adminAcceptArtistAddressesAndSplits to take effect, which is restricted
  *   to the Admin ACL contract, or the artist if the core contract owner has
  *   renounced ownership. Also note that a proposal will be automatically
- *   accepted if the artist only proposes changed payee percentages without 
+ *   accepted if the artist only proposes changed payee percentages without
  *   modifying any payee addresses.)
  * - toggleProjectIsPaused (note the artist can still mint while paused)
  * - updateProjectSecondaryMarketRoyaltyPercentage (up to
@@ -646,7 +646,7 @@ contract GenArt721CoreV3 is
      * percentages do not have to all be changed, but they must all be defined
      * as a complete set.
      * Note that if the artist is only proposing a change to the payee percentage
-     * splits, without modifying the payee addresses, the proposal will be 
+     * splits, without modifying the payee addresses, the proposal will be
      * automatically approved and the new splits will become active immediately.
      * Also note that if the artist is proposing sending funds to the zero
      * address, this function will revert and the proposal will not be created.
@@ -712,15 +712,13 @@ contract GenArt721CoreV3 is
             _additionalPayeeSecondarySalesPercentage
         );
         // automatically accept if no proposed addresses modifications
-        bool automaticAccept = (
-            (_artistAddress == projectFinance.artistAddress) &&
-            (_additionalPayeePrimarySales ==
-            projectFinance.additionalPayeePrimarySales) &&
-            (_additionalPayeeSecondarySales ==
-            projectFinance.additionalPayeeSecondarySales)
-        );
-        // automatically accept if no proposed addresses modifications
         // store proposal hash on-chain, only if not automatic accept
+        bool automaticAccept = ((_artistAddress ==
+            projectFinance.artistAddress) &&
+            (_additionalPayeePrimarySales ==
+                projectFinance.additionalPayeePrimarySales) &&
+            (_additionalPayeeSecondarySales ==
+                projectFinance.additionalPayeeSecondarySales));
         if (automaticAccept) {
             // clear any previously proposed values
             proposedArtistAddressesAndSplitsHash[_projectId] = bytes32(0);

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -700,14 +700,14 @@ contract GenArt721CoreV3 is
             "Secondary payee is zero address"
         );
         // effects
-        // automatically accept if no new proposed addresses
+        // automatically accept if no proposed addresses modifications
         bool automaticAccept; // default false
         if (
-            _artistAddress == projectFinance.artistAddress &&
-            _additionalPayeePrimarySales ==
-            projectFinance.additionalPayeePrimarySales &&
-            _additionalPayeeSecondarySales ==
-            projectFinance.additionalPayeeSecondarySales
+            (_artistAddress == projectFinance.artistAddress) &&
+            (_additionalPayeePrimarySales ==
+            projectFinance.additionalPayeePrimarySales) &&
+            (_additionalPayeeSecondarySales ==
+            projectFinance.additionalPayeeSecondarySales)
         ) {
             automaticAccept = true;
         }
@@ -732,7 +732,7 @@ contract GenArt721CoreV3 is
             _additionalPayeeSecondarySales,
             _additionalPayeeSecondarySalesPercentage
         );
-        // automatically accept if no new proposed addresses
+        // automatically accept if no proposed addresses modifications
         if (automaticAccept) {
             // clear any previously proposed values
             proposedArtistAddressesAndSplitsHash[_projectId] = bytes32(0);

--- a/test/core/GenArt721CoreV1_Integration.tests.ts
+++ b/test/core/GenArt721CoreV1_Integration.tests.ts
@@ -164,22 +164,24 @@ describe("GenArt721CoreV1 Integration", async function () {
       const deployerBalance = await this.accounts.deployer.getBalance();
 
       const additionalPayeePercentage = 100;
-      this.genArt721Core
+      await this.genArt721Core
         .connect(this.accounts.artist)
         .updateProjectAdditionalPayeeInfo(
           this.projectZero,
           this.accounts.additional.address,
           additionalPayeePercentage
         );
-      this.genArt721Core
+      await this.genArt721Core
         .connect(this.accounts.artist)
         .toggleProjectIsPaused(this.projectZero);
 
       // pricePerTokenInWei setup above to be 1 ETH
-      await expect(
-        this.minter.connect(this.accounts.user).purchase(this.projectZero, {
-          value: this.pricePerTokenInWei,
-        })
+      expect(
+        await this.minter
+          .connect(this.accounts.user)
+          .purchase(this.projectZero, {
+            value: this.pricePerTokenInWei,
+          })
       )
         .to.emit(this.genArt721Core, "Transfer")
         .withArgs(
@@ -188,10 +190,10 @@ describe("GenArt721CoreV1 Integration", async function () {
           this.projectZeroTokenZero
         );
 
-      this.projectZeroInfo = await this.genArt721Core.projectTokenInfo(
+      const projectZeroInfo = await this.genArt721Core.projectTokenInfo(
         this.projectZero
       );
-      expect(this.projectZeroInfo.invocations).to.equal("1");
+      expect(projectZeroInfo.invocations).to.equal("1");
 
       expect(
         (await this.accounts.deployer.getBalance()).sub(deployerBalance)

--- a/test/core/GenArt721CoreV2_PRTNR_Integration.tests.ts
+++ b/test/core/GenArt721CoreV2_PRTNR_Integration.tests.ts
@@ -184,22 +184,24 @@ describe("GenArt721CoreV2_PRTNR_Integration", async function () {
       const deployerBalance = await this.accounts.deployer.getBalance();
 
       const additionalPayeePercentage = 100;
-      this.genArt721Core
+      await this.genArt721Core
         .connect(this.accounts.artist)
         .updateProjectAdditionalPayeeInfo(
           this.projectZero,
           this.accounts.additional.address,
           additionalPayeePercentage
         );
-      this.genArt721Core
+      await this.genArt721Core
         .connect(this.accounts.artist)
         .toggleProjectIsPaused(this.projectZero);
 
       // pricePerTokenInWei setup above to be 1 ETH
-      await expect(
-        this.minter.connect(this.accounts.user).purchase(this.projectZero, {
-          value: this.pricePerTokenInWei,
-        })
+      expect(
+        await this.minter
+          .connect(this.accounts.user)
+          .purchase(this.projectZero, {
+            value: this.pricePerTokenInWei,
+          })
       )
         .to.emit(this.genArt721Core, "Transfer")
         .withArgs(
@@ -208,10 +210,10 @@ describe("GenArt721CoreV2_PRTNR_Integration", async function () {
           this.projectZeroTokenZero
         );
 
-      this.projectZeroInfo = await this.genArt721Core.projectTokenInfo(
+      const projectZeroInfo = await this.genArt721Core.projectTokenInfo(
         this.projectZero
       );
-      expect(this.projectZeroInfo.invocations).to.equal("1");
+      expect(projectZeroInfo.invocations).to.equal("1");
 
       expect(
         (await this.accounts.deployer.getBalance()).sub(deployerBalance)

--- a/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
+++ b/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
@@ -683,6 +683,166 @@ describe("GenArt721CoreV3 Project Configure", async function () {
         "Must match artist proposal"
       );
     });
+
+    it("does not allow proposing payment to the zero address", async function () {
+      // update additional primary to zero address and non-zero percentage
+      let valuesToUpdateTo = [
+        this.projectZero,
+        this.accounts.artist2.address,
+        constants.ZERO_ADDRESS,
+        50,
+        this.accounts.additional2.address,
+        51,
+      ];
+      // artist proposes new values
+      await expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.artist)
+          .proposeArtistPaymentAddressesAndSplits(...valuesToUpdateTo),
+        "Primary payee is zero address"
+      );
+      // update additional secondary to zero address and non-zero percentage
+      valuesToUpdateTo = [
+        this.projectZero,
+        this.accounts.artist2.address,
+        this.accounts.additional.address,
+        50,
+        constants.ZERO_ADDRESS,
+        51,
+      ];
+      // artist proposes new values
+      await expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.artist)
+          .proposeArtistPaymentAddressesAndSplits(...valuesToUpdateTo),
+        "Secondary payee is zero address"
+      );
+    });
+
+    it("automatically accepts when only percentages are changed", async function () {
+      // update additional primary to zero address and non-zero percentage
+      let valuesToUpdateTo = [
+        this.projectZero,
+        this.accounts.artist2.address,
+        this.accounts.additional.address,
+        50,
+        this.accounts.additional2.address,
+        51,
+      ];
+      // successful artist proposes new values
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .proposeArtistPaymentAddressesAndSplits(...valuesToUpdateTo);
+      // admin accept initial new values
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .adminAcceptArtistAddressesAndSplits(...this.valuesToUpdateTo);
+      // only change percentages
+      valuesToUpdateTo = [
+        valuesToUpdateTo[0],
+        valuesToUpdateTo[1],
+        valuesToUpdateTo[2],
+        90,
+        valuesToUpdateTo[4],
+        91,
+      ];
+      // artist proposes new values, is automatically accepted
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.artist2)
+          .proposeArtistPaymentAddressesAndSplits(...valuesToUpdateTo)
+      )
+        .to.emit(this.genArt721Core, "AcceptedArtistAddressesAndSplits")
+        .withArgs(this.projectZero);
+      // check that propose event was also emitted
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.artist2)
+          .proposeArtistPaymentAddressesAndSplits(...valuesToUpdateTo)
+      )
+        .to.emit(this.genArt721Core, "ProposedArtistAddressesAndSplits")
+        .withArgs(...valuesToUpdateTo);
+      // check that values were updated
+      expect(
+        await this.genArt721Core.projectIdToArtistAddress(this.projectZero)
+      ).to.equal(this.accounts.artist2.address);
+      expect(
+        await this.genArt721Core.projectIdToAdditionalPayeePrimarySales(
+          this.projectZero
+        )
+      ).to.equal(this.accounts.additional.address);
+      expect(
+        await this.genArt721Core.projectIdToAdditionalPayeeSecondarySales(
+          this.projectZero
+        )
+      ).to.equal(this.accounts.additional2.address);
+      expect(
+        await this.genArt721Core.projectIdToAdditionalPayeePrimarySalesPercentage(
+          this.projectZero
+        )
+      ).to.equal(90);
+      expect(
+        await this.genArt721Core.projectIdToAdditionalPayeeSecondarySalesPercentage(
+          this.projectZero
+        )
+      ).to.equal(91);
+    });
+
+    it("clears stale proposal hashes during auto-approval", async function () {
+      // update additional primary to zero address and non-zero percentage
+      let valuesToUpdateTo = [
+        this.projectZero,
+        this.accounts.artist2.address,
+        this.accounts.additional.address,
+        50,
+        this.accounts.additional2.address,
+        51,
+      ];
+      // successful artist proposes new values
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .proposeArtistPaymentAddressesAndSplits(...valuesToUpdateTo);
+      // admin accept initial new values
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .adminAcceptArtistAddressesAndSplits(...this.valuesToUpdateTo);
+      // propose a change that requires admin approval, hash stored on-chain
+      // change a payment address
+      valuesToUpdateTo = [
+        valuesToUpdateTo[0],
+        valuesToUpdateTo[1],
+        this.accounts.user.address,
+        90,
+        valuesToUpdateTo[4],
+        91,
+      ];
+      expect(
+        await this.genArt721Core
+          .connect(this.accounts.artist2)
+          .proposeArtistPaymentAddressesAndSplits(...valuesToUpdateTo)
+      )
+        .to.not.emit(this.genArt721Core, "AcceptedArtistAddressesAndSplits")
+        .withArgs(this.projectZero);
+      // artist changes to an auto-approved request (only percentages changed)
+      valuesToUpdateTo = [
+        valuesToUpdateTo[0],
+        valuesToUpdateTo[1],
+        this.accounts.additional.address, // back to current active additional primary
+        90,
+        valuesToUpdateTo[4],
+        91,
+      ];
+      // artist proposes new values, is automatically accepted
+      await this.genArt721Core
+        .connect(this.accounts.artist2)
+        .proposeArtistPaymentAddressesAndSplits(...valuesToUpdateTo);
+      // check that on-chain proposal hash is cleared after automatic approval
+      expect(
+        await this.genArt721Core.proposedArtistAddressesAndSplitsHash(
+          this.projectZero
+        )
+      ).to.equal(constants.ZERO_BYTES32);
+    });
   });
 
   describe("updateProjectSecondaryMarketRoyaltyPercentage", function () {


### PR DESCRIPTION
Update core V3 contract to automatically accept artist proposed updates that do not change artist payment addresses.

This allows an artist to immediately update (only) their payment address percent splits without admin approval.
Thank you @sarahrossien for bringing this to my attention today!

## Other Changes
On-chain validation is added that prevents artists from directing funds to the zero address. This should be done regardless of if auto-approval is implemented.

## Tests
Tests added to maintain 100% coverage for V3 core contract.