### PR TITLE
Raise AB Max Primary Sales Percentage on V3 Core Explorations

### DIFF
--- a/contracts/explorations/GenArt721CoreV3_Explorations.sol
+++ b/contracts/explorations/GenArt721CoreV3_Explorations.sol
@@ -33,7 +33,7 @@ import "../libs/0.8.x/Bytes32Strings.sol";
  * - updateArtblocksDependencyRegistryAddress
  * - updateArtblocksPrimarySalesAddress
  * - updateArtblocksSecondarySalesAddress
- * - updateArtblocksPrimarySalesPercentage (up to 25%)
+ * - updateArtblocksPrimarySalesPercentage (up to 100%)
  * - updateArtblocksSecondarySalesBPS (up to 100%)
  * - updateMinterContract
  * - updateRandomizerAddress
@@ -101,7 +101,7 @@ contract GenArt721CoreV3_Explorations is
     uint8 constant AT_CHARACTER_CODE = uint8(bytes1("@")); // 0x40
 
     // numeric constants
-    uint256 constant ART_BLOCKS_MAX_PRIMARY_SALES_PERCENTAGE = 25; // 25%
+    uint256 constant ART_BLOCKS_MAX_PRIMARY_SALES_PERCENTAGE = 100; // 100%
     uint256 constant ART_BLOCKS_MAX_SECONDARY_SALES_BPS = 10000; // 10_000 BPS = 100%
     uint256 constant ARTIST_MAX_SECONDARY_ROYALTY_PERCENTAGE = 95; // 95%
 

--- a/test/core/V3/GenArt721CoreV3_ContractConfigure.test.ts
+++ b/test/core/V3/GenArt721CoreV3_ContractConfigure.test.ts
@@ -81,22 +81,32 @@ for (const coreContractName of coreContractsToTest) {
     });
 
     describe("updateArtblocksPrimarySalesPercentage", function () {
-      it("does not allow a value > 25%", async function () {
+      beforeEach(async function () {
+        if (coreContractName === "GenArt721CoreV3") {
+          this.maxABPrimarySalesPercentage = 25; // 25% maximum percentage on V3 core
+        } else if (coreContractName === "GenArt721CoreV3_Explorations") {
+          this.maxABPrimarySalesPercentage = 100; // 100% maximum percentage on V3 core explorations
+        } else {
+          throw new Error("Invalid core contract name");
+        }
+      });
+
+      it("does not allow a value > ART_BLOCKS_MAX_PRIMARY_SALES_PERCENTAGE", async function () {=
         await expectRevert(
           this.genArt721Core
             .connect(this.accounts.deployer)
-            .updateArtblocksPrimarySalesPercentage(26),
+            .updateArtblocksPrimarySalesPercentage(this.maxABPrimarySalesPercentage + 1),
           "Max of ART_BLOCKS_MAX_PRIMARY_SALES_PERCENTAGE percent"
         );
       });
 
-      it("does allow a value of 25%", async function () {
+      it("does allow a value of ART_BLOCKS_MAX_PRIMARY_SALES_PERCENTAGE", async function () {
         await this.genArt721Core
           .connect(this.accounts.deployer)
-          .updateArtblocksPrimarySalesPercentage(25);
+          .updateArtblocksPrimarySalesPercentage(this.maxABPrimarySalesPercentage);
       });
 
-      it("does allow a value of < 25%", async function () {
+      it("does allow a value of 0%", async function () {
         await this.genArt721Core
           .connect(this.accounts.deployer)
           .updateArtblocksPrimarySalesPercentage(0);

--- a/test/core/V3/GenArt721CoreV3_ContractConfigure.test.ts
+++ b/test/core/V3/GenArt721CoreV3_ContractConfigure.test.ts
@@ -91,11 +91,13 @@ for (const coreContractName of coreContractsToTest) {
         }
       });
 
-      it("does not allow a value > ART_BLOCKS_MAX_PRIMARY_SALES_PERCENTAGE", async function () {=
+      it("does not allow a value > ART_BLOCKS_MAX_PRIMARY_SALES_PERCENTAGE", async function () {
         await expectRevert(
           this.genArt721Core
             .connect(this.accounts.deployer)
-            .updateArtblocksPrimarySalesPercentage(this.maxABPrimarySalesPercentage + 1),
+            .updateArtblocksPrimarySalesPercentage(
+              this.maxABPrimarySalesPercentage + 1
+            ),
           "Max of ART_BLOCKS_MAX_PRIMARY_SALES_PERCENTAGE percent"
         );
       });
@@ -103,7 +105,9 @@ for (const coreContractName of coreContractsToTest) {
       it("does allow a value of ART_BLOCKS_MAX_PRIMARY_SALES_PERCENTAGE", async function () {
         await this.genArt721Core
           .connect(this.accounts.deployer)
-          .updateArtblocksPrimarySalesPercentage(this.maxABPrimarySalesPercentage);
+          .updateArtblocksPrimarySalesPercentage(
+            this.maxABPrimarySalesPercentage
+          );
       });
 
       it("does allow a value of 0%", async function () {


### PR DESCRIPTION
Raise AB Max Primary Sales Percentage on V3 Core Explorations from 25% to 100%.

This is a follow-on to #345, which was accidentally auto-merged (despite it having a do-not-merge flag)