### PR TITLE
checkDelegateForContract To Read External _vault Param

### DIFF
--- a/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV2.sol
+++ b/contracts/minter-suite/Minters/MinterMerkle/MinterMerkleV2.sol
@@ -453,7 +453,7 @@ contract MinterMerkleV2 is ReentrancyGuard, IFilteredMinterMerkleV0 {
             bool isValidDelegee = delegationRegistryContract
                 .checkDelegateForContract(
                     msg.sender, // delegate
-                    vault, // vault
+                    _vault, // vault
                     genArt721CoreAddress // contract
                 );
             require(isValidDelegee, "Invalid delegate-vault pairing");


### PR DESCRIPTION
purchaseTo_kem() was pointing to the in-memory `vault` which stores address(0), but it should instead be reading the externally passed-in `_vault`.

Note: ideally our unit tests should catch this -- it was missed because we're mocking the `checkDelegateForContract` call to return true/false as needed _regardless of input params_. With this mock pattern that means we can't directly test the result of this param's usage, but I think we could just use calledWith and confirm the _vault param's a different address and it's not the address(0) val that's coming from vault
https://stackoverflow.com/questions/43995861/to-have-been-calledwith-is-not-a-function-error-in-chai3-5-0