### PR TITLE
Skip failing tests on coverage

### DIFF
--- a/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
+++ b/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
@@ -877,7 +877,8 @@ describe("GenArt721CoreV3 Project Configure", async function () {
       expect(script).to.equal(CONTRACT_SIZE_LIMIT_SCRIPT);
     });
 
-    it("fails to upload 26 KB script", async function () {
+    // skip on coverage because contract max sizes are ignored
+    it("fails to upload 26 KB script [ @skip-on-coverage ]", async function () {
       await expectRevert(
         this.genArt721Core.connect(this.accounts.artist).addProjectScript(
           this.projectZero,

--- a/test/libs/BytecodeStorage_BytecodeTextCR_DMock.test.ts
+++ b/test/libs/BytecodeStorage_BytecodeTextCR_DMock.test.ts
@@ -177,7 +177,8 @@ describe("BytecodeStorage + BytecodeTextCR_DMock Library Tests", async function 
       expect(text).to.equal(targetText);
     });
 
-    it("fails to upload 26 KB script", async function () {
+    // skip on coverage because contract max sizes are ignored
+    it("fails to upload 26 KB script [ @skip-on-coverage ]", async function () {
       await expectRevert(
         this.bytecodeTextCR_DMock
           .connect(this.accounts.deployer)


### PR DESCRIPTION
Skip two failing tests on coverage that are only failing due to max contract size being ignored in `solidity-coverage` library.

This implements the same strategy as any other tests that rely on accurate gas calculations.

