### PR TITLE
Add AdminACLV1 to Improve Operations of V3 Core

### DIFF
--- a/contracts/AdminACLV1.sol
+++ b/contracts/AdminACLV1.sol
@@ -23,7 +23,7 @@ import "@openzeppelin-4.7/contracts/utils/structs/EnumerableSet.sol";
  * This contract continues to broadcast support (and require future-adminACL
  * broadcasted support) for IAdminACLV0 via ERC165 interface detection.
  */
-contract AdminACLV0 is IAdminACLV0, ERC165 {
+contract AdminACLV1 is IAdminACLV0, ERC165 {
     /// New address added to set of addresses who may approve artist-proposed
     /// payment addresses.
     event PaymentApproverAdded(address indexed _approver);

--- a/contracts/AdminACLV1.sol
+++ b/contracts/AdminACLV1.sol
@@ -85,7 +85,7 @@ contract AdminACLV1 is IAdminACLV0, ERC165 {
             ERC165(_newAdminACL).supportsInterface(
                 type(IAdminACLV0).interfaceId
             ),
-            "AdminACLV0: new admin ACL does not support IAdminACLV0"
+            "AdminACLV1: new admin ACL does not support IAdminACLV0"
         );
         Ownable(_contract).transferOwnership(_newAdminACL);
     }

--- a/contracts/AdminACLV1.sol
+++ b/contracts/AdminACLV1.sol
@@ -9,14 +9,19 @@ import "@openzeppelin-4.7/contracts/utils/introspection/ERC165.sol";
 import "@openzeppelin-4.7/contracts/utils/structs/EnumerableSet.sol";
 
 /**
- * @title Admin ACL contract, V0.
+ * @title Admin ACL contract, V1.
  * @author Art Blocks Inc.
  * @notice Privileged Roles and Ownership:
- * This contract has a single superAdmin that passes all ACL checks. All checks
- * for any other address will return false.
+ * This contract has a single superAdmin that passes all ACL checks. It also
+ * contains a set of payment approvers who may only call the function
+ * `GenArt721CoreV3.adminAcceptArtistAddressesAndSplits`. All checks for any
+ * other address will return false.
  * The superAdmin can be changed by the current superAdmin.
+ * Payment approvers may only be changed by the current superAdmin.
  * Care must be taken to ensure that the admin ACL contract is secure behind a
  * multi-sig or other secure access control mechanism.
+ * This contract continues to broadcast support (and require future-adminACL
+ * broadcasted support) for IAdminACLV0 via ERC165 interface detection.
  */
 contract AdminACLV0 is IAdminACLV0, ERC165 {
     /// New address added to set of addresses who may approve artist-proposed
@@ -96,7 +101,10 @@ contract AdminACLV0 is IAdminACLV0, ERC165 {
 
     /**
      * @notice Checks if sender `_sender` is allowed to call function with selector
-     * `_selector` on contract `_contract`. Returns true if sender is superAdmin.
+     * `_selector` on contract `_contract`. Returns true if sender is superAdmin,
+     * or if `_selector` is
+     * GenArt721CoreV3.adminAcceptArtistAddressesAndSplits.selector and address
+     * is in set of payment approvers.
      */
     function allowed(
         address _sender,

--- a/contracts/AdminACLV1.sol
+++ b/contracts/AdminACLV1.sol
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.17;
+
+import "./interfaces/0.8.x/IAdminACLV0.sol";
+import "./GenArt721CoreV3.sol";
+import "@openzeppelin-4.7/contracts/access/Ownable.sol";
+import "@openzeppelin-4.7/contracts/utils/introspection/ERC165.sol";
+import "@openzeppelin-4.7/contracts/utils/structs/EnumerableSet.sol";
+
+/**
+ * @title Admin ACL contract, V0.
+ * @author Art Blocks Inc.
+ * @notice Privileged Roles and Ownership:
+ * This contract has a single superAdmin that passes all ACL checks. All checks
+ * for any other address will return false.
+ * The superAdmin can be changed by the current superAdmin.
+ * Care must be taken to ensure that the admin ACL contract is secure behind a
+ * multi-sig or other secure access control mechanism.
+ */
+contract AdminACLV0 is IAdminACLV0, ERC165 {
+    /// New address added to set of addresses who may approve artist-proposed
+    /// payment addresses.
+    event PaymentApproverAdded(address indexed _approver);
+
+    /// Address removed from set of addresses who may approve artist-proposed
+    /// payment addresses.
+    event PaymentApproverRemoved(address indexed _approver);
+
+    // add Enumerable Set methods
+    using EnumerableSet for EnumerableSet.AddressSet;
+
+    string public AdminACLType = "AdminACLV1";
+
+    /// superAdmin is the only address that passes any and all ACL checks
+    address public superAdmin;
+
+    // Set of addresses that have been granted admin approval of artist-
+    // proposed payment address changes
+    EnumerableSet.AddressSet private _paymentApprovers;
+
+    constructor() {
+        superAdmin = msg.sender;
+    }
+
+    /**
+     * @notice Allows superAdmin change the superAdmin address.
+     * @param _newSuperAdmin The new superAdmin address.
+     * @param _genArt721CoreAddressesToUpdate Array of genArt721Core
+     * addresses to update to the new superAdmin, for indexing purposes only.
+     * @dev this function is gated to only superAdmin address.
+     */
+    function changeSuperAdmin(
+        address _newSuperAdmin,
+        address[] calldata _genArt721CoreAddressesToUpdate
+    ) external {
+        require(msg.sender == superAdmin, "Only superAdmin");
+        address previousSuperAdmin = superAdmin;
+        superAdmin = _newSuperAdmin;
+        emit SuperAdminTransferred(
+            previousSuperAdmin,
+            _newSuperAdmin,
+            _genArt721CoreAddressesToUpdate
+        );
+    }
+
+    /**
+     * Calls transferOwnership on other contract from this contract.
+     * This is useful for updating to a new AdminACL contract.
+     * @dev this function is gated to only superAdmin address.
+     * @dev This implementation requires that the new AdminACL contract
+     * broadcasts support of IAdminACLV0 via ERC165 interface detection.
+     */
+    function transferOwnershipOn(address _contract, address _newAdminACL)
+        external
+    {
+        require(msg.sender == superAdmin, "Only superAdmin");
+        // ensure new AdminACL contract supports IAdminACLV0
+        require(
+            ERC165(_newAdminACL).supportsInterface(
+                type(IAdminACLV0).interfaceId
+            ),
+            "AdminACLV0: new admin ACL does not support IAdminACLV0"
+        );
+        Ownable(_contract).transferOwnership(_newAdminACL);
+    }
+
+    /**
+     * @notice Calls renounceOwnership on other contract from this contract.
+     * @dev this function is gated to only superAdmin address.
+     */
+    function renounceOwnershipOn(address _contract) external {
+        require(msg.sender == superAdmin, "Only superAdmin");
+        Ownable(_contract).renounceOwnership();
+    }
+
+    /**
+     * @notice Checks if sender `_sender` is allowed to call function with selector
+     * `_selector` on contract `_contract`. Returns true if sender is superAdmin.
+     */
+    function allowed(
+        address _sender,
+        address, /*_contract*/
+        bytes4 _selector
+    ) external view returns (bool) {
+        // always allow superAdmin
+        if (_sender == superAdmin) {
+            return true;
+        }
+        // if calling payment approval function, check if sender is in approver
+        // set
+        if (
+            _selector ==
+            GenArt721CoreV3.adminAcceptArtistAddressesAndSplits.selector
+        ) {
+            return _paymentApprovers.contains(_sender);
+        }
+        // otherwise, return false
+        return false;
+    }
+
+    /**
+     *
+     * @notice Adds address to payment approvers set. Only callable by
+     * superAdmin. Address must not already be in set.
+     * @param _approver NFT core address to be registered.
+     */
+    function addPaymentApprover(address _approver) external {
+        require(msg.sender == superAdmin, "Only superAdmin");
+        require(
+            _paymentApprovers.add(_approver),
+            "AdminACLV1: Already registered"
+        );
+        emit PaymentApproverAdded(_approver);
+    }
+
+    /**
+     *
+     * @notice Removes address to payment approvers set. Only callable by
+     * superAdmin. Address must be in set.
+     * @param _approver NFT core address to be registered.
+     */
+    function removePaymentApprover(address _approver) external {
+        require(msg.sender == superAdmin, "Only superAdmin");
+        require(
+            _paymentApprovers.remove(_approver),
+            "AdminACLV1: Not registered"
+        );
+        emit PaymentApproverRemoved(_approver);
+    }
+
+    /**
+     * @notice Gets quantity of addresses registered to approve artist-proposed
+     * payment addresses.
+     * @return uint256 quantity of addresses approved
+     */
+    function getNumPaymentApprovers() external view returns (uint256) {
+        return _paymentApprovers.length();
+    }
+
+    /**
+     * @notice Get artist-proposed payment address approver address at index
+     * `_index` of enumerable set.
+     * @param _index enumerable set index to query.
+     * @return NFTAddress payment approver address at index `_index`
+     * @dev index must be < quantity of registered payment approvers
+     */
+    function getPaymentApproverAt(uint256 _index)
+        external
+        view
+        returns (address NFTAddress)
+    {
+        return _paymentApprovers.at(_index);
+    }
+
+    /**
+     * @inheritdoc ERC165
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC165)
+        returns (bool)
+    {
+        return
+            interfaceId == type(IAdminACLV0).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+}

--- a/scripts/adminACL-deployments/1_reference_mainnet_AdminACL_deployer.ts
+++ b/scripts/adminACL-deployments/1_reference_mainnet_AdminACL_deployer.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Created By: Art Blocks Inc.
+
+import { ethers } from "hardhat";
+// explorations
+import { AdminACLV1__factory } from "../contracts/factories/AdminACLV1__factory";
+
+// delay to avoid issues with reorgs and tx failures
+import { delay } from "../util/utils";
+const EXTRA_DELAY_BETWEEN_TX = 5000; // ms
+
+/**
+ * This script was created to deploy the AdminACLV1 contract to the Ethereum
+ * mainnet. It is intended to document the deployment process and provide a
+ * reference for the steps required to deploy the AdminACLV1 contract.
+ */
+//////////////////////////////////////////////////////////////////////////////
+// CONFIG BEGINS HERE
+//////////////////////////////////////////////////////////////////////////////
+const superAdminAddress = "0xCF00eC2B327BCfA2bee2D8A5Aee0A7671d08A283"; // Art Blocks contract-management multi-sig
+//////////////////////////////////////////////////////////////////////////////
+// CONFIG ENDS HERE
+//////////////////////////////////////////////////////////////////////////////
+
+async function main() {
+  const [deployer] = await ethers.getSigners();
+  const network = await ethers.provider.getNetwork();
+  const networkName = network.name == "homestead" ? "mainnet" : network.name;
+  if (networkName != "mainnet") {
+    throw new Error("This script is intended to be run on mainnet only");
+  }
+  //////////////////////////////////////////////////////////////////////////////
+  // DEPLOYMENT BEGINS HERE
+  //////////////////////////////////////////////////////////////////////////////
+
+  // Deploy AdminACL contract
+  const adminACLFactory = new AdminACLV1__factory(deployer);
+  const adminACL = await adminACLFactory.deploy();
+  await adminACL.deployed();
+  const adminACLAddress = adminACL.address;
+  console.log(`Admin ACL V1 deployed at ${adminACLAddress}`);
+  await delay(EXTRA_DELAY_BETWEEN_TX);
+
+  //////////////////////////////////////////////////////////////////////////////
+  // DEPLOYMENT ENDS HERE
+  //////////////////////////////////////////////////////////////////////////////
+
+  //////////////////////////////////////////////////////////////////////////////
+  // SETUP BEGINS HERE
+  //////////////////////////////////////////////////////////////////////////////
+
+  // change superAdmin to Art Blocks contract-management multi-sig
+  // note: this gives the multi-sig the superAdmin role, but does not refresh
+  // the superAdmin role on the core contracts. See next steps below for that.
+  await adminACL.changeSuperAdmin(superAdminAddress, []);
+
+  // Output instructions for manual Etherscan verification.
+  const standardVerify = "yarn hardhat verify";
+  console.log(`Verify Admin ACL V1 contract deployment with:`);
+  console.log(`${standardVerify} --network ${networkName} ${adminACL.address}`);
+
+  //////////////////////////////////////////////////////////////////////////////
+  // SETUP ENDS HERE
+  //////////////////////////////////////////////////////////////////////////////
+
+  console.log("Next Steps:");
+  console.log(
+    "1. Verify Admin ACL V1 contract deployment on Etherscan (see above)"
+  );
+  console.log(
+    "2. Migrate existing AdminACLV0's to the Admin ACL V1 address in Core contract via the AdminACLV0's transferOwnershipOn function (one call per core contract using the AdminACLV0)"
+  );
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/test/admin-acl/AdminACLV0/AdminACLV0.test.ts
+++ b/test/admin-acl/AdminACLV0/AdminACLV0.test.ts
@@ -1,16 +1,4 @@
 import {
-  BN,
-  constants,
-  expectEvent,
-  expectRevert,
-  balance,
-  ether,
-} from "@openzeppelin/test-helpers";
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-
-import {
   getAccounts,
   assignDefaultConstants,
   deployAndGet,
@@ -18,7 +6,8 @@ import {
   mintProjectUntilRemaining,
   advanceEVMByTime,
 } from "../../util/common";
-import { FOUR_WEEKS } from "../../util/constants";
+
+import { AdminACLV0V1_Common } from "../AdminACLV0V1.common";
 
 /**
  * Tests for functionality of AdminACLV0.
@@ -61,81 +50,7 @@ describe("AdminACLV0", async function () {
     );
   });
 
-  describe("transferOwnershipOn", function () {
-    it("does not allow transfer to new AdminACL that doesn't broadcast support of IAdminACLV0", async function () {
-      await expectRevert(
-        this.adminACL.transferOwnershipOn(
-          this.genArt721Core.address,
-          this.adminACL_NoInterfaceBroadcast.address
-        ),
-        "AdminACLV0: new admin ACL does not support IAdminACLV0"
-      );
-    });
-
-    it("allows transfer to new AdminACL that broadcasts support of IAdminACLV0", async function () {
-      await this.adminACL.transferOwnershipOn(
-        this.genArt721Core.address,
-        this.adminACL_InterfaceBroadcast.address
-      );
-    });
-
-    it("is not callable by non-superAdmin", async function () {
-      await expectRevert(
-        this.adminACL
-          .connect(this.accounts.user)
-          .transferOwnershipOn(
-            this.genArt721Core.address,
-            this.adminACL_InterfaceBroadcast.address
-          ),
-        "Only superAdmin"
-      );
-    });
-  });
-
-  describe("changeSuperAdmin", function () {
-    it("emits an event", async function () {
-      await expect(
-        this.adminACL.changeSuperAdmin(this.accounts.deployer2.address, [
-          this.genArt721Core.address,
-        ])
-      )
-        .to.emit(this.adminACL, "SuperAdminTransferred")
-        .withArgs(
-          this.accounts.deployer.address,
-          this.accounts.deployer2.address,
-          [this.genArt721Core.address]
-        );
-    });
-
-    it("updates superAdmin", async function () {
-      await this.adminACL.changeSuperAdmin(this.accounts.deployer2.address, [
-        this.genArt721Core.address,
-      ]);
-      expect(await this.adminACL.superAdmin()).to.equal(
-        this.accounts.deployer2.address
-      );
-    });
-
-    it("is not callable by non-superAdmin", async function () {
-      await expectRevert(
-        this.adminACL
-          .connect(this.accounts.user)
-          .changeSuperAdmin(this.accounts.deployer2.address, [
-            this.genArt721Core.address,
-          ]),
-        "Only superAdmin"
-      );
-    });
-  });
-
-  describe("renounceOwnershipOn", function () {
-    it("is not callable by non-superAdmin", async function () {
-      await expectRevert(
-        this.adminACL
-          .connect(this.accounts.user)
-          .renounceOwnershipOn(this.genArt721Core.address),
-        "Only superAdmin"
-      );
-    });
+  describe("common tests", async function () {
+    await AdminACLV0V1_Common("AdminACLV0");
   });
 });

--- a/test/admin-acl/AdminACLV0V1.common.ts
+++ b/test/admin-acl/AdminACLV0V1.common.ts
@@ -89,5 +89,11 @@ export const AdminACLV0V1_Common = async (adminACLContractName: string) => {
         "Only superAdmin"
       );
     });
+
+    it("is callable by superAdmin", async function () {
+      await this.adminACL
+        .connect(this.accounts.deployer)
+        .renounceOwnershipOn(this.genArt721Core.address);
+    });
   });
 };

--- a/test/admin-acl/AdminACLV0V1.common.ts
+++ b/test/admin-acl/AdminACLV0V1.common.ts
@@ -1,0 +1,93 @@
+import {
+  BN,
+  constants,
+  expectEvent,
+  expectRevert,
+  balance,
+  ether,
+} from "@openzeppelin/test-helpers";
+import { expect } from "chai";
+
+/**
+ * These tests are intended to check common AdminACL V0/V1 functionality.
+ * @dev assumes common BeforeEach to populate accounts, constants, and setup
+ */
+export const AdminACLV0V1_Common = async (adminACLContractName: string) => {
+  describe("transferOwnershipOn", function () {
+    it("does not allow transfer to new AdminACL that doesn't broadcast support of IAdminACLV0", async function () {
+      await expectRevert(
+        this.adminACL.transferOwnershipOn(
+          this.genArt721Core.address,
+          this.adminACL_NoInterfaceBroadcast.address
+        ),
+        `${adminACLContractName}: new admin ACL does not support IAdminACLV0`
+      );
+    });
+
+    it("allows transfer to new AdminACL that broadcasts support of IAdminACLV0", async function () {
+      await this.adminACL.transferOwnershipOn(
+        this.genArt721Core.address,
+        this.adminACL_InterfaceBroadcast.address
+      );
+    });
+
+    it("is not callable by non-superAdmin", async function () {
+      await expectRevert(
+        this.adminACL
+          .connect(this.accounts.user)
+          .transferOwnershipOn(
+            this.genArt721Core.address,
+            this.adminACL_InterfaceBroadcast.address
+          ),
+        "Only superAdmin"
+      );
+    });
+  });
+
+  describe("changeSuperAdmin", function () {
+    it("emits an event", async function () {
+      await expect(
+        this.adminACL.changeSuperAdmin(this.accounts.deployer2.address, [
+          this.genArt721Core.address,
+        ])
+      )
+        .to.emit(this.adminACL, "SuperAdminTransferred")
+        .withArgs(
+          this.accounts.deployer.address,
+          this.accounts.deployer2.address,
+          [this.genArt721Core.address]
+        );
+    });
+
+    it("updates superAdmin", async function () {
+      await this.adminACL.changeSuperAdmin(this.accounts.deployer2.address, [
+        this.genArt721Core.address,
+      ]);
+      expect(await this.adminACL.superAdmin()).to.equal(
+        this.accounts.deployer2.address
+      );
+    });
+
+    it("is not callable by non-superAdmin", async function () {
+      await expectRevert(
+        this.adminACL
+          .connect(this.accounts.user)
+          .changeSuperAdmin(this.accounts.deployer2.address, [
+            this.genArt721Core.address,
+          ]),
+        "Only superAdmin"
+      );
+    });
+  });
+
+  describe("renounceOwnershipOn", function () {
+    it("is not callable by non-superAdmin", async function () {
+      await expectRevert(
+        this.adminACL
+          .connect(this.accounts.user)
+          .renounceOwnershipOn(this.genArt721Core.address),
+        "Only superAdmin"
+      );
+    });
+  });
+};

--- a/test/admin-acl/AdminACLV1/AdminACLV1.test.ts
+++ b/test/admin-acl/AdminACLV1/AdminACLV1.test.ts
@@ -1,0 +1,260 @@
+import {
+  getAccounts,
+  assignDefaultConstants,
+  deployAndGet,
+  deployCoreWithMinterFilter,
+  mintProjectUntilRemaining,
+  advanceEVMByTime,
+} from "../../util/common";
+import {
+  BN,
+  constants,
+  expectEvent,
+  expectRevert,
+  balance,
+  ether,
+} from "@openzeppelin/test-helpers";
+
+import { expect } from "chai";
+
+import { AdminACLV0V1_Common } from "../AdminACLV0V1.common";
+
+/**
+ * Tests for functionality of AdminACLV1.
+ */
+describe("AdminACLV1", async function () {
+  beforeEach(async function () {
+    // standard accounts and constants
+    this.accounts = await getAccounts();
+    await assignDefaultConstants.call(this);
+
+    // deploy and configure minter filter and minter
+    ({
+      genArt721Core: this.genArt721Core,
+      minterFilter: this.minterFilter,
+      randomizer: this.randomizer,
+      adminACL: this.adminACL,
+    } = await deployCoreWithMinterFilter.call(
+      this,
+      "GenArt721CoreV3",
+      "MinterFilterV1",
+      false,
+      "AdminACLV1"
+    ));
+
+    this.minter = await deployAndGet.call(this, "MinterSetPriceV2", [
+      this.genArt721Core.address,
+      this.minterFilter.address,
+    ]);
+
+    // deploy alternate admin ACL that does not broadcast support of IAdminACLV0
+    this.adminACL_NoInterfaceBroadcast = await deployAndGet.call(
+      this,
+      "MockAdminACLV0Events",
+      []
+    );
+
+    // deploy another admin ACL that does broadcast support of IAdminACLV0
+    this.adminACL_InterfaceBroadcast = await deployAndGet.call(
+      this,
+      "AdminACLV1",
+      []
+    );
+
+    // add project zero
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .addProject("name", this.accounts.artist.address);
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .toggleProjectIsActive(this.projectZero);
+    await this.genArt721Core
+      .connect(this.accounts.artist)
+      .updateProjectMaxInvocations(this.projectZero, this.maxInvocations);
+
+    // configure minter for project zero
+    await this.minterFilter
+      .connect(this.accounts.deployer)
+      .addApprovedMinter(this.minter.address);
+    await this.minterFilter
+      .connect(this.accounts.deployer)
+      .setMinterForProject(this.projectZero, this.minter.address);
+    await this.minter
+      .connect(this.accounts.artist)
+      .updatePricePerTokenInWei(this.projectZero, 0);
+  });
+
+  describe("common tests", async function () {
+    await AdminACLV0V1_Common("AdminACLV1");
+  });
+
+  describe("addPaymentApprover", async function () {
+    it("should revert if not called by admin", async function () {
+      await expectRevert(
+        this.adminACL
+          .connect(this.accounts.user)
+          .addPaymentApprover(this.accounts.user.address),
+        "Only superAdmin"
+      );
+    });
+
+    it("adds address when called by superAdmin", async function () {
+      expect(
+        await this.adminACL
+          .connect(this.accounts.deployer)
+          .addPaymentApprover(this.accounts.user.address)
+      )
+        .to.emit(this.adminACL, "PaymentApproverAdded")
+        .withArgs(this.accounts.user.address);
+      // expect address to be added to the set of approvers
+      expect(await this.adminACL.getPaymentApproverAt(0)).to.equal(
+        this.accounts.user.address
+      );
+    });
+
+    it("does not allow adding address to set if already added", async function () {
+      await this.adminACL
+        .connect(this.accounts.deployer)
+        .addPaymentApprover(this.accounts.user.address);
+      await expectRevert(
+        this.adminACL
+          .connect(this.accounts.deployer)
+          .addPaymentApprover(this.accounts.user.address),
+        "AdminACLV1: Already registered"
+      );
+    });
+
+    it("allows artist payment address approval by non-superAdmin after adding", async function () {
+      await this.adminACL
+        .connect(this.accounts.deployer)
+        .addPaymentApprover(this.accounts.user.address);
+
+      // artist propose updated splits
+      let valuesToUpdateTo = [
+        this.projectZero,
+        this.accounts.artist2.address,
+        this.accounts.additional.address,
+        50,
+        this.accounts.additional2.address,
+        51,
+      ];
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .proposeArtistPaymentAddressesAndSplits(...valuesToUpdateTo);
+
+      // expect added address to be allowed to call V3 core's approve function
+      await this.genArt721Core
+        .connect(this.accounts.user)
+        .adminAcceptArtistAddressesAndSplits(...valuesToUpdateTo);
+    });
+
+    it("does not allow artist payment address approval by non-superAdmin before adding", async function () {
+      // artist propose updated splits
+      let valuesToUpdateTo = [
+        this.projectZero,
+        this.accounts.artist2.address,
+        this.accounts.additional.address,
+        50,
+        this.accounts.additional2.address,
+        51,
+      ];
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .proposeArtistPaymentAddressesAndSplits(...valuesToUpdateTo);
+
+      // expect non-superAdmin address to not be allowed to call V3 core's approve function
+      await expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.user)
+          .adminAcceptArtistAddressesAndSplits(...valuesToUpdateTo),
+        "Only Admin ACL allowed, or artist if owner has renounced"
+      );
+    });
+  });
+
+  describe("removePaymentApprover", async function () {
+    it("should revert if not called by admin", async function () {
+      await expectRevert(
+        this.adminACL
+          .connect(this.accounts.user)
+          .removePaymentApprover(this.accounts.user.address),
+        "Only superAdmin"
+      );
+    });
+
+    it("removes address when called by superAdmin", async function () {
+      await this.adminACL
+        .connect(this.accounts.deployer)
+        .addPaymentApprover(this.accounts.user.address);
+      expect(
+        await this.adminACL
+          .connect(this.accounts.deployer)
+          .removePaymentApprover(this.accounts.user.address)
+      )
+        .to.emit(this.adminACL, "PaymentApproverRemoved")
+        .withArgs(this.accounts.user.address);
+      // expect address to not be in the set of approvers
+      await expectRevert(
+        this.adminACL.getPaymentApproverAt(0),
+        "VM Exception while processing transaction: reverted with panic code 0x32 (Array accessed at an out-of-bounds or negative index)"
+      );
+    });
+
+    it("does not allow removing address to set if not already in set", async function () {
+      await expectRevert(
+        this.adminACL
+          .connect(this.accounts.deployer)
+          .removePaymentApprover(this.accounts.user.address),
+        "AdminACLV1: Not registered"
+      );
+    });
+
+    it("does not allow artist payment address approval by non-superAdmin after adding and removing", async function () {
+      await this.adminACL
+        .connect(this.accounts.deployer)
+        .addPaymentApprover(this.accounts.user.address);
+      await this.adminACL
+        .connect(this.accounts.deployer)
+        .removePaymentApprover(this.accounts.user.address);
+
+      // artist propose updated splits
+      let valuesToUpdateTo = [
+        this.projectZero,
+        this.accounts.artist2.address,
+        this.accounts.additional.address,
+        50,
+        this.accounts.additional2.address,
+        51,
+      ];
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .proposeArtistPaymentAddressesAndSplits(...valuesToUpdateTo);
+
+      // expect non-superAdmin address to not be allowed to call V3 core's approve function
+      await expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.user)
+          .adminAcceptArtistAddressesAndSplits(...valuesToUpdateTo),
+        "Only Admin ACL allowed, or artist if owner has renounced"
+      );
+    });
+  });
+
+  describe("getNumPaymentApprovers", async function () {
+    it("should return correct number of approvers", async function () {
+      expect(await this.adminACL.getNumPaymentApprovers()).to.equal(0);
+      await this.adminACL
+        .connect(this.accounts.deployer)
+        .addPaymentApprover(this.accounts.user.address);
+      expect(await this.adminACL.getNumPaymentApprovers()).to.equal(1);
+      await this.adminACL
+        .connect(this.accounts.deployer)
+        .addPaymentApprover(this.accounts.user2.address);
+      expect(await this.adminACL.getNumPaymentApprovers()).to.equal(2);
+      await this.adminACL
+        .connect(this.accounts.deployer)
+        .removePaymentApprover(this.accounts.user.address);
+      expect(await this.adminACL.getNumPaymentApprovers()).to.equal(1);
+    });
+  });
+});

--- a/test/admin-acl/AdminACLV1/AdminACLV1.test.ts
+++ b/test/admin-acl/AdminACLV1/AdminACLV1.test.ts
@@ -240,6 +240,18 @@ describe("AdminACLV1", async function () {
     });
   });
 
+  describe("allowed", async function () {
+    it("should return false when calling with non-superAdmin address and not GenArt721CoreV3.adminAcceptArtistAddressesAndSplits", async function () {
+      // expect non-superAdmin address to not be allowed to call V3 core's approve function
+      await expectRevert(
+        this.genArt721Core
+          .connect(this.accounts.user)
+          .updateArtblocksPrimarySalesAddress(this.accounts.additional.address),
+        "Only Admin ACL allowed"
+      );
+    });
+  });
+
   describe("getNumPaymentApprovers", async function () {
     it("should return correct number of approvers", async function () {
       expect(await this.adminACL.getNumPaymentApprovers()).to.equal(0);

--- a/test/admin-acl/AdminACLV1/AdminACLV1.test.ts
+++ b/test/admin-acl/AdminACLV1/AdminACLV1.test.ts
@@ -99,7 +99,7 @@ describe("AdminACLV1", async function () {
     });
 
     it("adds address when called by superAdmin", async function () {
-      expect(
+      await expect(
         await this.adminACL
           .connect(this.accounts.deployer)
           .addPaymentApprover(this.accounts.user.address)
@@ -186,7 +186,7 @@ describe("AdminACLV1", async function () {
       await this.adminACL
         .connect(this.accounts.deployer)
         .addPaymentApprover(this.accounts.user.address);
-      expect(
+      await expect(
         await this.adminACL
           .connect(this.accounts.deployer)
           .removePaymentApprover(this.accounts.user.address)

--- a/test/util/common.ts
+++ b/test/util/common.ts
@@ -86,7 +86,8 @@ export async function deployAndGet(
 export async function deployCoreWithMinterFilter(
   coreContractName: string,
   minterFilterName: string,
-  useAdminACLWithEvents: boolean = false
+  useAdminACLWithEvents: boolean = false,
+  _adminACLContractName?: string
 ): Promise<CoreWithMinterSuite> {
   if (coreContractName.endsWith("V2_PBAB")) {
     throw new Error("V2_PBAB not supported");
@@ -130,9 +131,13 @@ export async function deployCoreWithMinterFilter(
     coreContractName.endsWith("V3_Explorations")
   ) {
     randomizer = await deployAndGet.call(this, "BasicRandomizerV2", []);
-    const adminACLContractName = useAdminACLWithEvents
+    let adminACLContractName = useAdminACLWithEvents
       ? "MockAdminACLV0Events"
       : "AdminACLV0";
+    // if function input has adminACL contract name, use that instead
+    adminACLContractName = _adminACLContractName
+      ? _adminACLContractName
+      : adminACLContractName;
     adminACL = await deployAndGet.call(this, adminACLContractName, []);
     genArt721Core = await deployAndGet.call(this, coreContractName, [
       this.name,


### PR DESCRIPTION
Add AdminACLV1 that includes a set of "payment approvers" that are specifically allowed to call functions with the selector `GenArt721CoreV3.adminAcceptArtistAddressesAndSplits.selector`.

This update allows the superAdmin wallet to delegate the calling of the commonly required `GenArt721CoreV3.adminAcceptArtistAddressesAndSplits` function. This is a relatively lower-tier admin responsibility in terms of risk, and requires frequent approval calls such that it becomes overly burdensome for the superAdmin multisig to always be required to call.

The set of addresses is enumerable on-chain, but is not planned to be indexed at this time (although events are emitted during add/remove operations).

TODO

- [x] Add tests for coverage of the new AdminACLV1 contract
- [x] Add deployment script