### PR TITLE
QSP-1 (PR#299)

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -1069,7 +1069,8 @@ contract GenArt721CoreV3 is
     /**
      * @notice Adds a script to project `_projectId`.
      * @param _projectId Project to be updated.
-     * @param _script Script to be added.
+     * @param _script Script to be added. Required to be a non-empty string,
+     * but no further validation is performed.
      */
     function addProjectScript(uint256 _projectId, string memory _script)
         external
@@ -1089,7 +1090,8 @@ contract GenArt721CoreV3 is
      * @notice Updates script for project `_projectId` at script ID `_scriptId`.
      * @param _projectId Project to be updated.
      * @param _scriptId Script ID to be updated.
-     * @param _script The updated script value.
+     * @param _script The updated script value. Required to be a non-empty
+     * string, but no further validation is performed.
      */
     function updateProjectScript(
         uint256 _projectId,

--- a/contracts/libs/0.8.x/BytecodeStorage.sol
+++ b/contracts/libs/0.8.x/BytecodeStorage.sol
@@ -43,7 +43,7 @@ library BytecodeStorage {
 
     /**
      * @notice Write a string to contract bytecode
-     * @param _data string to be written to contract
+     * @param _data string to be written to contract. No input validation is performed on this parameter.
      * @return address_ address of deployed contract with bytecode containing concat(gated-cleanup-logic, data)
      */
     function writeToBytecode(string memory _data)


### PR DESCRIPTION
Clarify input validation of scripts being added to a project.

- The V3 core contract validates that the input script is a non-empty string
- No other data validation is performed by the core contract, or the library

natspec comments are updated accordingly.