### PR TITLE
Deploy scripts for MinterMerkleV2, mainnet and dev

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -91,7 +91,7 @@ module.exports = {
   },
   contractSizer: {
     alphaSort: true,
-    runOnCompile: true,
+    runOnCompile: false,
     disambiguatePaths: false,
   },
   docgen: {

--- a/scripts/minter-deployments/1_reference_goerli-dev_minter-merkle_deployer.ts
+++ b/scripts/minter-deployments/1_reference_goerli-dev_minter-merkle_deployer.ts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Created By: Art Blocks Inc.
+
+import { ethers } from "hardhat";
+// explorations
+import { MinterMerkleV2__factory } from "../contracts/factories/MinterMerkleV2__factory";
+
+// delay to avoid issues with reorgs and tx failures
+import { delay } from "../util/utils";
+const EXTRA_DELAY_BETWEEN_TX = 5000; // ms
+
+/**
+ * This script was created to deploy the MinterMerkleV2 contract to the Ethereum
+ * Goerli testnet, for the Art Blocks dev environment.
+ * It is intended to document the deployment process and provide a reference
+ * for the steps required to deploy the MinterMerkleV2 contract.
+ */
+//////////////////////////////////////////////////////////////////////////////
+// CONFIG BEGINS HERE
+//////////////////////////////////////////////////////////////////////////////
+const genArt721V3Core_Flagship = "0xF396C180bb2f92EE28535D23F5224A5b9425ceca";
+const minterFilter_Flagship = "0x7EcFFfc1A3Eb7Ce76D4b29Df3e5098D2D921D367";
+const genArt721V3Core_Explorations =
+  "0x7244352F6C7aFbB74D4b63Bd7e8189e84a83f179";
+const minterFilter_Explorations = "0x6600e8d744aa7545A8757eF928117866cF431A26";
+//////////////////////////////////////////////////////////////////////////////
+// CONFIG ENDS HERE
+//////////////////////////////////////////////////////////////////////////////
+
+async function main() {
+  const [deployer] = await ethers.getSigners();
+  const network = await ethers.provider.getNetwork();
+  const networkName = network.name == "homestead" ? "mainnet" : network.name;
+  if (networkName != "goerli") {
+    throw new Error("This script is intended to be run on mainnet only");
+  }
+  //////////////////////////////////////////////////////////////////////////////
+  // DEPLOYMENT BEGINS HERE
+  //////////////////////////////////////////////////////////////////////////////
+
+  // Deploy Minter contract(s)
+  const minterMerkleFactory = new MinterMerkleV2__factory(deployer);
+  // flagship
+  const minterMerkleFlagship = await minterMerkleFactory.deploy(
+    genArt721V3Core_Flagship,
+    minterFilter_Flagship
+  );
+  await minterMerkleFlagship.deployed();
+  const minterMerkleFlagshipAddress = minterMerkleFlagship.address;
+  console.log(
+    `MinterMerkleV2 (flagship) deployed at ${minterMerkleFlagshipAddress}`
+  );
+  await delay(EXTRA_DELAY_BETWEEN_TX);
+  // explorations
+  const minterMerkleExplorations = await minterMerkleFactory.deploy(
+    genArt721V3Core_Explorations,
+    minterFilter_Explorations
+  );
+  await minterMerkleExplorations.deployed();
+  const minterMerkleExplorationsAddress = minterMerkleExplorations.address;
+  console.log(
+    `MinterMerkleV2 (explorations) deployed at ${minterMerkleExplorationsAddress}`
+  );
+  await delay(EXTRA_DELAY_BETWEEN_TX);
+
+  //////////////////////////////////////////////////////////////////////////////
+  // DEPLOYMENT ENDS HERE
+  //////////////////////////////////////////////////////////////////////////////
+
+  //////////////////////////////////////////////////////////////////////////////
+  // SETUP BEGINS HERE
+  //////////////////////////////////////////////////////////////////////////////
+
+  // DO NOT allowlist the minters on the minter filter here. If a new minter type
+  // is added to the minter filter, it will need to be added to the minter filter
+  // enum in the subgraph first. Otherwise, the subgraph will fail to progress.
+
+  // Output instructions for manual Etherscan verification.
+  const standardVerify = "yarn hardhat verify";
+  console.log(`Verify MinterMerkleV2 (flagship) contract deployment with:`);
+  console.log(
+    `${standardVerify} --network ${networkName} ${minterMerkleFlagshipAddress} ${genArt721V3Core_Flagship} ${minterFilter_Flagship}`
+  );
+  console.log(`Verify MinterMerkleV2 (explorations) contract deployment with:`);
+  console.log(
+    `${standardVerify} --network ${networkName} ${minterMerkleExplorationsAddress} ${genArt721V3Core_Explorations} ${minterFilter_Explorations}`
+  );
+
+  //////////////////////////////////////////////////////////////////////////////
+  // SETUP ENDS HERE
+  //////////////////////////////////////////////////////////////////////////////
+
+  console.log("Next Steps:");
+  console.log(
+    "1. Verify Admin ACL V1 contract deployment on Etherscan (see above)"
+  );
+  console.log(
+    "2. WAIT for subgraph to sync, and ensure enum with new minter type is added to subgraph"
+  );
+  console.log(
+    "3. AFTER subgraph syncs with type MinterMerkleV2 included in MinterType enum, allowlist the new minters type on their corresponding minter filters"
+  );
+  console.log(
+    `3a. e.g. Call addApprovedMinter on ${minterFilter_Flagship} with arg ${minterMerkleFlagshipAddress}`
+  );
+  console.log(
+    `3b. e.g. Call addApprovedMinter on ${minterFilter_Explorations} with arg ${minterMerkleExplorationsAddress}`
+  );
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/minter-deployments/1_reference_mainnet_minter-merkle_deployer.ts
+++ b/scripts/minter-deployments/1_reference_mainnet_minter-merkle_deployer.ts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Created By: Art Blocks Inc.
+
+import { ethers } from "hardhat";
+// explorations
+import { MinterMerkleV2__factory } from "../contracts/factories/MinterMerkleV2__factory";
+
+// delay to avoid issues with reorgs and tx failures
+import { delay } from "../util/utils";
+const EXTRA_DELAY_BETWEEN_TX = 5000; // ms
+
+/**
+ * This script was created to deploy the MinterMerkleV2 contract to the Ethereum
+ * mainnet. It is intended to document the deployment process and provide a
+ * reference for the steps required to deploy the MinterMerkleV2 contract.
+ */
+//////////////////////////////////////////////////////////////////////////////
+// CONFIG BEGINS HERE
+//////////////////////////////////////////////////////////////////////////////
+const genArt721V3Core_Flagship = "0x99a9B7c1116f9ceEB1652de04d5969CcE509B069";
+const minterFilter_Flagship = "0x092B8F64e713d66b38522978BCf4649db14b931E";
+const genArt721V3Core_Explorations =
+  "0x942BC2d3e7a589FE5bd4A5C6eF9727DFd82F5C8a";
+const minterFilter_Explorations = "0x3F4bbde879F9BB0E95AEa08fF12F55E171495C8f";
+//////////////////////////////////////////////////////////////////////////////
+// CONFIG ENDS HERE
+//////////////////////////////////////////////////////////////////////////////
+
+async function main() {
+  const [deployer] = await ethers.getSigners();
+  const network = await ethers.provider.getNetwork();
+  const networkName = network.name == "homestead" ? "mainnet" : network.name;
+  if (networkName != "mainnet") {
+    throw new Error("This script is intended to be run on mainnet only");
+  }
+  //////////////////////////////////////////////////////////////////////////////
+  // DEPLOYMENT BEGINS HERE
+  //////////////////////////////////////////////////////////////////////////////
+
+  // Deploy Minter contract(s)
+  const minterMerkleFactory = new MinterMerkleV2__factory(deployer);
+  // flagship
+  const minterMerkleFlagship = await minterMerkleFactory.deploy(
+    genArt721V3Core_Flagship,
+    minterFilter_Flagship
+  );
+  await minterMerkleFlagship.deployed();
+  const minterMerkleFlagshipAddress = minterMerkleFlagship.address;
+  console.log(
+    `MinterMerkleV2 (flagship) deployed at ${minterMerkleFlagshipAddress}`
+  );
+  await delay(EXTRA_DELAY_BETWEEN_TX);
+  // explorations
+  const minterMerkleExplorations = await minterMerkleFactory.deploy(
+    genArt721V3Core_Explorations,
+    minterFilter_Explorations
+  );
+  await minterMerkleExplorations.deployed();
+  const minterMerkleExplorationsAddress = minterMerkleExplorations.address;
+  console.log(
+    `MinterMerkleV2 (explorations) deployed at ${minterMerkleExplorationsAddress}`
+  );
+  await delay(EXTRA_DELAY_BETWEEN_TX);
+
+  //////////////////////////////////////////////////////////////////////////////
+  // DEPLOYMENT ENDS HERE
+  //////////////////////////////////////////////////////////////////////////////
+
+  //////////////////////////////////////////////////////////////////////////////
+  // SETUP BEGINS HERE
+  //////////////////////////////////////////////////////////////////////////////
+
+  // DO NOT allowlist the minters on the minter filter here. If a new minter type
+  // is added to the minter filter, it will need to be added to the minter filter
+  // enum in the subgraph first. Otherwise, the subgraph will fail to progress.
+
+  // Output instructions for manual Etherscan verification.
+  const standardVerify = "yarn hardhat verify";
+  console.log(`Verify MinterMerkleV2 (flagship) contract deployment with:`);
+  console.log(
+    `${standardVerify} --network ${networkName} ${minterMerkleFlagshipAddress} ${genArt721V3Core_Flagship} ${minterFilter_Flagship}`
+  );
+  console.log(`Verify MinterMerkleV2 (explorations) contract deployment with:`);
+  console.log(
+    `${standardVerify} --network ${networkName} ${minterMerkleExplorationsAddress} ${genArt721V3Core_Explorations} ${minterFilter_Explorations}`
+  );
+
+  //////////////////////////////////////////////////////////////////////////////
+  // SETUP ENDS HERE
+  //////////////////////////////////////////////////////////////////////////////
+
+  console.log("Next Steps:");
+  console.log(
+    "1. Verify Admin ACL V1 contract deployment on Etherscan (see above)"
+  );
+  console.log(
+    "2. WAIT for subgraph to sync, and ensure enum with new minter type is added to subgraph"
+  );
+  console.log(
+    "3. AFTER subgraph syncs with type MinterMerkleV2 included in MinterType enum, allowlist the new minters type on their corresponding minter filters"
+  );
+  console.log(
+    `3a. e.g. Call addApprovedMinter on ${minterFilter_Flagship} with arg ${minterMerkleFlagshipAddress}`
+  );
+  console.log(
+    `3b. e.g. Call addApprovedMinter on ${minterFilter_Explorations} with arg ${minterMerkleExplorationsAddress}`
+  );
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
Add deploy scripts for deployment of MinterMerkleV2 for dev and mainnet environments.

Note that dev deployments have already been executed, and are available here: 
- (dev flagship) https://goerli.etherscan.io/address/0x126eC6A5Dd59f9414c778c7433E6C9100c4936fB#code
- (dev explorations) https://goerli.etherscan.io/address/0x723D5203689bA5A249Ea97630A5bE3FDd6B69cd7#code

@jakerockland - mainnet deployments should be g2g with your deployer wallet, when you get the chance 👍 The script deploys a MinterMerkleV2 minter for both the flagship and the explorations contracts.

I've also stopped contract sizer from polluting the terminal on every compile.