### PR TITLE
Improve CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
           name: Hardhat Test
           command: |
             TEST_FILES="$(circleci tests glob "./test/**/*.ts" | circleci tests split)"
-            yarn test ${TEST_FILES}
+            yarn test:parallel ${TEST_FILES}
   lint-and-test:
     docker:
       - image: "cimg/base:stable"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
       - run:
           name: Hardhat Test
           command: |
-            TEST_FILES="$(circleci tests glob "./test/**/*[!.common].ts" | circleci tests split)"
+            TEST_FILES="$(circleci tests glob "./test/**/*.ts" | circleci tests split)"
             yarn test:parallel ${TEST_FILES}
   lint-and-test:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,19 +31,11 @@ jobs:
           lts: true
       - node/install-packages:
           pkg-manager: yarn
-      - run: mkdir ~/junit
       - run:
           name: Hardhat Test
           command: |
-            TEST_FILES="$(circleci tests glob "./test/**/*.ts" | circleci tests split --split-by=timings)"
+            TEST_FILES="$(circleci tests glob "./test/**/*.ts" | circleci tests split)"
             yarn test ${TEST_FILES}
-      - run:
-          command: cp junit.xml ~/junit/
-          when: always
-      - store_test_results:
-          path: ~/junit
-      - store_artifacts:
-          path: ~/junit
   lint-and-test:
     docker:
       - image: "cimg/base:stable"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,21 +18,14 @@ jobs:
       - node/install-packages:
           pkg-manager: yarn
       - run: node --version
-      - run:
-          name: Compile
-          command: yarn compile
-      - save_cache:
-          paths:
-            - ~/artblocks-contracts
-          key: compiled-env-{{ .Environment.CIRCLE_SHA1 }}
   lint:
     docker:
       - image: "cimg/base:stable"
     resource_class: large
-    working_directory: ~/artblocks-contracts
     steps:
-      - restore_cache:
-          key: compiled-env-{{ .Environment.CIRCLE_SHA1 }}
+      - node/install:
+          install-yarn: true
+          lts: true
       - run:
           name: Lint
           command: yarn lint
@@ -41,13 +34,16 @@ jobs:
       - image: "cimg/base:stable"
     resource_class: large
     working_directory: ~/artblocks-contracts
+    parallelism: 5
     steps:
-      - restore_cache:
-          key: compiled-env-{{ .Environment.CIRCLE_SHA1 }}
-      - run: node --version
+      - node/install:
+          install-yarn: true
+          lts: true
       - run:
-          name: Run tests
-          command: yarn test
+          name: Hardhat Test
+          command: |
+            TEST_FILES="$(circleci tests glob "./test/**/*.spec.ts" | circleci tests split)"
+            yarn test ${TEST_FILES}
 
 workflows:
   run-ci:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,11 @@ orbs:
   aws-cli: circleci/aws-cli@3.0.0
 
 jobs:
-  lint-and-test:
+  checkout_and_compile:
     docker:
       - image: "cimg/base:stable"
     resource_class: large
+    working_directory: ~/artblocks-contracts
     steps:
       - checkout
       - node/install:
@@ -18,8 +19,34 @@ jobs:
           pkg-manager: yarn
       - run: node --version
       - run:
+          name: Compile
+          command: yarn compile
+      - save_cache:
+          paths:
+            - ~/artblocks-contracts
+          key: compiled-env-{{ .Environment.CIRCLE_SHA1 }}
+  lint:
+    docker:
+      - image: "cimg/base:stable"
+    resource_class: large
+    working_directory: ~/artblocks-contracts
+    steps:
+      - checkout
+      - restore_cache:
+          key: compiled-env-{{ .Environment.CIRCLE_SHA1 }}
+      - run:
           name: Lint
           command: yarn lint
+  test:
+    docker:
+      - image: "cimg/base:stable"
+    resource_class: large
+    working_directory: ~/artblocks-contracts
+    steps:
+      - checkout
+      - restore_cache:
+          key: compiled-env-{{ .Environment.CIRCLE_SHA1 }}
+      - run: node --version
       - run:
           name: Run tests
           command: yarn test
@@ -27,4 +54,10 @@ jobs:
 workflows:
   run-ci:
     jobs:
-      - lint-and-test
+      - checkout_and_compile
+      - lint:
+          requires:
+            - checkout_and_compile
+      - test:
+          requires:
+            - checkout_and_compile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
   aws-cli: circleci/aws-cli@3.0.0
 
 jobs:
-  checkout_and_compile:
+  lint:
     docker:
       - image: "cimg/base:stable"
     resource_class: large
@@ -16,12 +16,14 @@ jobs:
           lts: true
       - node/install-packages:
           pkg-manager: yarn
-      - run: node --version
+      - run:
+          name: Lint
+          command: yarn lint
   test:
     docker:
       - image: "cimg/base:stable"
     resource_class: large
-    parallelism: 5
+    parallelism: 10
     steps:
       - checkout
       - node/install:
@@ -32,15 +34,23 @@ jobs:
       - run:
           name: Hardhat Test
           command: |
-            TEST_FILES="$(circleci tests glob "./test/**/*.test.ts" | circleci tests split)"
+            TEST_FILES="$(circleci tests glob "./test/**/*.ts" | circleci tests split)"
             yarn test ${TEST_FILES}
+  lint-and-test:
+    docker:
+      - image: "cimg/base:stable"
+    resource_class: small
+    steps:
+      - run:
+          name: Success
+          command: echo "Success"
 
 workflows:
   run-ci:
     jobs:
-      - checkout_and_compile
-      - node/run:
-          yarn-run: lint
-      - test:
+      - lint
+      - test
+      - lint-and-test:
           requires:
-            - checkout_and_compile
+            - lint
+            - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
     docker:
       - image: "cimg/base:stable"
     resource_class: large
-    parallelism: 5
+    parallelism: 8
     steps:
       - checkout
       - node/install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,11 +31,19 @@ jobs:
           lts: true
       - node/install-packages:
           pkg-manager: yarn
+      - run: mkdir ~/junit
       - run:
           name: Hardhat Test
           command: |
-            TEST_FILES="$(circleci tests glob "./test/**/*.ts" | circleci tests split)"
+            TEST_FILES="$(circleci tests glob "./test/**/*.ts" | circleci tests split --split-by=timings)"
             yarn test ${TEST_FILES}
+      - run:
+          command: cp junit.xml ~/junit/
+          when: always
+      - store_test_results:
+          path: ~/junit
+      - store_artifacts:
+          path: ~/junit
   lint-and-test:
     docker:
       - image: "cimg/base:stable"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
       - run:
           name: Hardhat Test
           command: |
-            TEST_FILES="$(circleci tests glob "./test/**/*.ts" | circleci tests split)"
+            TEST_FILES="$(circleci tests glob "./test/**/*[!.common].ts" | circleci tests split)"
             yarn test:parallel ${TEST_FILES}
   lint-and-test:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,6 @@ jobs:
     resource_class: large
     working_directory: ~/artblocks-contracts
     steps:
-      - checkout
       - restore_cache:
           key: compiled-env-{{ .Environment.CIRCLE_SHA1 }}
       - run:
@@ -43,7 +42,6 @@ jobs:
     resource_class: large
     working_directory: ~/artblocks-contracts
     steps:
-      - checkout
       - restore_cache:
           key: compiled-env-{{ .Environment.CIRCLE_SHA1 }}
       - run: node --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,6 @@ jobs:
     docker:
       - image: "cimg/base:stable"
     resource_class: large
-    working_directory: ~/artblocks-contracts
     steps:
       - checkout
       - node/install:
@@ -23,6 +22,7 @@ jobs:
       - image: "cimg/base:stable"
     resource_class: large
     steps:
+      - checkout
       - node/install:
           install-yarn: true
           lts: true
@@ -33,7 +33,6 @@ jobs:
     docker:
       - image: "cimg/base:stable"
     resource_class: large
-    working_directory: ~/artblocks-contracts
     parallelism: 5
     steps:
       - node/install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,8 @@ jobs:
       - node/install:
           install-yarn: true
           lts: true
+      - node/install-packages:
+          pkg-manager: yarn
       - run:
           name: Lint
           command: yarn lint
@@ -35,9 +37,12 @@ jobs:
     resource_class: large
     parallelism: 5
     steps:
+      - checkout
       - node/install:
           install-yarn: true
           lts: true
+      - node/install-packages:
+          pkg-manager: yarn
       - run:
           name: Hardhat Test
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,20 +17,6 @@ jobs:
       - node/install-packages:
           pkg-manager: yarn
       - run: node --version
-  lint:
-    docker:
-      - image: "cimg/base:stable"
-    resource_class: large
-    steps:
-      - checkout
-      - node/install:
-          install-yarn: true
-          lts: true
-      - node/install-packages:
-          pkg-manager: yarn
-      - run:
-          name: Lint
-          command: yarn lint
   test:
     docker:
       - image: "cimg/base:stable"
@@ -46,16 +32,15 @@ jobs:
       - run:
           name: Hardhat Test
           command: |
-            TEST_FILES="$(circleci tests glob "./test/**/*.spec.ts" | circleci tests split)"
+            TEST_FILES="$(circleci tests glob "./test/**/*.test.ts" | circleci tests split)"
             yarn test ${TEST_FILES}
 
 workflows:
   run-ci:
     jobs:
       - checkout_and_compile
-      - lint:
-          requires:
-            - checkout_and_compile
+      - node/run:
+          yarn-run: lint
       - test:
           requires:
             - checkout_and_compile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
     docker:
       - image: "cimg/base:stable"
     resource_class: large
-    parallelism: 10
+    parallelism: 5
     steps:
       - checkout
       - node/install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
           name: Hardhat Test
           command: |
             TEST_FILES="$(circleci tests glob "./test/**/*.ts" | circleci tests split)"
-            yarn test:parallel ${TEST_FILES}
+            yarn test ${TEST_FILES}
   lint-and-test:
     docker:
       - image: "cimg/base:stable"

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": { "project": "./tsconfig.json" },
+  "plugins": ["@typescript-eslint"],
+  "rules": {
+    "@typescript-eslint/no-floating-promises": ["error"]
+  }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -105,4 +105,7 @@ module.exports = {
     enabled: true,
     coinmarketcap: process.env.COINMARKETCAP_API_KEY,
   },
+  mocha: {
+    timeout: 100000,
+  },
 };

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "hardhat-docgen": "^1.3.0",
     "hardhat-gas-reporter": "^1.0.8",
     "husky": "^7.0.4",
+    "jest-junit": "^14.0.1",
     "keccak256": "^1.0.6",
     "merkletreejs": "^0.2.31",
     "prettier": "^2.3.2",
@@ -68,5 +69,14 @@
     "@openzeppelin-0.5/contracts": "npm:@openzeppelin/contracts@2.5.1",
     "@openzeppelin-4.5/contracts": "npm:@openzeppelin/contracts@4.5.0",
     "@openzeppelin-4.7/contracts": "npm:@openzeppelin/contracts@4.7.1"
