### PR TITLE
Update hardhat config to use a `gasMultiplier`

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -62,11 +62,13 @@ module.exports = {
       url: MAINNET_JSON_RPC_PROVIDER_URL,
       accounts: [`0x${MAINNET_PRIVATE_KEY}`],
       gasPrice: "auto",
+      gasMultiplier: 1.5,
     },
     goerli: {
       url: GOERLI_JSON_RPC_PROVIDER_URL,
       accounts: [`0x${TESTNET_PRIVATE_KEY}`],
       gasPrice: "auto",
+      gasMultiplier: 1.5,
     },
     coverage: {
       url: "http://localhost:8545",


### PR DESCRIPTION
While working through https://github.com/ArtBlocks/artblocks/issues/298, I found that the recently introduced usage of `"auto"` gas pricing is generally WAI, with the caveat that it is a bit less aggressive than I think we want it to be, for DevX reasons. 

This updates our config to also us a `gasMultiplier` param of `1.5` (vs. the default of `1`) to ensure that TXs are processed in a bit more timely of a manner.

For additional context, see: https://hardhat.org/hardhat-runner/docs/config#networks-configuration

cc @Asupkay for vis, if visibility into this approach is at all relevant for some of the application automation work you were doing and allows for any simplification of your approach (may be what you're already doing based on recent convo).