### PR TITLE
QSP-2 (PR#299) Docs surrounding selfdestruct logic

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -1104,6 +1104,14 @@ contract GenArt721CoreV3 is
         Project storage project = projects[_projectId];
         require(_scriptId < project.scriptCount, "scriptId out of range");
         // purge old contract bytecode contract from the blockchain state
+        // note: Although this does reduce usage of Ethereum state, it does not
+        // reduce the gas costs of removal transactions. We believe this is the
+        // best behavior at the time of writing, and do not expect this to
+        // result in any breaking changes in the future. All current proposals
+        // to change the self-destruct opcode are backwards compatible, but may
+        // result in not removing the bytecode from the blockchain state. This
+        // implementation is compatible with that architecture, as it does not
+        // rely on the bytecode being removed from the blockchain state.
         project.scriptBytecodeAddresses[_scriptId].purgeBytecode();
         // store script in contract bytecode, replacing reference address from
         // the contract that no longer exists with the newly created one
@@ -1123,6 +1131,14 @@ contract GenArt721CoreV3 is
         Project storage project = projects[_projectId];
         require(project.scriptCount > 0, "there are no scripts to remove");
         // purge old contract bytecode contract from the blockchain state
+        // note: Although this does reduce usage of Ethereum state, it does not
+        // reduce the gas costs of removal transactions. We believe this is the
+        // best behavior at the time of writing, and do not expect this to
+        // result in any breaking changes in the future. All current proposals
+        // to change the self-destruct opcode are backwards compatible, but may
+        // result in not removing the bytecode from the blockchain state. This
+        // implementation is compatible with that architecture, as it does not
+        // rely on the bytecode being removed from the blockchain state.
         project.scriptBytecodeAddresses[project.scriptCount - 1].purgeBytecode();
         // delete reference to contract address that no longer exists
         delete project.scriptBytecodeAddresses[project.scriptCount - 1];

--- a/contracts/libs/0.8.x/BytecodeStorage.sol
+++ b/contracts/libs/0.8.x/BytecodeStorage.sol
@@ -277,6 +277,14 @@ library BytecodeStorage {
 
     /**
      * @notice Purge contract bytecode for cleanup purposes
+     * note: Although this does reduce usage of Ethereum state, it does not reduce the gas costs of removal
+     * transactions. We believe this is the best behavior at the time of writing, and do not expect this to
+     * result in any breaking changes in the future. All current proposals to change the self-destruct opcode
+     * are backwards compatible, but may result in not removing the bytecode from the blockchain state. This
+     * implementation is compatible with that architecture, as it does not rely on the bytecode being removed
+     * from the blockchain state (as opposed to using a CREATE2 style opcode when creating bytecode contracts,
+     * which could be used in a way that may rely on the bytecode being removed from the blockchain state,
+     * e.g. replacing a contract at a given deployed address).
      * @param _address address of deployed contract with bytecode containing concat(gated-cleanup-logic, data)
      * @dev This contract is only callable by the address of the contract that originally deployed the bytecode
      *      being purged. If this method is called by any other address, it will revert with the `INVALID` op-code.


### PR DESCRIPTION
Add documentation explaining why we have included selfdestruct logic that enables bytecode-storage contacts to be removed from Ethereum's state.

In general, the comments indicate that we believe selfdestructing is the most ideal behavior at the time of writing/deploying this contract, even though it does not reduce gas costs, due to reducing the usage of Ethereum state. The comments also indicate that the design is compatible with all current proposals that remove the self-destruct opcode, since this implementation does not rely on bytecode being removed from the blockchain.