### PR TITLE
Add simple reset functionality to DA w/Refund

### DIFF
--- a/contracts/interfaces/0.8.x/IFilteredMinterDAExpRefundV0.sol
+++ b/contracts/interfaces/0.8.x/IFilteredMinterDAExpRefundV0.sol
@@ -24,7 +24,7 @@ interface IFilteredMinterDAExpRefundV0 is IFilteredMinterV1 {
     );
 
     /// Auction details cleared for project `projectId`.
-    event ResetAuctionDetails(uint256 indexed projectId);
+    event ResetAuctionDetails(uint256 indexed projectId, uint256 priceAtReset);
 
     /// Maximum and minimum allowed price decay half lifes updated.
     event AuctionHalfLifeRangeSecondsUpdated(

--- a/contracts/interfaces/0.8.x/IFilteredMinterDAExpRefundV0.sol
+++ b/contracts/interfaces/0.8.x/IFilteredMinterDAExpRefundV0.sol
@@ -24,7 +24,15 @@ interface IFilteredMinterDAExpRefundV0 is IFilteredMinterV1 {
     );
 
     /// Auction details cleared for project `projectId`.
-    event ResetAuctionDetails(uint256 indexed projectId, uint256 priceAtReset);
+    /// At time of reset, the project has had `numPurchases` purchases on this
+    /// minter, with a most recent purchase price of `latestPurchasePrice`. If
+    /// the number of purchases is 0, the latest purchase price will have a
+    /// dummy value of 0.
+    event ResetAuctionDetails(
+        uint256 indexed projectId,
+        uint256 numPurchases,
+        uint256 latestPurchasePrice
+    );
 
     /// Maximum and minimum allowed price decay half lifes updated.
     event AuctionHalfLifeRangeSecondsUpdated(


### PR DESCRIPTION
Add a simple auction reset functionality to the DA w/Refund PR.

This allows admin to reset an active auction, even after refundable purchases have been completed, to handle a situation where, e.g., our frontend goes down or has a bug during a live auction.

The following constraints are enforced on-chain during a reset:
- The next auction start price after a reset must be less than or equal to the most recent purchase price prior to the reset. This keeps an auction purchase price monotonically decreasing, simplifying refund and revenue payout logic.
  - Note that if no purchases were made prior to an auction's reset, the subsequent auction may start at any price, since refund and revenue logic won't be affected (it doesn't yet exist on the project).

The following implementations are removed from the minter:
- Admin no longer is required to mark an auction above base price as valid.
  - This level of separation of power no longer makes sense due to a user now relying on some rational behavior from Admin and Artist during an auction. Removing the requirement for admin to validate a sellout price eliminates unnecessary overhead that doesn't add meaningful protections to users.
  
## Design Choices
This implementation is relatively simple, and buries the somewhat minimal complexity in the minter, as opposed to the "delay" solution presented in #384, which adds a lot of complexity to the minter, subgraph, and frontend. On this minter, auctions look nearly identical to existing DA auctions, and frontend display and logic should be almost the same when purchasing.

## Note on Tests
- Tests are not written for this added logic since this PR merges into #382 (which will need many tests before merging into main)