+  },
+  "jest": {
+    "reporters": [
+      "default",
+      "jest-junit"
+    ]
+  },
+  "jest-junit": {
+    "addFileAttribute": "true"
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "hardhat-docgen": "^1.3.0",
     "hardhat-gas-reporter": "^1.0.8",
     "husky": "^7.0.4",
-    "jest-junit": "^14.0.1",
     "keccak256": "^1.0.6",
     "merkletreejs": "^0.2.31",
     "prettier": "^2.3.2",
@@ -69,14 +68,5 @@
     "@openzeppelin-0.5/contracts": "npm:@openzeppelin/contracts@2.5.1",
     "@openzeppelin-4.5/contracts": "npm:@openzeppelin/contracts@4.5.0",
     "@openzeppelin-4.7/contracts": "npm:@openzeppelin/contracts@4.7.1"
-  },
-  "jest": {
-    "reporters": [
-      "default",
-      "jest-junit"
-    ]
-  },
-  "jest-junit": {
-    "addFileAttribute": "true"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "docgen": "hardhat docgen",
     "generate:typechain": "typechain --target ethers-v5 --outDir ./scripts/contracts './artifacts/contracts/**/!(*.dbg)*.json'",
     "test": "hardhat test",
+    "test:parallel": "hardhat test --parallel",
     "coverage": "hardhat coverage",
     "format": "prettier --write 'contracts/**/*.sol' && prettier --write 'scripts/**/*.ts' && prettier --write 'test/**/*.ts'",
     "lint": "prettier --check 'contracts/**/*.sol' && prettier --check 'scripts/**/*.ts' && prettier --check 'test/**/*.ts'",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:parallel": "hardhat test --parallel",
     "coverage": "hardhat coverage",
     "format": "prettier --write 'contracts/**/*.sol' && prettier --write 'scripts/**/*.ts' && prettier --write 'test/**/*.ts'",
-    "lint": "prettier --check 'contracts/**/*.sol' && prettier --check 'scripts/**/*.ts' && prettier --check 'test/**/*.ts'",
+    "lint": "prettier --check 'contracts/**/*.sol' && prettier --check 'scripts/**/*.ts' && prettier --check 'test/**/*.ts' && npx eslint 'test/**/*.ts'",
     "remix": "remixd -s ./ --remix-ide https://remix.ethereum.org"
   },
   "husky": {
@@ -43,9 +43,12 @@
     "@typechain/ethers-v5": "^6.0.5",
     "@types/jest": "^27.0.3",
     "@types/mocha": "^9.1.1",
+    "@typescript-eslint/eslint-plugin": "^5.40.0",
+    "@typescript-eslint/parser": "^5.40.0",
     "aws-sdk-client-mock": "^0.6.2",
     "chai": "^4.3.4",
     "dotenv": "^8.2.0",
+    "eslint": "^8.25.0",
     "ethereum-waffle": "^3.4.0",
     "ethers": "^5.4.1",
     "hardhat": "^2.10.2",

--- a/test/Legacy/GenArt721LegacyMinter.test.ts
+++ b/test/Legacy/GenArt721LegacyMinter.test.ts
@@ -71,10 +71,10 @@ describe("GenArt721Minter", async function () {
       .connect(this.accounts.artist)
       .updateProjectMaxInvocations(this.projectOne, 15);
 
-    this.genArt721Core
+    await this.genArt721Core
       .connect(this.accounts.artist)
       .toggleProjectIsPaused(this.projectZero);
-    this.genArt721Core
+    await this.genArt721Core
       .connect(this.accounts.artist)
       .toggleProjectIsPaused(this.projectOne);
   });

--- a/test/admin-acl/AdminACLV0/AdminACLV0.test.ts
+++ b/test/admin-acl/AdminACLV0/AdminACLV0.test.ts
@@ -94,8 +94,8 @@ describe("AdminACLV0", async function () {
 
   describe("changeSuperAdmin", function () {
     it("emits an event", async function () {
-      expect(
-        await this.adminACL.changeSuperAdmin(this.accounts.deployer2.address, [
+      await expect(
+        this.adminACL.changeSuperAdmin(this.accounts.deployer2.address, [
           this.genArt721Core.address,
         ])
       )

--- a/test/core/GenArt721CoreV1_Integration.tests.ts
+++ b/test/core/GenArt721CoreV1_Integration.tests.ts
@@ -66,7 +66,7 @@ describe("GenArt721CoreV1 Integration", async function () {
   });
 
   describe("common tests", async function () {
-    GenArt721MinterV1V2PRTNR_Common();
+    await GenArt721MinterV1V2PRTNR_Common();
   });
 
   describe("purchase payments and gas", async function () {
@@ -176,12 +176,10 @@ describe("GenArt721CoreV1 Integration", async function () {
         .toggleProjectIsPaused(this.projectZero);
 
       // pricePerTokenInWei setup above to be 1 ETH
-      expect(
-        await this.minter
-          .connect(this.accounts.user)
-          .purchase(this.projectZero, {
-            value: this.pricePerTokenInWei,
-          })
+      await expect(
+        this.minter.connect(this.accounts.user).purchase(this.projectZero, {
+          value: this.pricePerTokenInWei,
+        })
       )
         .to.emit(this.genArt721Core, "Transfer")
         .withArgs(

--- a/test/core/GenArt721CoreV2_ENGINE_FLEX_Integration.tests.ts
+++ b/test/core/GenArt721CoreV2_ENGINE_FLEX_Integration.tests.ts
@@ -67,7 +67,7 @@ describe("GenArt721CoreV2_PBAB_FLEX_Integration", async function () {
   });
 
   describe("common tests", async function () {
-    GenArt721MinterV1V2PRTNR_Common();
+    await GenArt721MinterV1V2PRTNR_Common();
   });
 
   describe("external asset dependencies", async function () {

--- a/test/core/GenArt721CoreV2_PRTNR_Integration.tests.ts
+++ b/test/core/GenArt721CoreV2_PRTNR_Integration.tests.ts
@@ -70,7 +70,7 @@ describe("GenArt721CoreV2_PRTNR_Integration", async function () {
   });
 
   describe("common tests", async function () {
-    GenArt721MinterV1V2PRTNR_Common();
+    await GenArt721MinterV1V2PRTNR_Common();
   });
 
   describe("initial nextProjectId", function () {
@@ -196,12 +196,10 @@ describe("GenArt721CoreV2_PRTNR_Integration", async function () {
         .toggleProjectIsPaused(this.projectZero);
 
       // pricePerTokenInWei setup above to be 1 ETH
-      expect(
-        await this.minter
-          .connect(this.accounts.user)
-          .purchase(this.projectZero, {
-            value: this.pricePerTokenInWei,
-          })
+      await expect(
+        this.minter.connect(this.accounts.user).purchase(this.projectZero, {
+          value: this.pricePerTokenInWei,
+        })
       )
         .to.emit(this.genArt721Core, "Transfer")
         .withArgs(

--- a/test/core/V3/GenArt721CoreV3_AdminACLRequests.test.ts
+++ b/test/core/V3/GenArt721CoreV3_AdminACLRequests.test.ts
@@ -22,10 +22,8 @@ import { FOUR_WEEKS } from "../../util/constants";
 async function validateAdminACLRequest(functionName: string, args: any[]) {
   const targetSelector = this.coreInterface.getSighash(functionName);
   // emits event when being minted out
-  expect(
-    await this.genArt721Core
-      .connect(this.accounts.deployer)
-      [functionName](...args)
+  await expect(
+    this.genArt721Core.connect(this.accounts.deployer)[functionName](...args)
   )
     .to.emit(this.adminACL, "ACLCheck")
     .withArgs(this.accounts.deployer.address, targetSelector);

--- a/test/core/V3/GenArt721CoreV3_AdminACLRequests.test.ts
+++ b/test/core/V3/GenArt721CoreV3_AdminACLRequests.test.ts
@@ -55,7 +55,8 @@ describe("GenArt721CoreV3 AminACL Requests", async function () {
     } = await deployCoreWithMinterFilter.call(
       this,
       "GenArt721CoreV3",
-      "MinterFilterV1"
+      "MinterFilterV1",
+      true
     ));
 
     this.minter = await deployAndGet.call(this, "MinterSetPriceV2", [

--- a/test/core/V3/GenArt721CoreV3_ContractConfigure.test.ts
+++ b/test/core/V3/GenArt721CoreV3_ContractConfigure.test.ts
@@ -148,8 +148,8 @@ describe("GenArt721CoreV3 Contract Configure", async function () {
         .connect(this.accounts.deployer)
         .forbidNewProjects();
       // update owner of core to null address, expect OwnershipTransferred event
-      expect(
-        await this.adminACL
+      await expect(
+        this.adminACL
           .connect(this.accounts.deployer)
           .renounceOwnershipOn(this.genArt721Core.address)
       )

--- a/test/core/V3/GenArt721CoreV3_Events.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Events.test.ts
@@ -70,8 +70,8 @@ describe("GenArt721CoreV3 Events", async function () {
   describe("MinterUpdated", function () {
     it("emits MinterUpdated when being updated", async function () {
       // emits expected event arg(s)
-      expect(
-        await this.genArt721Core
+      await expect(
+        this.genArt721Core
           .connect(this.accounts.deployer)
           .updateMinterContract(this.accounts.deployer.address)
       )
@@ -101,21 +101,21 @@ describe("GenArt721CoreV3 Events", async function () {
       // target event is the last log
       const targetLog = receipt.logs[receipt.logs.length - 1];
       // expect "PlatformUpdated" event as log 0
-      expect(targetLog.topics[0]).to.be.equal(
+      await expect(targetLog.topics[0]).to.be.equal(
         ethers.utils.keccak256(
           ethers.utils.toUtf8Bytes("PlatformUpdated(bytes32)")
         )
       );
       // expect field to be bytes32 of "nextProjectId" as log 1
-      expect(targetLog.topics[1]).to.be.equal(
+      await expect(targetLog.topics[1]).to.be.equal(
         ethers.utils.formatBytes32String("nextProjectId")
       );
     });
 
     it("emits artblocksSecondarySalesAddress", async function () {
       // emits expected event arg(s)
-      expect(
-        await this.genArt721Core
+      await expect(
+        this.genArt721Core
           .connect(this.accounts.deployer)
           .updateArtblocksSecondarySalesAddress(this.accounts.artist.address)
       )
@@ -127,10 +127,10 @@ describe("GenArt721CoreV3 Events", async function () {
 
     it("emits 'randomizerAddress'", async function () {
       // emits expected event arg(s)
-      expect(
+      await expect(
         // it is OK that this randomizer address isn't a particularly valid
         // address for the purposes of this test
-        await this.genArt721Core
+        this.genArt721Core
           .connect(this.accounts.deployer)
           .updateRandomizerAddress(this.accounts.additional.address)
       )
@@ -140,8 +140,8 @@ describe("GenArt721CoreV3 Events", async function () {
 
     it("emits 'curationRegistryAddress'", async function () {
       // emits expected event arg(s)
-      expect(
-        await this.genArt721Core
+      await expect(
+        this.genArt721Core
           .connect(this.accounts.deployer)
           .updateArtblocksCurationRegistryAddress(this.accounts.artist.address)
       )
@@ -151,8 +151,8 @@ describe("GenArt721CoreV3 Events", async function () {
 
     it("emits 'dependencyRegistryAddress'", async function () {
       // emits expected event arg(s)
-      expect(
-        await this.genArt721Core
+      await expect(
+        this.genArt721Core
           .connect(this.accounts.deployer)
           .updateArtblocksDependencyRegistryAddress(
             this.accounts.artist.address
@@ -166,8 +166,8 @@ describe("GenArt721CoreV3 Events", async function () {
 
     it("emits 'artblocksPrimaryPercentage'", async function () {
       // emits expected event arg(s)
-      expect(
-        await this.genArt721Core
+      await expect(
+        this.genArt721Core
           .connect(this.accounts.deployer)
           .updateArtblocksPrimarySalesPercentage(11)
       )
@@ -179,8 +179,8 @@ describe("GenArt721CoreV3 Events", async function () {
 
     it("emits 'artblocksSecondaryBPS'", async function () {
       // emits expected event arg(s)
-      expect(
-        await this.genArt721Core
+      await expect(
+        this.genArt721Core
           .connect(this.accounts.deployer)
           .updateArtblocksSecondarySalesBPS(240)
       )
@@ -190,10 +190,8 @@ describe("GenArt721CoreV3 Events", async function () {
 
     it("emits 'newProjectsForbidden'", async function () {
       // emits expected event arg(s)
-      expect(
-        await this.genArt721Core
-          .connect(this.accounts.deployer)
-          .forbidNewProjects()
+      await expect(
+        this.genArt721Core.connect(this.accounts.deployer).forbidNewProjects()
       )
         .to.emit(this.genArt721Core, "PlatformUpdated")
         .withArgs(ethers.utils.formatBytes32String("newProjectsForbidden"));
@@ -201,8 +199,8 @@ describe("GenArt721CoreV3 Events", async function () {
 
     it("emits `defaultBaseURI`", async function () {
       // emits expected event arg(s)
-      expect(
-        await this.genArt721Core
+      await expect(
+        this.genArt721Core
           .connect(this.accounts.deployer)
           .updateDefaultBaseURI("https://newbaseuri.com/token/")
       )
@@ -220,10 +218,8 @@ describe("GenArt721CoreV3 Events", async function () {
         1
       );
       // emits expected event arg(s) when completing project
-      expect(
-        await this.minter
-          .connect(this.accounts.artist)
-          .purchase(this.projectZero)
+      await expect(
+        this.minter.connect(this.accounts.artist).purchase(this.projectZero)
       )
         .to.emit(this.genArt721Core, "ProjectUpdated")
         .withArgs(
@@ -234,16 +230,16 @@ describe("GenArt721CoreV3 Events", async function () {
 
     it("emits active", async function () {
       // emits expected event arg(s) when toggling project inactive
-      expect(
-        await this.genArt721Core
+      await expect(
+        this.genArt721Core
           .connect(this.accounts.deployer)
           .toggleProjectIsActive(this.projectZero)
       )
         .to.emit(this.genArt721Core, "ProjectUpdated")
         .withArgs(this.projectZero, ethers.utils.formatBytes32String("active"));
       // emits expected event arg(s) when toggling project active
-      expect(
-        await this.genArt721Core
+      await expect(
+        this.genArt721Core
           .connect(this.accounts.deployer)
           .toggleProjectIsActive(this.projectZero)
       )
@@ -253,8 +249,8 @@ describe("GenArt721CoreV3 Events", async function () {
 
     it("emits artistAddress", async function () {
       // emits expected event arg(s)
-      expect(
-        await this.genArt721Core
+      await expect(
+        this.genArt721Core
           .connect(this.accounts.deployer)
           .updateProjectArtistAddress(
             this.projectZero,
@@ -270,8 +266,8 @@ describe("GenArt721CoreV3 Events", async function () {
 
     it("emits paused", async function () {
       // emits expected event arg(s)
-      expect(
-        await this.genArt721Core
+      await expect(
+        this.genArt721Core
           .connect(this.accounts.artist)
           .toggleProjectIsPaused(this.projectZero)
       )
@@ -281,8 +277,8 @@ describe("GenArt721CoreV3 Events", async function () {
 
     it("emits created", async function () {
       // emits expected event arg(s)
-      expect(
-        await this.genArt721Core
+      await expect(
+        this.genArt721Core
           .connect(this.accounts.deployer)
           .addProject("new project", this.accounts.artist.address)
       )
@@ -292,8 +288,8 @@ describe("GenArt721CoreV3 Events", async function () {
 
     it("emits name", async function () {
       // emits expected event arg(s)
-      expect(
-        await this.genArt721Core
+      await expect(
+        this.genArt721Core
           .connect(this.accounts.deployer)
           .updateProjectName(this.projectZero, "new project name")
       )
@@ -303,8 +299,8 @@ describe("GenArt721CoreV3 Events", async function () {
 
     it("emits artistName", async function () {
       // emits expected event arg(s)
-      expect(
-        await this.genArt721Core
+      await expect(
+        this.genArt721Core
           .connect(this.accounts.deployer)
           .updateProjectArtistName(this.projectZero, "new artist name")
       )
@@ -317,8 +313,8 @@ describe("GenArt721CoreV3 Events", async function () {
 
     it("emits secondaryMarketRoyaltyPercentage", async function () {
       // emits expected event arg(s)
-      expect(
-        await this.genArt721Core
+      await expect(
+        this.genArt721Core
           .connect(this.accounts.artist)
           .updateProjectSecondaryMarketRoyaltyPercentage(this.projectZero, 10)
       )
@@ -331,8 +327,8 @@ describe("GenArt721CoreV3 Events", async function () {
 
     it("emits description", async function () {
       // emits expected event arg(s)
-      expect(
-        await this.genArt721Core
+      await expect(
+        this.genArt721Core
           .connect(this.accounts.artist)
           .updateProjectDescription(this.projectZero, "new description")
       )
@@ -345,8 +341,8 @@ describe("GenArt721CoreV3 Events", async function () {
 
     it("emits website", async function () {
       // emits expected event arg(s)
-      expect(
-        await this.genArt721Core
+      await expect(
+        this.genArt721Core
           .connect(this.accounts.artist)
           .updateProjectWebsite(this.projectZero, "new website")
       )
@@ -359,8 +355,8 @@ describe("GenArt721CoreV3 Events", async function () {
 
     it("emits license", async function () {
       // emits expected event arg(s)
-      expect(
-        await this.genArt721Core
+      await expect(
+        this.genArt721Core
           .connect(this.accounts.artist)
           .updateProjectLicense(this.projectZero, "new license")
       )
@@ -373,8 +369,8 @@ describe("GenArt721CoreV3 Events", async function () {
 
     it("emits maxInvocations", async function () {
       // emits expected event arg(s)
-      expect(
-        await this.genArt721Core
+      await expect(
+        this.genArt721Core
           .connect(this.accounts.artist)
           .updateProjectMaxInvocations(this.projectZero, 10)
       )
@@ -388,16 +384,16 @@ describe("GenArt721CoreV3 Events", async function () {
     it("emits script when adding/editing/removing script", async function () {
       // emits expected event arg(s)
       // add script
-      expect(
-        await this.genArt721Core
+      await expect(
+        this.genArt721Core
           .connect(this.accounts.artist)
           .addProjectScript(this.projectZero, `console.log("hello world")`)
       )
         .to.emit(this.genArt721Core, "ProjectUpdated")
         .withArgs(this.projectZero, ethers.utils.formatBytes32String("script"));
       // edit script
-      expect(
-        await this.genArt721Core
+      await expect(
+        this.genArt721Core
           .connect(this.accounts.artist)
           .updateProjectScript(
             this.projectZero,
@@ -408,8 +404,8 @@ describe("GenArt721CoreV3 Events", async function () {
         .to.emit(this.genArt721Core, "ProjectUpdated")
         .withArgs(this.projectZero, ethers.utils.formatBytes32String("script"));
       // remove script
-      expect(
-        await this.genArt721Core
+      await expect(
+        this.genArt721Core
           .connect(this.accounts.artist)
           .removeProjectLastScript(this.projectZero)
       )
@@ -419,8 +415,8 @@ describe("GenArt721CoreV3 Events", async function () {
 
     it("emits scriptType", async function () {
       // emits expected event arg(s)
-      expect(
-        await this.genArt721Core
+      await expect(
+        this.genArt721Core
           .connect(this.accounts.artist)
           .updateProjectScriptType(
             this.projectZero,
@@ -436,8 +432,8 @@ describe("GenArt721CoreV3 Events", async function () {
 
     it("emits aspectRatio", async function () {
       // emits expected event arg(s)
-      expect(
-        await this.genArt721Core
+      await expect(
+        this.genArt721Core
           .connect(this.accounts.artist)
           .updateProjectAspectRatio(this.projectZero, "1.77777778")
       )
@@ -450,8 +446,8 @@ describe("GenArt721CoreV3 Events", async function () {
 
     it("emits baseURI", async function () {
       // emits expected event arg(s)
-      expect(
-        await this.genArt721Core
+      await expect(
+        this.genArt721Core
           .connect(this.accounts.artist)
           .updateProjectBaseURI(
             this.projectZero,

--- a/test/core/V3/GenArt721CoreV3_Integration.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Integration.test.ts
@@ -129,8 +129,8 @@ describe("GenArt721CoreV3 Integration", async function () {
         .connect(this.accounts.user)
         .deploy();
       // update owner of core to new userAdminACL, expect OwnershipTransferred event
-      expect(
-        await this.adminACL
+      await expect(
+        this.adminACL
           .connect(this.accounts.deployer)
           .transferOwnershipOn(this.genArt721Core.address, userAdminACL.address)
       )
@@ -151,7 +151,7 @@ describe("GenArt721CoreV3 Integration", async function () {
 
     it("behaves as expected when renouncing ownership", async function () {
       // update owner of core to null address, expect OwnershipTransferred event
-      expect(
+      await expect(
         await this.adminACL
           .connect(this.accounts.deployer)
           .renounceOwnershipOn(this.genArt721Core.address)

--- a/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
+++ b/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
@@ -747,16 +747,16 @@ describe("GenArt721CoreV3 Project Configure", async function () {
         91,
       ];
       // artist proposes new values, is automatically accepted
-      expect(
-        await this.genArt721Core
+      await expect(
+        this.genArt721Core
           .connect(this.accounts.artist2)
           .proposeArtistPaymentAddressesAndSplits(...valuesToUpdateTo)
       )
         .to.emit(this.genArt721Core, "AcceptedArtistAddressesAndSplits")
         .withArgs(this.projectZero);
       // check that propose event was also emitted
-      expect(
-        await this.genArt721Core
+      await expect(
+        this.genArt721Core
           .connect(this.accounts.artist2)
           .proposeArtistPaymentAddressesAndSplits(...valuesToUpdateTo)
       )
@@ -816,16 +816,16 @@ describe("GenArt721CoreV3 Project Configure", async function () {
         0,
       ];
       // artist proposes new values, is automatically accepted
-      expect(
-        await this.genArt721Core
+      await expect(
+        this.genArt721Core
           .connect(this.accounts.artist2)
           .proposeArtistPaymentAddressesAndSplits(...valuesToUpdateTo)
       )
         .to.emit(this.genArt721Core, "AcceptedArtistAddressesAndSplits")
         .withArgs(this.projectZero);
       // check that propose event was also emitted
-      expect(
-        await this.genArt721Core
+      await expect(
+        this.genArt721Core
           .connect(this.accounts.artist2)
           .proposeArtistPaymentAddressesAndSplits(...valuesToUpdateTo)
       )
@@ -885,8 +885,8 @@ describe("GenArt721CoreV3 Project Configure", async function () {
         valuesToUpdateTo[4],
         91,
       ];
-      expect(
-        await this.genArt721Core
+      await expect(
+        this.genArt721Core
           .connect(this.accounts.artist2)
           .proposeArtistPaymentAddressesAndSplits(...valuesToUpdateTo)
       )

--- a/test/minter-filter/enumeration/MinterFilterV0Enumeration.PRTNR.test.ts
+++ b/test/minter-filter/enumeration/MinterFilterV0Enumeration.PRTNR.test.ts
@@ -30,6 +30,6 @@ describe("MinterFilterV0Enumeration_V2PRTNRCore", async function () {
   });
 
   describe("common tests", async function () {
-    MinterFilterEnumeration_Common();
+    await MinterFilterEnumeration_Common();
   });
 });

--- a/test/minter-filter/enumeration/MinterFilterV0V1Enumeration.test.ts
+++ b/test/minter-filter/enumeration/MinterFilterV0V1Enumeration.test.ts
@@ -49,7 +49,7 @@ runForEach.forEach((params) => {
     });
 
     describe("common tests", async function () {
-      MinterFilterEnumeration_Common();
+      await MinterFilterEnumeration_Common();
     });
 
     describe("test specific to V1", async function () {

--- a/test/minter-filter/events/MinterFilterV0Events.PRTNR.test.ts
+++ b/test/minter-filter/events/MinterFilterV0Events.PRTNR.test.ts
@@ -50,6 +50,6 @@ describe("MinterFilterV0Events_V2PRTNRCore", async function () {
   });
 
   describe("common tests", async function () {
-    MinterFilterEvents_Common();
+    await MinterFilterEvents_Common();
   });
 });

--- a/test/minter-filter/events/MinterFilterV0V1Events.test.ts
+++ b/test/minter-filter/events/MinterFilterV0V1Events.test.ts
@@ -71,7 +71,7 @@ runForEach.forEach((params) => {
     });
 
     describe("common tests", async function () {
-      MinterFilterEvents_Common();
+      await MinterFilterEvents_Common();
     });
   });
 });

--- a/test/minter-filter/permissions/MinterFilterV0Permissions.PRTNR.test.ts
+++ b/test/minter-filter/permissions/MinterFilterV0Permissions.PRTNR.test.ts
@@ -39,6 +39,6 @@ describe("MinterFilterV0PermissionsEvents_V2PRTNRCore", async function () {
   });
 
   describe("common tests", async function () {
-    MinterFilterPermissions_Common();
+    await MinterFilterPermissions_Common();
   });
 });

--- a/test/minter-filter/permissions/MinterFilterV0Permissions.test.ts
+++ b/test/minter-filter/permissions/MinterFilterV0Permissions.test.ts
@@ -39,6 +39,6 @@ describe("MinterFilterV0PermissionsEvents", async function () {
   });
 
   describe("common tests", async function () {
-    MinterFilterPermissions_Common();
+    await MinterFilterPermissions_Common();
   });
 });

--- a/test/minter-filter/permissions/MinterFilterV0V1Permissions.test.ts
+++ b/test/minter-filter/permissions/MinterFilterV0V1Permissions.test.ts
@@ -55,7 +55,7 @@ runForEach.forEach((params) => {
     });
 
     describe("common tests", async function () {
-      MinterFilterPermissions_Common();
+      await MinterFilterPermissions_Common();
     });
   });
 });

--- a/test/minter-filter/views/MinterFilterV0V1Views.test.ts
+++ b/test/minter-filter/views/MinterFilterV0V1Views.test.ts
@@ -57,7 +57,7 @@ runForEach.forEach((params) => {
     });
 
     describe("common tests", async function () {
-      MinterFilterViews_Common();
+      await MinterFilterViews_Common();
     });
   });
 });

--- a/test/minter-filter/views/MinterFilterV0Views.PRTNR.test.ts
+++ b/test/minter-filter/views/MinterFilterV0Views.PRTNR.test.ts
@@ -36,6 +36,6 @@ describe("MinterFilterV0Views", async function () {
   });
 
   describe("common tests", async function () {
-    MinterFilterViews_Common();
+    await MinterFilterViews_Common();
   });
 });

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExp.common.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExp.common.ts
@@ -23,7 +23,7 @@ const DAExpAuctionParamsAreZero = (auctionParams) => {
  */
 export const MinterDAExp_Common = async () => {
   describe("common minter tests", async () => {
-    Minter_Common();
+    await Minter_Common();
   });
 
   describe("purchase", async function () {

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV0.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV0.test.ts
@@ -109,7 +109,7 @@ describe("MinterDAExpV0_V1Core", async function () {
   });
 
   describe("common tests", async function () {
-    MinterDAExp_Common();
+    await MinterDAExp_Common();
   });
 
   describe("calculate gas", async function () {

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV1.PRTNR.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV1.PRTNR.test.ts
@@ -55,7 +55,7 @@ describe("MinterDAExpV1_V1PRTNRCore", async function () {
       this.minterFilter.address,
     ]);
 
-    safeAddProject(
+    await safeAddProject(
       this.genArt721Core,
       this.accounts.deployer,
       this.accounts.artist.address
@@ -104,11 +104,11 @@ describe("MinterDAExpV1_V1PRTNRCore", async function () {
   });
 
   describe("common DAEXP tests", async function () {
-    MinterDAExp_Common();
+    await MinterDAExp_Common();
   });
 
   describe("common DA V1V2 tests", async function () {
-    MinterDAV1V2_Common();
+    await MinterDAV1V2_Common();
   });
 
   describe("calculate gas", async function () {

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV1.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV1.test.ts
@@ -55,7 +55,7 @@ describe("MinterDAExpV1_V1Core", async function () {
       this.minterFilter.address,
     ]);
 
-    safeAddProject(
+    await safeAddProject(
       this.genArt721Core,
       this.accounts.deployer,
       this.accounts.artist.address
@@ -104,11 +104,11 @@ describe("MinterDAExpV1_V1Core", async function () {
   });
 
   describe("common DAEXP tests", async function () {
-    MinterDAExp_Common();
+    await MinterDAExp_Common();
   });
 
   describe("common DA V1V2 tests", async function () {
-    MinterDAV1V2_Common();
+    await MinterDAV1V2_Common();
   });
 
   describe("calculate gas", async function () {

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
@@ -105,15 +105,15 @@ describe("MinterDAExpV2_V3Core", async function () {
   });
 
   describe("common DAEXP tests", async function () {
-    MinterDAExp_Common();
+    await MinterDAExp_Common();
   });
 
   describe("common DA V1V2 tests", async function () {
-    MinterDAV1V2_Common();
+    await MinterDAV1V2_Common();
   });
 
   describe("common DA V2 tests", async function () {
-    MinterDAV2_Common();
+    await MinterDAV2_Common();
   });
 
   describe("setAuctionDetails", async function () {

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALin.common.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALin.common.ts
@@ -23,7 +23,7 @@ const DALinAuctionParamsAreZero = (auctionParams) => {
  */
 export const MinterDALin_Common = async () => {
   describe("common minter tests", async () => {
-    Minter_Common();
+    await Minter_Common();
   });
 
   describe("purchase", async function () {

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV0.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV0.test.ts
@@ -109,7 +109,7 @@ describe("MinterDALinV0_V1Core", async function () {
   });
 
   describe("common tests", async function () {
-    MinterDALin_Common();
+    await MinterDALin_Common();
   });
 
   describe("calculate gas", async function () {

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV1.PRTNR.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV1.PRTNR.test.ts
@@ -103,11 +103,11 @@ describe("MinterDALinV1_V2PRTNRCore", async function () {
   });
 
   describe("common DALin tests", async () => {
-    MinterDALin_Common();
+    await MinterDALin_Common();
   });
 
   describe("common DA V1V2 tests", async function () {
-    MinterDAV1V2_Common();
+    await MinterDAV1V2_Common();
   });
 
   describe("calculate gas", async function () {

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV1.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV1.test.ts
@@ -103,11 +103,11 @@ describe("MinterDALinV1_V1Core", async function () {
   });
 
   describe("common DALin tests", async () => {
-    MinterDALin_Common();
+    await MinterDALin_Common();
   });
 
   describe("common DA V1V2 tests", async function () {
-    MinterDAV1V2_Common();
+    await MinterDAV1V2_Common();
   });
 
   describe("calculate gas", async function () {

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
@@ -104,15 +104,15 @@ describe("MinterDALinV2_V3Core", async function () {
   });
 
   describe("common DALin tests", async () => {
-    MinterDALin_Common();
+    await MinterDALin_Common();
   });
 
   describe("common DA V1V2 tests", async function () {
-    MinterDAV1V2_Common();
+    await MinterDAV1V2_Common();
   });
 
   describe("common DA V2 tests", async function () {
-    MinterDAV2_Common();
+    await MinterDAV2_Common();
   });
 
   describe("setAuctionDetails", async function () {

--- a/test/minter-suite-minters/MinterHolder/MinterHolder.common.ts
+++ b/test/minter-suite-minters/MinterHolder/MinterHolder.common.ts
@@ -23,7 +23,7 @@ import { getGnosisSafe } from "../../util/GnosisSafeNetwork";
  */
 export const MinterHolder_Common = async () => {
   describe("common minter tests", async () => {
-    Minter_Common();
+    await Minter_Common();
   });
 
   describe("updatePricePerTokenInWei", async function () {

--- a/test/minter-suite-minters/MinterHolder/MinterHolderV0.test.ts
+++ b/test/minter-suite-minters/MinterHolder/MinterHolderV0.test.ts
@@ -92,7 +92,7 @@ describe("MinterHolderV0", async function () {
     await this.genArt721Core
       .connect(this.accounts.artist)
       .toggleProjectIsPaused(this.projectOne);
-    this.genArt721Core
+    await this.genArt721Core
       .connect(this.accounts.artist)
       .toggleProjectIsPaused(this.projectTwo);
 
@@ -154,7 +154,7 @@ describe("MinterHolderV0", async function () {
   });
 
   describe("common MinterHolder tests", async () => {
-    MinterHolder_Common();
+    await MinterHolder_Common();
   });
 
   describe("calculates gas", async function () {

--- a/test/minter-suite-minters/MinterHolder/MinterHolderV0.test.ts
+++ b/test/minter-suite-minters/MinterHolder/MinterHolderV0.test.ts
@@ -86,10 +86,10 @@ describe("MinterHolderV0", async function () {
       .connect(this.accounts.artist)
       .updateProjectMaxInvocations(this.projectTwo, this.maxInvocations);
 
-    this.genArt721Core
+    await this.genArt721Core
       .connect(this.accounts.artist)
       .toggleProjectIsPaused(this.projectZero);
-    this.genArt721Core
+    await this.genArt721Core
       .connect(this.accounts.artist)
       .toggleProjectIsPaused(this.projectOne);
     this.genArt721Core

--- a/test/minter-suite-minters/MinterHolder/MinterHolderV1.test.ts
+++ b/test/minter-suite-minters/MinterHolder/MinterHolderV1.test.ts
@@ -85,13 +85,13 @@ describe("MinterHolderV1", async function () {
       .connect(this.accounts.artist)
       .updateProjectMaxInvocations(this.projectTwo, this.maxInvocations);
 
-    this.genArt721Core
+    await this.genArt721Core
       .connect(this.accounts.artist)
       .toggleProjectIsPaused(this.projectZero);
-    this.genArt721Core
+    await this.genArt721Core
       .connect(this.accounts.artist)
       .toggleProjectIsPaused(this.projectOne);
-    this.genArt721Core
+    await this.genArt721Core
       .connect(this.accounts.artist)
       .toggleProjectIsPaused(this.projectTwo);
 

--- a/test/minter-suite-minters/MinterHolder/MinterHolderV1.test.ts
+++ b/test/minter-suite-minters/MinterHolder/MinterHolderV1.test.ts
@@ -153,7 +153,7 @@ describe("MinterHolderV1", async function () {
   });
 
   describe("common MinterHolder tests", async () => {
-    MinterHolder_Common();
+    await MinterHolder_Common();
   });
 
   describe("setProjectMaxInvocations", async function () {

--- a/test/minter-suite-minters/MinterMerkle/MinterMerkle.common.ts
+++ b/test/minter-suite-minters/MinterMerkle/MinterMerkle.common.ts
@@ -44,7 +44,7 @@ export function hashAddress(_address) {
  */
 export const MinterMerkle_Common = async () => {
   describe("common minter tests", async () => {
-    Minter_Common();
+    await Minter_Common();
   });
 
   describe("deploy", async () => {

--- a/test/minter-suite-minters/MinterMerkle/MinterMerkleV0.test.ts
+++ b/test/minter-suite-minters/MinterMerkle/MinterMerkleV0.test.ts
@@ -167,7 +167,7 @@ describe("MinterMerkleV0", async function () {
   });
 
   describe("common MinterMerkle tests", async () => {
-    MinterMerkle_Common();
+    await MinterMerkle_Common();
   });
 
   describe("calculates gas", async function () {

--- a/test/minter-suite-minters/MinterMerkle/MinterMerkleV0.test.ts
+++ b/test/minter-suite-minters/MinterMerkle/MinterMerkleV0.test.ts
@@ -81,13 +81,13 @@ describe("MinterMerkleV0", async function () {
       .connect(this.accounts.artist)
       .updateProjectMaxInvocations(this.projectTwo, this.maxInvocations);
 
-    this.genArt721Core
+    await this.genArt721Core
       .connect(this.accounts.artist)
       .toggleProjectIsPaused(this.projectZero);
-    this.genArt721Core
+    await this.genArt721Core
       .connect(this.accounts.artist)
       .toggleProjectIsPaused(this.projectOne);
-    this.genArt721Core
+    await this.genArt721Core
       .connect(this.accounts.artist)
       .toggleProjectIsPaused(this.projectTwo);
 

--- a/test/minter-suite-minters/MinterMerkle/MinterMerkleV1.test.ts
+++ b/test/minter-suite-minters/MinterMerkle/MinterMerkleV1.test.ts
@@ -82,13 +82,13 @@ describe("MinterMerkleV1", async function () {
       .connect(this.accounts.artist)
       .updateProjectMaxInvocations(this.projectTwo, this.maxInvocations);
 
-    this.genArt721Core
+    await this.genArt721Core
       .connect(this.accounts.artist)
       .toggleProjectIsPaused(this.projectZero);
-    this.genArt721Core
+    await this.genArt721Core
       .connect(this.accounts.artist)
       .toggleProjectIsPaused(this.projectOne);
-    this.genArt721Core
+    await this.genArt721Core
       .connect(this.accounts.artist)
       .toggleProjectIsPaused(this.projectTwo);
 
@@ -168,7 +168,7 @@ describe("MinterMerkleV1", async function () {
   });
 
   describe("common MinterMerkle tests", async () => {
-    MinterMerkle_Common();
+    await MinterMerkle_Common();
   });
 
   describe("setProjectMaxInvocations", async function () {

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPrice.common.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPrice.common.ts
@@ -10,7 +10,7 @@ import { Minter_Common } from "../../Minter.common";
  */
 export const MinterSetPrice_ETH_Common = async () => {
   describe("common minter tests", async () => {
-    Minter_Common();
+    await Minter_Common();
   });
 
   describe("updatePricePerTokenInWei", async function () {

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV0.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV0.test.ts
@@ -141,7 +141,7 @@ describe("MinterSetPriceV0_V1Core", async function () {
   });
 
   describe("common MinterSetPrice (ETH) tests", async () => {
-    MinterSetPrice_ETH_Common();
+    await MinterSetPrice_ETH_Common();
   });
 
   describe("calculates gas", async function () {

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV1.PRTNR.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV1.PRTNR.test.ts
@@ -132,11 +132,11 @@ describe("MinterSetPriceV1_V2PRTNRCore", async function () {
   });
 
   describe("common MinterSetPrice (ETH) tests", async () => {
-    MinterSetPrice_ETH_Common();
+    await MinterSetPrice_ETH_Common();
   });
 
   describe("common MinterSetPrice V1V2 tests", async function () {
-    MinterSetPriceV1V2_Common();
+    await MinterSetPriceV1V2_Common();
   });
 
   describe("calculates gas", async function () {

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV1.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV1.test.ts
@@ -133,11 +133,11 @@ describe("MinterSetPriceV1_V1Core", async function () {
   });
 
   describe("common MinterSetPrice (ETH) tests", async () => {
-    MinterSetPrice_ETH_Common();
+    await MinterSetPrice_ETH_Common();
   });
 
   describe("common MinterSetPrice V1V2 tests", async function () {
-    MinterSetPriceV1V2_Common();
+    await MinterSetPriceV1V2_Common();
   });
 
   describe("calculates gas", async function () {

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
@@ -137,15 +137,15 @@ describe("MinterSetPriceV2_V3Core", async function () {
   });
 
   describe("common MinterSetPrice (ETH) tests", async () => {
-    MinterSetPrice_ETH_Common();
+    await MinterSetPrice_ETH_Common();
   });
 
   describe("common MinterSetPrice V1V2 tests", async function () {
-    MinterSetPriceV1V2_Common();
+    await MinterSetPriceV1V2_Common();
   });
 
   describe("common MinterSetPrice V2 tests", async function () {
-    MinterSetPriceV2_Common();
+    await MinterSetPriceV2_Common();
   });
 
   describe("setProjectMaxInvocations", async function () {

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20.common.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20.common.ts
@@ -11,7 +11,7 @@ import { Minter_Common } from "../../Minter.common";
  */
 export const MinterSetPriceERC20_Common = async () => {
   describe("common minter tests", async () => {
-    Minter_Common();
+    await Minter_Common();
   });
 
   describe("updatePricePerTokenInWei", async function () {

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V0.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V0.test.ts
@@ -80,13 +80,13 @@ describe("MinterSetPriceERC20V0_V1Core", async function () {
       .connect(this.accounts.artist)
       .updateProjectMaxInvocations(this.projectTwo, this.maxInvocations);
 
-    this.genArt721Core
+    await this.genArt721Core
       .connect(this.accounts.artist)
       .toggleProjectIsPaused(this.projectZero);
-    this.genArt721Core
+    await this.genArt721Core
       .connect(this.accounts.artist)
       .toggleProjectIsPaused(this.projectOne);
-    this.genArt721Core
+    await this.genArt721Core
       .connect(this.accounts.artist)
       .toggleProjectIsPaused(this.projectTwo);
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V0.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V0.test.ts
@@ -119,7 +119,7 @@ describe("MinterSetPriceERC20V0_V1Core", async function () {
   });
 
   describe("common MinterSetPrice (ETH) tests", async () => {
-    MinterSetPriceERC20_Common();
+    await MinterSetPriceERC20_Common();
   });
 
   describe("calculates gas", async function () {

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V1.PRTNR.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V1.PRTNR.test.ts
@@ -114,11 +114,11 @@ describe("MinterSetPriceERC20V1_V2PRTNRCore", async function () {
   });
 
   describe("common MinterSetPrice (ETH) tests", async () => {
-    MinterSetPriceERC20_Common();
+    await MinterSetPriceERC20_Common();
   });
 
   describe("common MinterSetPrice V1V2 tests", async function () {
-    MinterSetPriceV1V2_Common();
+    await MinterSetPriceV1V2_Common();
   });
 
   describe("calculates gas", async function () {

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V1.PRTNR.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V1.PRTNR.test.ts
@@ -75,13 +75,13 @@ describe("MinterSetPriceERC20V1_V2PRTNRCore", async function () {
       .connect(this.accounts.artist)
       .updateProjectMaxInvocations(this.projectTwo, this.maxInvocations);
 
-    this.genArt721Core
+    await this.genArt721Core
       .connect(this.accounts.artist)
       .toggleProjectIsPaused(this.projectZero);
-    this.genArt721Core
+    await this.genArt721Core
       .connect(this.accounts.artist)
       .toggleProjectIsPaused(this.projectOne);
-    this.genArt721Core
+    await this.genArt721Core
       .connect(this.accounts.artist)
       .toggleProjectIsPaused(this.projectTwo);
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V1.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V1.test.ts
@@ -119,11 +119,11 @@ describe("MinterSetPriceERC20V1_V1Core", async function () {
   });
 
   describe("common MinterSetPrice (ETH) tests", async () => {
-    MinterSetPriceERC20_Common();
+    await MinterSetPriceERC20_Common();
   });
 
   describe("common MinterSetPrice V1V2 tests", async function () {
-    MinterSetPriceV1V2_Common();
+    await MinterSetPriceV1V2_Common();
   });
 
   describe("calculates gas", async function () {

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V1.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V1.test.ts
@@ -80,13 +80,13 @@ describe("MinterSetPriceERC20V1_V1Core", async function () {
       .connect(this.accounts.artist)
       .updateProjectMaxInvocations(this.projectTwo, this.maxInvocations);
 
-    this.genArt721Core
+    await this.genArt721Core
       .connect(this.accounts.artist)
       .toggleProjectIsPaused(this.projectZero);
-    this.genArt721Core
+    await this.genArt721Core
       .connect(this.accounts.artist)
       .toggleProjectIsPaused(this.projectOne);
-    this.genArt721Core
+    await this.genArt721Core
       .connect(this.accounts.artist)
       .toggleProjectIsPaused(this.projectTwo);
 

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V1V2.common.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V1V2.common.ts
@@ -16,7 +16,7 @@ import { isCoreV3 } from "../../../util/common";
  */
 export const MinterSetPriceERC20V1V2_Common = async () => {
   describe("common MinterSetPrice V1V2 minter tests", async () => {
-    MinterSetPriceV1V2_Common();
+    await MinterSetPriceV1V2_Common();
   });
 
   describe("gnosis safe V1V2", async function () {

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
@@ -82,13 +82,13 @@ describe("MinterSetPriceERC20V2_V3Core", async function () {
       .connect(this.accounts.artist)
       .updateProjectMaxInvocations(this.projectTwo, this.maxInvocations);
 
-    this.genArt721Core
+    await this.genArt721Core
       .connect(this.accounts.artist)
       .toggleProjectIsPaused(this.projectZero);
-    this.genArt721Core
+    await this.genArt721Core
       .connect(this.accounts.artist)
       .toggleProjectIsPaused(this.projectOne);
-    this.genArt721Core
+    await this.genArt721Core
       .connect(this.accounts.artist)
       .toggleProjectIsPaused(this.projectTwo);
 
@@ -121,15 +121,15 @@ describe("MinterSetPriceERC20V2_V3Core", async function () {
   });
 
   describe("common MinterSetPrice (ETH) tests", async () => {
-    MinterSetPriceERC20_Common();
+    await MinterSetPriceERC20_Common();
   });
 
   describe("common MinterSetPrice V1V2 tests", async function () {
-    MinterSetPriceV1V2_Common();
+    await MinterSetPriceV1V2_Common();
   });
 
   describe("common MinterSetPrice V2 tests", async function () {
-    MinterSetPriceV2_Common();
+    await MinterSetPriceV2_Common();
   });
 
   describe("updatePricePerTokenInWei", async function () {

--- a/test/minters-pbab/GenArt721MinterBurner_PBAB.test.ts
+++ b/test/minters-pbab/GenArt721MinterBurner_PBAB.test.ts
@@ -113,7 +113,7 @@ describe("GenArt721MinterBurner_PBAB", async function () {
 
   // base tests
   describe("common tests", async function () {
-    GenArt721Minter_PBAB_Common();
+    await GenArt721Minter_PBAB_Common();
   });
 
   describe("setBurnERC20DuringPurchase", async function () {

--- a/test/minters-pbab/GenArt721MinterBurner_PBAB.test.ts
+++ b/test/minters-pbab/GenArt721MinterBurner_PBAB.test.ts
@@ -80,7 +80,7 @@ describe("GenArt721MinterBurner_PBAB", async function () {
       .connect(this.accounts.artist)
       .updateProjectMaxInvocations(this.projectTwo, this.maxInvocations);
 
-    this.genArt721Core
+    await this.genArt721Core
       .connect(this.accounts.artist)
       .toggleProjectIsPaused(this.projectZero);
     this.genArt721Core

--- a/test/minters-pbab/GenArt721Minter_PBAB.test.ts
+++ b/test/minters-pbab/GenArt721Minter_PBAB.test.ts
@@ -110,7 +110,7 @@ describe("GenArt721Minter_PBAB", async function () {
 
   // base tests
   describe("common tests", async function () {
-    GenArt721Minter_PBAB_Common();
+    await GenArt721Minter_PBAB_Common();
   });
 
   // no additional tests neeeded for this contract

--- a/test/minters-pbab/GenArt721Minter_PBAB.test.ts
+++ b/test/minters-pbab/GenArt721Minter_PBAB.test.ts
@@ -77,13 +77,13 @@ describe("GenArt721Minter_PBAB", async function () {
       .connect(this.accounts.artist)
       .updateProjectMaxInvocations(this.projectTwo, this.maxInvocations);
 
-    this.genArt721Core
+    await this.genArt721Core
       .connect(this.accounts.artist)
       .toggleProjectIsPaused(this.projectZero);
-    this.genArt721Core
+    await this.genArt721Core
       .connect(this.accounts.artist)
       .toggleProjectIsPaused(this.projectOne);
-    this.genArt721Core
+    await this.genArt721Core
       .connect(this.accounts.artist)
       .toggleProjectIsPaused(this.projectTwo);
 

--- a/test/royalty-overrides/GenArt721RoyaltyOverride.PRTNR.test.ts
+++ b/test/royalty-overrides/GenArt721RoyaltyOverride.PRTNR.test.ts
@@ -124,10 +124,10 @@ describe("GenArt721RoyaltyOverride_PRTNR", async function () {
       .connect(artist1)
       .updateProjectMaxInvocations(projectOne, 15);
 
-    this.tokenA
+    await this.tokenA
       .connect(this.royaltyAccounts.artist0)
       .toggleProjectIsPaused(projectZero);
-    this.tokenA
+    await this.tokenA
       .connect(this.royaltyAccounts.artist1)
       .toggleProjectIsPaused(projectOne);
 
@@ -205,10 +205,10 @@ describe("GenArt721RoyaltyOverride_PRTNR", async function () {
       .connect(artist1)
       .updateProjectMaxInvocations(projectOne, 15);
 
-    this.tokenB
+    await this.tokenB
       .connect(this.royaltyAccounts.artist0)
       .toggleProjectIsPaused(projectZero);
-    this.tokenB
+    await this.tokenB
       .connect(this.royaltyAccounts.artist1)
       .toggleProjectIsPaused(projectOne);
 

--- a/test/royalty-overrides/GenArt721RoyaltyOverride.PRTNR.test.ts
+++ b/test/royalty-overrides/GenArt721RoyaltyOverride.PRTNR.test.ts
@@ -277,7 +277,7 @@ describe("GenArt721RoyaltyOverride_PRTNR", async function () {
       let response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -290,7 +290,7 @@ describe("GenArt721RoyaltyOverride_PRTNR", async function () {
       response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject1);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist1.address,
@@ -317,7 +317,7 @@ describe("GenArt721RoyaltyOverride_PRTNR", async function () {
       response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenB.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -330,7 +330,7 @@ describe("GenArt721RoyaltyOverride_PRTNR", async function () {
       response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenB.address, tokenIdProject1);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist1.address,
@@ -352,7 +352,7 @@ describe("GenArt721RoyaltyOverride_PRTNR", async function () {
       let response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -369,7 +369,7 @@ describe("GenArt721RoyaltyOverride_PRTNR", async function () {
       response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -393,7 +393,7 @@ describe("GenArt721RoyaltyOverride_PRTNR", async function () {
       let response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -414,7 +414,7 @@ describe("GenArt721RoyaltyOverride_PRTNR", async function () {
       response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -514,7 +514,7 @@ describe("GenArt721RoyaltyOverride_PRTNR", async function () {
       let response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenB.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -573,7 +573,7 @@ describe("GenArt721RoyaltyOverride_PRTNR", async function () {
       let response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -590,7 +590,7 @@ describe("GenArt721RoyaltyOverride_PRTNR", async function () {
       response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -610,7 +610,7 @@ describe("GenArt721RoyaltyOverride_PRTNR", async function () {
       let response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -627,7 +627,7 @@ describe("GenArt721RoyaltyOverride_PRTNR", async function () {
       response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,

--- a/test/royalty-overrides/GenArt721RoyaltyOverride.test.ts
+++ b/test/royalty-overrides/GenArt721RoyaltyOverride.test.ts
@@ -118,10 +118,10 @@ describe("GenArt721RoyaltyOverride", async function () {
       .connect(artist1)
       .updateProjectMaxInvocations(projectOne, 15);
 
-    this.tokenA
+    await this.tokenA
       .connect(this.royaltyAccounts.artist0)
       .toggleProjectIsPaused(projectZero);
-    this.tokenA
+    await this.tokenA
       .connect(this.royaltyAccounts.artist1)
       .toggleProjectIsPaused(projectOne);
 
@@ -199,10 +199,10 @@ describe("GenArt721RoyaltyOverride", async function () {
       .connect(artist1)
       .updateProjectMaxInvocations(projectOne, 15);
 
-    this.tokenB
+    await this.tokenB
       .connect(this.royaltyAccounts.artist0)
       .toggleProjectIsPaused(projectZero);
-    this.tokenB
+    await this.tokenB
       .connect(this.royaltyAccounts.artist1)
       .toggleProjectIsPaused(projectOne);
 

--- a/test/royalty-overrides/GenArt721RoyaltyOverride.test.ts
+++ b/test/royalty-overrides/GenArt721RoyaltyOverride.test.ts
@@ -271,7 +271,7 @@ describe("GenArt721RoyaltyOverride", async function () {
       let response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -284,7 +284,7 @@ describe("GenArt721RoyaltyOverride", async function () {
       response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject1);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist1.address,
@@ -311,7 +311,7 @@ describe("GenArt721RoyaltyOverride", async function () {
       response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenB.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -324,7 +324,7 @@ describe("GenArt721RoyaltyOverride", async function () {
       response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenB.address, tokenIdProject1);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist1.address,
@@ -346,7 +346,7 @@ describe("GenArt721RoyaltyOverride", async function () {
       let response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -363,7 +363,7 @@ describe("GenArt721RoyaltyOverride", async function () {
       response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -387,7 +387,7 @@ describe("GenArt721RoyaltyOverride", async function () {
       let response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -408,7 +408,7 @@ describe("GenArt721RoyaltyOverride", async function () {
       response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -508,7 +508,7 @@ describe("GenArt721RoyaltyOverride", async function () {
       let response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenB.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -567,7 +567,7 @@ describe("GenArt721RoyaltyOverride", async function () {
       let response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -584,7 +584,7 @@ describe("GenArt721RoyaltyOverride", async function () {
       response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -604,7 +604,7 @@ describe("GenArt721RoyaltyOverride", async function () {
       let response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -621,7 +621,7 @@ describe("GenArt721RoyaltyOverride", async function () {
       response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,

--- a/test/royalty-overrides/GenArt721RoyaltyOverride_PBAB.test.ts
+++ b/test/royalty-overrides/GenArt721RoyaltyOverride_PBAB.test.ts
@@ -123,10 +123,10 @@ describe("GenArt721RoyaltyOverride_PBAB", async function () {
       .connect(artist1)
       .updateProjectMaxInvocations(projectOne, 15);
 
-    this.tokenA
+    await this.tokenA
       .connect(this.royaltyAccounts.artist0)
       .toggleProjectIsPaused(projectZero);
-    this.tokenA
+    await this.tokenA
       .connect(this.royaltyAccounts.artist1)
       .toggleProjectIsPaused(projectOne);
 
@@ -188,10 +188,10 @@ describe("GenArt721RoyaltyOverride_PBAB", async function () {
       .connect(artist1)
       .updateProjectMaxInvocations(projectOne, 15);
 
-    this.tokenB
+    await this.tokenB
       .connect(this.royaltyAccounts.artist0)
       .toggleProjectIsPaused(projectZero);
-    this.tokenB
+    await this.tokenB
       .connect(this.royaltyAccounts.artist1)
       .toggleProjectIsPaused(projectOne);
 

--- a/test/royalty-overrides/GenArt721RoyaltyOverride_PBAB.test.ts
+++ b/test/royalty-overrides/GenArt721RoyaltyOverride_PBAB.test.ts
@@ -243,7 +243,7 @@ describe("GenArt721RoyaltyOverride_PBAB", async function () {
       let response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -257,7 +257,7 @@ describe("GenArt721RoyaltyOverride_PBAB", async function () {
       response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject1);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist1.address,
@@ -285,7 +285,7 @@ describe("GenArt721RoyaltyOverride_PBAB", async function () {
       response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenB.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -299,7 +299,7 @@ describe("GenArt721RoyaltyOverride_PBAB", async function () {
       response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenB.address, tokenIdProject1);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist1.address,
@@ -322,7 +322,7 @@ describe("GenArt721RoyaltyOverride_PBAB", async function () {
       let response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -340,7 +340,7 @@ describe("GenArt721RoyaltyOverride_PBAB", async function () {
       response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -365,7 +365,7 @@ describe("GenArt721RoyaltyOverride_PBAB", async function () {
       let response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -387,7 +387,7 @@ describe("GenArt721RoyaltyOverride_PBAB", async function () {
       response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -488,7 +488,7 @@ describe("GenArt721RoyaltyOverride_PBAB", async function () {
       let response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenB.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -531,7 +531,7 @@ describe("GenArt721RoyaltyOverride_PBAB", async function () {
       let response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -591,7 +591,7 @@ describe("GenArt721RoyaltyOverride_PBAB", async function () {
       let response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -609,7 +609,7 @@ describe("GenArt721RoyaltyOverride_PBAB", async function () {
       response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -630,7 +630,7 @@ describe("GenArt721RoyaltyOverride_PBAB", async function () {
       let response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -648,7 +648,7 @@ describe("GenArt721RoyaltyOverride_PBAB", async function () {
       response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -714,7 +714,7 @@ describe("GenArt721RoyaltyOverride_PBAB", async function () {
       let response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -732,7 +732,7 @@ describe("GenArt721RoyaltyOverride_PBAB", async function () {
       response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -753,7 +753,7 @@ describe("GenArt721RoyaltyOverride_PBAB", async function () {
       let response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,
@@ -771,7 +771,7 @@ describe("GenArt721RoyaltyOverride_PBAB", async function () {
       response = await this.royaltyOverride
         .connect(this.royaltyAccounts.anyone)
         .getRoyalties(this.tokenA.address, tokenIdProject0);
-      assertRoyaltiesResponse(
+      await assertRoyaltiesResponse(
         response,
         [
           this.royaltyAccounts.artist0.address,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1020,6 +1020,21 @@
   resolved "https://registry.yarnpkg.com/@ensdomains/resolver/-/resolver-0.2.4.tgz#c10fe28bf5efbf49bff4666d909aed0265efbc89"
   integrity sha512-bvaTH34PMCbv6anRa9I/0zjLJgY4EuznbEMgbV77JBCQ9KNC46rzi0avuxpOfu+xDjPEtSFGqVEOr5GlUSGudA==
 
+"@eslint/eslintrc@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.3.3.tgz#2b044ab39fdfa75b4688184f9e573ce3c5b0ff95"
+  integrity sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==
+  dependencies:
+    ajv "^6.12.4"
+    debug "^4.3.2"
+    espree "^9.4.0"
+    globals "^13.15.0"
+    ignore "^5.2.0"
+    import-fresh "^3.2.1"
+    js-yaml "^4.1.0"
+    minimatch "^3.1.2"
+    strip-json-comments "^3.1.1"
+
 "@ethereum-waffle/chai@^3.4.0":
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/@ethereum-waffle/chai/-/chai-3.4.0.tgz#2477877410a96bf370edd64df905b04fb9aba9d5"
@@ -1999,6 +2014,25 @@
     "@gnosis.pm/safe-core-sdk-types" "^1.1.0"
     node-fetch "^2.6.6"
 
+"@humanwhocodes/config-array@^0.10.5":
+  version "0.10.7"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.10.7.tgz#6d53769fd0c222767e6452e8ebda825c22e9f0dc"
+  integrity sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==
+  dependencies:
+    "@humanwhocodes/object-schema" "^1.2.1"
+    debug "^4.1.1"
+    minimatch "^3.0.4"
+
+"@humanwhocodes/module-importer@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz#af5b2691a22b44be847b0ca81641c5fb6ad0172c"
+  integrity sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==
+
+"@humanwhocodes/object-schema@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
+  integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
+
 "@jest/types@^27.2.5":
   version "27.2.5"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.2.5.tgz#420765c052605e75686982d24b061b4cbba22132"
@@ -2708,6 +2742,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
 
+"@types/json-schema@^7.0.9":
+  version "7.0.11"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
+  integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
+
 "@types/level-errors@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/level-errors/-/level-errors-3.0.0.tgz#15c1f4915a5ef763b51651b15e90f6dc081b96a8"
@@ -2849,6 +2888,87 @@
   integrity sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==
   dependencies:
     "@types/yargs-parser" "*"
+
+"@typescript-eslint/eslint-plugin@^5.40.0":
+  version "5.40.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.40.0.tgz#0159bb71410eec563968288a17bd4478cdb685bd"
+  integrity sha512-FIBZgS3DVJgqPwJzvZTuH4HNsZhHMa9SjxTKAZTlMsPw/UzpEjcf9f4dfgDJEHjK+HboUJo123Eshl6niwEm/Q==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.40.0"
+    "@typescript-eslint/type-utils" "5.40.0"
+    "@typescript-eslint/utils" "5.40.0"
+    debug "^4.3.4"
+    ignore "^5.2.0"
+    regexpp "^3.2.0"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/parser@^5.40.0":
+  version "5.40.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.40.0.tgz#432bddc1fe9154945660f67c1ba6d44de5014840"
+  integrity sha512-Ah5gqyX2ySkiuYeOIDg7ap51/b63QgWZA7w6AHtFrag7aH0lRQPbLzUjk0c9o5/KZ6JRkTTDKShL4AUrQa6/hw==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.40.0"
+    "@typescript-eslint/types" "5.40.0"
+    "@typescript-eslint/typescript-estree" "5.40.0"
+    debug "^4.3.4"
+
+"@typescript-eslint/scope-manager@5.40.0":
+  version "5.40.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.40.0.tgz#d6ea782c8e3a2371ba3ea31458dcbdc934668fc4"
+  integrity sha512-d3nPmjUeZtEWRvyReMI4I1MwPGC63E8pDoHy0BnrYjnJgilBD3hv7XOiETKLY/zTwI7kCnBDf2vWTRUVpYw0Uw==
+  dependencies:
+    "@typescript-eslint/types" "5.40.0"
+    "@typescript-eslint/visitor-keys" "5.40.0"
+
+"@typescript-eslint/type-utils@5.40.0":
+  version "5.40.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.40.0.tgz#4964099d0158355e72d67a370249d7fc03331126"
+  integrity sha512-nfuSdKEZY2TpnPz5covjJqav+g5qeBqwSHKBvz7Vm1SAfy93SwKk/JeSTymruDGItTwNijSsno5LhOHRS1pcfw==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "5.40.0"
+    "@typescript-eslint/utils" "5.40.0"
+    debug "^4.3.4"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/types@5.40.0":
+  version "5.40.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.40.0.tgz#8de07e118a10b8f63c99e174a3860f75608c822e"
+  integrity sha512-V1KdQRTXsYpf1Y1fXCeZ+uhjW48Niiw0VGt4V8yzuaDTU8Z1Xl7yQDyQNqyAFcVhpYXIVCEuxSIWTsLDpHgTbw==
+
+"@typescript-eslint/typescript-estree@5.40.0":
+  version "5.40.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.40.0.tgz#e305e6a5d65226efa5471ee0f12e0ffaab6d3075"
+  integrity sha512-b0GYlDj8TLTOqwX7EGbw2gL5EXS2CPEWhF9nGJiGmEcmlpNBjyHsTwbqpyIEPVpl6br4UcBOYlcI2FJVtJkYhg==
+  dependencies:
+    "@typescript-eslint/types" "5.40.0"
+    "@typescript-eslint/visitor-keys" "5.40.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/utils@5.40.0":
+  version "5.40.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.40.0.tgz#647f56a875fd09d33c6abd70913c3dd50759b772"
+  integrity sha512-MO0y3T5BQ5+tkkuYZJBjePewsY+cQnfkYeRqS6tPh28niiIwPnQ1t59CSRcs1ZwJJNOdWw7rv9pF8aP58IMihA==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@typescript-eslint/scope-manager" "5.40.0"
+    "@typescript-eslint/types" "5.40.0"
+    "@typescript-eslint/typescript-estree" "5.40.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+    semver "^7.3.7"
+
+"@typescript-eslint/visitor-keys@5.40.0":
+  version "5.40.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.40.0.tgz#dd2d38097f68e0d2e1e06cb9f73c0173aca54b68"
+  integrity sha512-ijJ+6yig+x9XplEpG2K6FUdJeQGGj/15U3S56W9IqXKJqleuD7zJ2AX/miLezwxpd7ZxDAqO87zWufKg+RPZyQ==
+  dependencies:
+    "@typescript-eslint/types" "5.40.0"
+    eslint-visitor-keys "^3.3.0"
 
 "@ungap/promise-all-settled@1.1.2":
   version "1.1.2"
@@ -3094,7 +3214,7 @@ acorn-import-assertions@^1.7.6:
   resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz#ba2b5939ce62c238db6d93d81c9b111b29b855e9"
   integrity sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==
 
-acorn-jsx@^5.0.0:
+acorn-jsx@^5.0.0, acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
@@ -3118,6 +3238,11 @@ acorn@^8.4.1:
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
   integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
+
+acorn@^8.8.0:
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
+  integrity sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==
 
 address@^1.0.1:
   version "1.1.2"
@@ -3159,7 +3284,7 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.5.2:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
-ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.5, ajv@^6.6.1, ajv@^6.9.1:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5, ajv@^6.6.1, ajv@^6.9.1:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -5180,6 +5305,15 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+cross-spawn@^7.0.2:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
+  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
 "crypt@>= 0.0.1":
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
@@ -5301,7 +5435,7 @@ debug@4, debug@^4.1.1:
   dependencies:
     ms "2.1.2"
 
-debug@4.3.4, debug@^4.3.3:
+debug@4.3.4, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -5368,7 +5502,7 @@ deep-extend@^0.6.0:
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
-deep-is@~0.1.3:
+deep-is@^0.1.3, deep-is@~0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
@@ -5923,7 +6057,7 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-scope@5.1.1:
+eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
   integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
@@ -5939,6 +6073,14 @@ eslint-scope@^4.0.3:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-scope@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.1.1.tgz#fff34894c2f65e5226d3041ac480b4513a163642"
+  integrity sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==
+  dependencies:
+    esrecurse "^4.3.0"
+    estraverse "^5.2.0"
+
 eslint-utils@^1.3.1:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.3.tgz#74fec7c54d0776b6f67e0251040b5806564e981f"
@@ -5946,10 +6088,27 @@ eslint-utils@^1.3.1:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
+eslint-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672"
+  integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
+  dependencies:
+    eslint-visitor-keys "^2.0.0"
+
 eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
+
+eslint-visitor-keys@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
+  integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
+
+eslint-visitor-keys@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
+  integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
 eslint@^5.6.0:
   version "5.16.0"
@@ -5993,6 +6152,50 @@ eslint@^5.6.0:
     table "^5.2.3"
     text-table "^0.2.0"
 
+eslint@^8.25.0:
+  version "8.25.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.25.0.tgz#00eb962f50962165d0c4ee3327708315eaa8058b"
+  integrity sha512-DVlJOZ4Pn50zcKW5bYH7GQK/9MsoQG2d5eDH0ebEkE8PbgzTTmtt/VTH9GGJ4BfeZCpBLqFfvsjX35UacUL83A==
+  dependencies:
+    "@eslint/eslintrc" "^1.3.3"
+    "@humanwhocodes/config-array" "^0.10.5"
+    "@humanwhocodes/module-importer" "^1.0.1"
+    ajv "^6.10.0"
+    chalk "^4.0.0"
+    cross-spawn "^7.0.2"
+    debug "^4.3.2"
+    doctrine "^3.0.0"
+    escape-string-regexp "^4.0.0"
+    eslint-scope "^7.1.1"
+    eslint-utils "^3.0.0"
+    eslint-visitor-keys "^3.3.0"
+    espree "^9.4.0"
+    esquery "^1.4.0"
+    esutils "^2.0.2"
+    fast-deep-equal "^3.1.3"
+    file-entry-cache "^6.0.1"
+    find-up "^5.0.0"
+    glob-parent "^6.0.1"
+    globals "^13.15.0"
+    globby "^11.1.0"
+    grapheme-splitter "^1.0.4"
+    ignore "^5.2.0"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    is-glob "^4.0.0"
+    js-sdsl "^4.1.4"
+    js-yaml "^4.1.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.4.1"
+    lodash.merge "^4.6.2"
+    minimatch "^3.1.2"
+    natural-compare "^1.4.0"
+    optionator "^0.9.1"
+    regexpp "^3.2.0"
+    strip-ansi "^6.0.1"
+    strip-json-comments "^3.1.0"
+    text-table "^0.2.0"
+
 espree@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/espree/-/espree-5.0.1.tgz#5d6526fa4fc7f0788a5cf75b15f30323e2f81f7a"
@@ -6001,6 +6204,15 @@ espree@^5.0.1:
     acorn "^6.0.7"
     acorn-jsx "^5.0.0"
     eslint-visitor-keys "^1.0.0"
+
+espree@^9.4.0:
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.4.0.tgz#cd4bc3d6e9336c433265fc0aa016fc1aaf182f8a"
+  integrity sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==
+  dependencies:
+    acorn "^8.8.0"
+    acorn-jsx "^5.3.2"
+    eslint-visitor-keys "^3.3.0"
 
 esprima@2.7.x, esprima@^2.7.1:
   version "2.7.3"
@@ -6012,7 +6224,7 @@ esprima@^4.0.0:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.0.1:
+esquery@^1.0.1, esquery@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
   integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
@@ -6787,7 +6999,7 @@ fast-check@^2.12.1:
   dependencies:
     pure-rand "^5.0.0"
 
-fast-deep-equal@^3.1.1:
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -6808,12 +7020,23 @@ fast-glob@^3.0.3:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
+fast-glob@^3.2.9:
+  version "3.2.12"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
+  integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-fast-levenshtein@~2.0.6:
+fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
@@ -6850,6 +7073,13 @@ file-entry-cache@^5.0.1:
   integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
   dependencies:
     flat-cache "^2.0.1"
+
+file-entry-cache@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
+  integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
+  dependencies:
+    flat-cache "^3.0.4"
 
 file-uri-to-path@1.0.0:
   version "1.0.0"
@@ -6901,7 +7131,7 @@ find-up@3.0.0, find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
-find-up@5.0.0:
+find-up@5.0.0, find-up@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
   integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
@@ -6956,6 +7186,14 @@ flat-cache@^2.0.1:
     rimraf "2.6.3"
     write "1.0.3"
 
+flat-cache@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
+  integrity sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==
+  dependencies:
+    flatted "^3.1.0"
+    rimraf "^3.0.2"
+
 flat@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/flat/-/flat-4.1.1.tgz#a392059cc382881ff98642f5da4dde0a959f309b"
@@ -6972,6 +7210,11 @@ flatted@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
+
+flatted@^3.1.0:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
+  integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
 flow-stoplight@^1.0.0:
   version "1.0.0"
@@ -7293,6 +7536,13 @@ glob-parent@^5.1.2, glob-parent@~5.1.0, glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
+glob-parent@^6.0.1:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
+  integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
+  dependencies:
+    is-glob "^4.0.3"
+
 glob-to-regexp@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
@@ -7374,6 +7624,13 @@ globals@^11.7.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
+globals@^13.15.0:
+  version "13.17.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.17.0.tgz#902eb1e680a41da93945adbdcb5a9f361ba69bd4"
+  integrity sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==
+  dependencies:
+    type-fest "^0.20.2"
+
 globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
@@ -7391,6 +7648,18 @@ globby@^10.0.1:
     glob "^7.1.3"
     ignore "^5.1.1"
     merge2 "^1.2.3"
+    slash "^3.0.0"
+
+globby@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
+  integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.2.9"
+    ignore "^5.2.0"
+    merge2 "^1.4.1"
     slash "^3.0.0"
 
 got@9.6.0, got@^9.6.0:
@@ -7434,6 +7703,11 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9,
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
+
+grapheme-splitter@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
+  integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
 
 growl@1.10.5:
   version "1.10.5"
@@ -7895,6 +8169,11 @@ ignore@^5.1.1:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
+ignore@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
+  integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
+
 immediate@^3.2.3:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.3.0.tgz#1aef225517836bcdf7f2a2de2600c79ff0269266"
@@ -7918,7 +8197,7 @@ import-fresh@^2.0.0:
     caller-path "^2.0.0"
     resolve-from "^3.0.0"
 
-import-fresh@^3.0.0:
+import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
   integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
@@ -8230,7 +8509,7 @@ is-glob@^4.0.0:
   dependencies:
     is-extglob "^2.1.1"
 
-is-glob@^4.0.1, is-glob@~4.0.1:
+is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -8465,6 +8744,11 @@ jest-worker@^27.4.1:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
+js-sdsl@^4.1.4:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.1.5.tgz#1ff1645e6b4d1b028cd3f862db88c9d887f26e2a"
+  integrity sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==
+
 js-sha3@0.5.5:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.5.5.tgz#baf0c0e8c54ad5903447df96ade7a4a1bca79a4a"
@@ -8506,7 +8790,7 @@ js-yaml@3.x, js-yaml@^3.12.0, js-yaml@^3.13.0, js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@4.1.0:
+js-yaml@4.1.0, js-yaml@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
@@ -8961,6 +9245,14 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+levn@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
+  integrity sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
+  dependencies:
+    prelude-ls "^1.2.1"
+    type-check "~0.4.0"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -9321,7 +9613,7 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-merge2@^1.2.3, merge2@^1.3.0:
+merge2@^1.2.3, merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
@@ -9508,6 +9800,13 @@ minimatch@5.0.1:
   integrity sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==
   dependencies:
     brace-expansion "^2.0.1"
+
+minimatch@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
 
 minimist@^1.2.0, minimist@^1.2.5, minimist@~1.2.5:
   version "1.2.5"
@@ -10098,6 +10397,18 @@ optionator@^0.8.1, optionator@^0.8.2:
     type-check "~0.3.2"
     word-wrap "~1.2.3"
 
+optionator@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
+  integrity sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==
+  dependencies:
+    deep-is "^0.1.3"
+    fast-levenshtein "^2.0.6"
+    levn "^0.4.1"
+    prelude-ls "^1.2.1"
+    type-check "^0.4.0"
+    word-wrap "^1.2.3"
+
 os-browserify@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
@@ -10438,6 +10749,11 @@ path-key@^2.0.0, path-key@^2.0.1:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
+path-key@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+
 path-parse@^1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
@@ -10606,6 +10922,11 @@ precond@0.2:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/precond/-/precond-0.2.3.tgz#aa9591bcaa24923f1e0f4849d240f47efc1075ac"
   integrity sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw=
+
+prelude-ls@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
+  integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -11091,6 +11412,11 @@ regexpp@^2.0.1:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
   integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
 
+regexpp@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
+  integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
+
 regexpu-core@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-2.0.0.tgz#49d038837b8dcf8bfa5b9a42139938e6ea2ae240"
@@ -11333,6 +11659,13 @@ rimraf@^2.2.8, rimraf@^2.6.3:
   dependencies:
     glob "^7.1.3"
 
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 ripemd160-min@0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/ripemd160-min/-/ripemd160-min-0.0.6.tgz#a904b77658114474d02503e819dcc55853b67e62"
@@ -11500,6 +11833,13 @@ semver@^7.3.4, semver@^7.3.5:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.3.7:
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
+  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
+  dependencies:
+    lru-cache "^6.0.0"
+
 semver@~5.4.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
@@ -11630,10 +11970,22 @@ shebang-command@^1.2.0:
   dependencies:
     shebang-regex "^1.0.0"
 
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+  dependencies:
+    shebang-regex "^3.0.0"
+
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 shelljs@^0.8.3:
   version "0.8.4"
@@ -12164,7 +12516,7 @@ strip-json-comments@2.0.1, strip-json-comments@^2.0.1, strip-json-comments@~2.0.
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
-strip-json-comments@3.1.1:
+strip-json-comments@3.1.1, strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
@@ -12550,7 +12902,7 @@ tslib@2.0.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
   integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
 
-tslib@^1.11.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.11.1, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -12564,6 +12916,13 @@ tsort@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/tsort/-/tsort-0.0.1.tgz#e2280f5e817f8bf4275657fd0f9aebd44f5a2786"
   integrity sha1-4igPXoF/i/QnVlf9D5rr1E9aJ4Y=
+
+tsutils@^3.21.0:
+  version "3.21.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
+  integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
+  dependencies:
+    tslib "^1.8.1"
 
 tty-browserify@0.0.0:
   version "0.0.0"
@@ -12592,6 +12951,13 @@ tweetnacl@^1.0.0, tweetnacl@^1.0.3:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
   integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==
 
+type-check@^0.4.0, type-check@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
+  integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
+  dependencies:
+    prelude-ls "^1.2.1"
+
 type-check@~0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
@@ -12603,6 +12969,11 @@ type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
+
+type-fest@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
+  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
 type-fest@^0.21.3:
   version "0.21.3"
@@ -14283,6 +14654,13 @@ which@1.3.1, which@^1.1.1, which@^1.2.9, which@^1.3.1:
   dependencies:
     isexe "^2.0.0"
 
+which@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
+  dependencies:
+    isexe "^2.0.0"
+
 wide-align@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
@@ -14300,7 +14678,7 @@ window-size@^0.2.0:
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.2.0.tgz#b4315bb4214a3d7058ebeee892e13fa24d98b075"
   integrity sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=
 
-word-wrap@~1.2.3:
+word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -8456,6 +8456,16 @@ jest-get-type@^27.3.1:
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.3.1.tgz#a8a2b0a12b50169773099eee60a0e6dd11423eff"
   integrity sha512-+Ilqi8hgHSAdhlQ3s12CAVNd8H96ZkQBfYoXmArzZnOfAtVAJEiPDBirjByEblvG/4LPJmkL+nBqPO3A1YJAEg==
 
+jest-junit@^14.0.1:
+  version "14.0.1"
+  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-14.0.1.tgz#5b357d6f5d333459585d628a24cd48b5bbc92ba2"
+  integrity sha512-h7/wwzPbllgpQhhVcRzRC76/cc89GlazThoV1fDxcALkf26IIlRsu/AcTG64f4nR2WPE3Cbd+i/sVf+NCUHrWQ==
+  dependencies:
+    mkdirp "^1.0.4"
+    strip-ansi "^6.0.1"
+    uuid "^8.3.2"
+    xml "^1.0.1"
+
 jest-worker@^27.4.1:
   version "27.4.5"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.4.5.tgz#d696e3e46ae0f24cff3fa7195ffba22889262242"
@@ -9544,7 +9554,7 @@ mkdirp-promise@^5.0.1:
   dependencies:
     mkdirp "*"
 
-mkdirp@*:
+mkdirp@*, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -14425,6 +14435,11 @@ xhr@^2.0.4, xhr@^2.2.0, xhr@^2.3.3:
     is-function "^1.0.1"
     parse-headers "^2.0.0"
     xtend "^4.0.0"
+
+xml@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==
 
 xmlhttprequest@1.8.0:
   version "1.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8456,16 +8456,6 @@ jest-get-type@^27.3.1:
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.3.1.tgz#a8a2b0a12b50169773099eee60a0e6dd11423eff"
   integrity sha512-+Ilqi8hgHSAdhlQ3s12CAVNd8H96ZkQBfYoXmArzZnOfAtVAJEiPDBirjByEblvG/4LPJmkL+nBqPO3A1YJAEg==
 
-jest-junit@^14.0.1:
-  version "14.0.1"
-  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-14.0.1.tgz#5b357d6f5d333459585d628a24cd48b5bbc92ba2"
-  integrity sha512-h7/wwzPbllgpQhhVcRzRC76/cc89GlazThoV1fDxcALkf26IIlRsu/AcTG64f4nR2WPE3Cbd+i/sVf+NCUHrWQ==
-  dependencies:
-    mkdirp "^1.0.4"
-    strip-ansi "^6.0.1"
-    uuid "^8.3.2"
-    xml "^1.0.1"
-
 jest-worker@^27.4.1:
   version "27.4.5"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.4.5.tgz#d696e3e46ae0f24cff3fa7195ffba22889262242"
@@ -9554,7 +9544,7 @@ mkdirp-promise@^5.0.1:
   dependencies:
     mkdirp "*"
 
-mkdirp@*, mkdirp@^1.0.4:
+mkdirp@*:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -14435,11 +14425,6 @@ xhr@^2.0.4, xhr@^2.2.0, xhr@^2.3.3:
     is-function "^1.0.1"
     parse-headers "^2.0.0"
     xtend "^4.0.0"
-
-xml@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
-  integrity sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==
 
 xmlhttprequest@1.8.0:
   version "1.8.0"


### PR DESCRIPTION
Improve CI by using parallelism in circleci, and improved linting to ensure no-floating-promises in tests (+ exposed test bug fixes)

This is a fallout of investigating how best to publish docs during CI. It will help us scale and keep CI times down when adding more V3 derivative contracts to our repo.

Improve CI:
- speed up tests via circleci parallelism (8 instances) 
  - brings down CI from >21 minutes to ~5 min 30 sec
- improve linting
  - eslint to ensure no floating promises in tests
    - this exposed many non-deterministic tests, some of which could potentially hide failing tests
  - all tests fixed to pass
  - one bug was exposed, but corrected, and no issues with the contracts (was using an incorrect contract, changed to desired contract, and ensured no coverage impacts)

## Design Choices
8 instances of parallelism were selected on CircleCI. 10 instances took ~5.5 mins, 5 instances took ~7 minutes, so settled on using 8 instances, which takes ~5.5 mins. If we have credit issues on CircleCI, we can use slightly less compute time by reducing parallelism, but for now it seems well worth it.

## Alternatives Considered
Using `hardhat test --parallel` was investigated, but due to [non-deterministic test ordering and long timeouts](https://hardhat.org/hardhat-runner/docs/guides/test-contracts#running-tests-in-parallel), the tests became flakey. Running hardhat in parallel mode also did not speed up tests much (~10%), so the added issues of variability were not worth the repeated issues that kept popping up.