### PR TITLE
Add test for returning correct minter type

### DIFF
--- a/augmentations.d.ts
+++ b/augmentations.d.ts
@@ -26,5 +26,7 @@ declare module "mocha" {
     projectTwoTokenOne: BigNumber;
     projectThreeTokenZero: BigNumber;
     projectThreeTokenOne: BigNumber;
+    // target minter name (e.g. "MinterMerkleV3")
+    targetMinterName: string | undefined;
   }
 }

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV0.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV0.test.ts
@@ -53,7 +53,8 @@ describe("MinterDAExpV0_V1Core", async function () {
       "MinterFilterV0"
     ));
 
-    this.minter = await deployAndGet.call(this, "MinterDAExpV0", [
+    this.targetMinterName = "MinterDAExpV0";
+    this.minter = await deployAndGet.call(this, this.targetMinterName, [
       this.genArt721Core.address,
       this.minterFilter.address,
     ]);

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV1.PRTNR.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV1.PRTNR.test.ts
@@ -50,7 +50,8 @@ describe("MinterDAExpV1_V1PRTNRCore", async function () {
       "MinterFilterV0"
     ));
 
-    this.minter = await deployAndGet.call(this, "MinterDAExpV1", [
+    this.targetMinterName = "MinterDAExpV1";
+    this.minter = await deployAndGet.call(this, this.targetMinterName, [
       this.genArt721Core.address,
       this.minterFilter.address,
     ]);

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV1.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV1.test.ts
@@ -50,7 +50,8 @@ describe("MinterDAExpV1_V1Core", async function () {
       "MinterFilterV0"
     ));
 
-    this.minter = await deployAndGet.call(this, "MinterDAExpV1", [
+    this.targetMinterName = "MinterDAExpV1";
+    this.minter = await deployAndGet.call(this, this.targetMinterName, [
       this.genArt721Core.address,
       this.minterFilter.address,
     ]);

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV2.test.ts
@@ -58,7 +58,8 @@ for (const coreContractName of coreContractsToTest) {
         "MinterFilterV1"
       ));
 
-      this.minter = await deployAndGet.call(this, "MinterDAExpV2", [
+      this.targetMinterName = "MinterDAExpV2";
+      this.minter = await deployAndGet.call(this, this.targetMinterName, [
         this.genArt721Core.address,
         this.minterFilter.address,
       ]);

--- a/test/minter-suite-minters/DA/MinterDAExpSettlement/MinterDAExpSettlementV0.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExpSettlement/MinterDAExpSettlementV0.test.ts
@@ -61,7 +61,8 @@ for (const coreContractName of coreContractsToTest) {
         "MinterFilterV1"
       ));
 
-      this.minter = await deployAndGet.call(this, "MinterDAExpSettlementV0", [
+      this.targetMinterName = "MinterDAExpSettlementV0";
+      this.minter = await deployAndGet.call(this, this.targetMinterName, [
         this.genArt721Core.address,
         this.minterFilter.address,
       ]);

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV0.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV0.test.ts
@@ -53,7 +53,8 @@ describe("MinterDALinV0_V1Core", async function () {
       "MinterFilterV0"
     ));
 
-    this.minter = await deployAndGet.call(this, "MinterDALinV0", [
+    this.targetMinterName = "MinterDALinV0";
+    this.minter = await deployAndGet.call(this, this.targetMinterName, [
       this.genArt721Core.address,
       this.minterFilter.address,
     ]);

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV1.PRTNR.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV1.PRTNR.test.ts
@@ -49,7 +49,8 @@ describe("MinterDALinV1_V2PRTNRCore", async function () {
       "MinterFilterV0"
     ));
 
-    this.minter = await deployAndGet.call(this, "MinterDALinV1", [
+    this.targetMinterName = "MinterDALinV1";
+    this.minter = await deployAndGet.call(this, this.targetMinterName, [
       this.genArt721Core.address,
       this.minterFilter.address,
     ]);

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV1.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV1.test.ts
@@ -49,7 +49,8 @@ describe("MinterDALinV1_V1Core", async function () {
       "MinterFilterV0"
     ));
 
-    this.minter = await deployAndGet.call(this, "MinterDALinV1", [
+    this.targetMinterName = "MinterDALinV1";
+    this.minter = await deployAndGet.call(this, this.targetMinterName, [
       this.genArt721Core.address,
       this.minterFilter.address,
     ]);

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV2.test.ts
@@ -57,7 +57,8 @@ for (const coreContractName of coreContractsToTest) {
         "MinterFilterV1"
       ));
 
-      this.minter = await deployAndGet.call(this, "MinterDALinV2", [
+      this.targetMinterName = "MinterDALinV2";
+      this.minter = await deployAndGet.call(this, this.targetMinterName, [
         this.genArt721Core.address,
         this.minterFilter.address,
       ]);

--- a/test/minter-suite-minters/Minter.common.ts
+++ b/test/minter-suite-minters/Minter.common.ts
@@ -1,3 +1,4 @@
+import { getContractFactory } from "@nomiclabs/hardhat-ethers/types";
 import { constants, expectRevert } from "@openzeppelin/test-helpers";
 import { expect } from "chai";
 import { ethers } from "hardhat";
@@ -9,6 +10,11 @@ import { ethers } from "hardhat";
  */
 export const Minter_Common = async () => {
   describe("constructor", async function () {
+    it("returns correct minter type", async function () {
+      const returnedMinterType = await this.minter.minterType();
+      expect(returnedMinterType).to.equal(this.targetMinterName);
+    });
+
     it("reverts when given incorrect minter filter and core addresses", async function () {
       const artblocksFactory = await ethers.getContractFactory(
         "GenArt721CoreV1"

--- a/test/minter-suite-minters/MinterHolder/MinterHolderV0.test.ts
+++ b/test/minter-suite-minters/MinterHolder/MinterHolderV0.test.ts
@@ -45,7 +45,8 @@ describe("MinterHolderV0", async function () {
       "MinterFilterV0"
     ));
 
-    this.minter = await deployAndGet.call(this, "MinterHolderV0", [
+    this.targetMinterName = "MinterHolderV0";
+    this.minter = await deployAndGet.call(this, this.targetMinterName, [
       this.genArt721Core.address,
       this.minterFilter.address,
     ]);

--- a/test/minter-suite-minters/MinterHolder/MinterHolderV1.test.ts
+++ b/test/minter-suite-minters/MinterHolder/MinterHolderV1.test.ts
@@ -51,7 +51,8 @@ for (const coreContractName of coreContractsToTest) {
         "MinterFilterV1"
       ));
 
-      this.minter = await deployAndGet.call(this, "MinterHolderV1", [
+      this.targetMinterName = "MinterHolderV1";
+      this.minter = await deployAndGet.call(this, this.targetMinterName, [
         this.genArt721Core.address,
         this.minterFilter.address,
       ]);

--- a/test/minter-suite-minters/MinterHolder/MinterHolderV2.test.ts
+++ b/test/minter-suite-minters/MinterHolder/MinterHolderV2.test.ts
@@ -49,8 +49,8 @@ for (const coreContractName of coreContractsToTest) {
         "DelegationRegistry",
         []
       );
-
-      this.minter = await deployAndGet.call(this, "MinterHolderV2", [
+      this.targetMinterName = "MinterHolderV2";
+      this.minter = await deployAndGet.call(this, this.targetMinterName, [
         this.genArt721Core.address,
         this.minterFilter.address,
         this.delegationRegistry.address,
@@ -166,7 +166,7 @@ for (const coreContractName of coreContractsToTest) {
     describe("constructor", async function () {
       it("emits an event indicating dependency registry in constructor", async function () {
         const contractFactory = await ethers.getContractFactory(
-          "MinterHolderV2"
+          this.targetMinterName
         );
         const tx = await contractFactory.deploy(
           this.genArt721Core.address,

--- a/test/minter-suite-minters/MinterMerkle/MinterMerkleV0.test.ts
+++ b/test/minter-suite-minters/MinterMerkle/MinterMerkleV0.test.ts
@@ -40,7 +40,8 @@ describe("MinterMerkleV0", async function () {
       "MinterFilterV0"
     ));
 
-    this.minter = await deployAndGet.call(this, "MinterMerkleV0", [
+    this.targetMinterName = "MinterMerkleV0";
+    this.minter = await deployAndGet.call(this, this.targetMinterName, [
       this.genArt721Core.address,
       this.minterFilter.address,
     ]);

--- a/test/minter-suite-minters/MinterMerkle/MinterMerkleV2.test.ts
+++ b/test/minter-suite-minters/MinterMerkle/MinterMerkleV2.test.ts
@@ -52,7 +52,8 @@ for (const coreContractName of coreContractsToTest) {
         "MinterFilterV1"
       ));
 
-      this.minter = await deployAndGet.call(this, "MinterMerkleV2", [
+      this.targetMinterName = "MinterMerkleV2";
+      this.minter = await deployAndGet.call(this, this.targetMinterName, [
         this.genArt721Core.address,
         this.minterFilter.address,
       ]);

--- a/test/minter-suite-minters/MinterMerkle/MinterMerkleV3.test.ts
+++ b/test/minter-suite-minters/MinterMerkle/MinterMerkleV3.test.ts
@@ -56,7 +56,8 @@ for (const coreContractName of coreContractsToTest) {
         []
       );
 
-      this.minter = await deployAndGet.call(this, "MinterMerkleV3", [
+      this.targetMinterName = "MinterMerkleV3";
+      this.minter = await deployAndGet.call(this, this.targetMinterName, [
         this.genArt721Core.address,
         this.minterFilter.address,
         this.delegationRegistry.address,
@@ -195,7 +196,7 @@ for (const coreContractName of coreContractsToTest) {
     describe("constructor", async function () {
       it("emits an event indicating dependency registry in constructor", async function () {
         const contractFactory = await ethers.getContractFactory(
-          "MinterMerkleV3"
+          this.targetMinterName
         );
         const tx = await contractFactory.deploy(
           this.genArt721Core.address,

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV0.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV0.test.ts
@@ -49,7 +49,10 @@ describe("MinterSetPriceV0_V1Core", async function () {
       "MinterFilterV0"
     ));
 
-    const minterFactory = await ethers.getContractFactory("MinterSetPriceV0");
+    this.targetMinterName = "MinterSetPriceV0";
+    const minterFactory = await ethers.getContractFactory(
+      this.targetMinterName
+    );
     this.minter1 = await minterFactory.deploy(
       this.genArt721Core.address,
       this.minterFilter.address

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV1.PRTNR.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV1.PRTNR.test.ts
@@ -44,7 +44,10 @@ describe("MinterSetPriceV1_V2PRTNRCore", async function () {
       "MinterFilterV0"
     ));
 
-    const minterFactory = await ethers.getContractFactory("MinterSetPriceV1");
+    this.targetMinterName = "MinterSetPriceV1";
+    const minterFactory = await ethers.getContractFactory(
+      this.targetMinterName
+    );
     this.minter1 = await minterFactory.deploy(
       this.genArt721Core.address,
       this.minterFilter.address

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV1.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV1.test.ts
@@ -45,7 +45,10 @@ describe("MinterSetPriceV1_V1Core", async function () {
       "MinterFilterV0"
     ));
 
-    const minterFactory = await ethers.getContractFactory("MinterSetPriceV1");
+    this.targetMinterName = "MinterSetPriceV1";
+    const minterFactory = await ethers.getContractFactory(
+      this.targetMinterName
+    );
     this.minter1 = await minterFactory.deploy(
       this.genArt721Core.address,
       this.minterFilter.address

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV2.test.ts
@@ -53,7 +53,10 @@ for (const coreContractName of coreContractsToTest) {
         "MinterFilterV1"
       ));
 
-      const minterFactory = await ethers.getContractFactory("MinterSetPriceV2");
+      this.targetMinterName = "MinterSetPriceV2";
+      const minterFactory = await ethers.getContractFactory(
+        this.targetMinterName
+      );
       this.minter1 = await minterFactory.deploy(
         this.genArt721Core.address,
         this.minterFilter.address

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V0.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V0.test.ts
@@ -36,8 +36,9 @@ describe("MinterSetPriceERC20V0_V1Core", async function () {
       "MinterFilterV0"
     ));
 
+    this.targetMinterName = "MinterSetPriceERC20V0";
     const minterFactory = await ethers.getContractFactory(
-      "MinterSetPriceERC20V0"
+      this.targetMinterName
     );
     this.minter = await minterFactory.deploy(
       this.genArt721Core.address,

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V1.PRTNR.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V1.PRTNR.test.ts
@@ -35,8 +35,9 @@ describe("MinterSetPriceERC20V1_V2PRTNRCore", async function () {
       "MinterFilterV0"
     ));
 
+    this.targetMinterName = "MinterSetPriceERC20V1";
     const minterFactory = await ethers.getContractFactory(
-      "MinterSetPriceERC20V1"
+      this.targetMinterName
     );
     this.minter = await minterFactory.deploy(
       this.genArt721Core.address,

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V1.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V1.test.ts
@@ -36,8 +36,9 @@ describe("MinterSetPriceERC20V1_V1Core", async function () {
       "MinterFilterV0"
     ));
 
+    this.targetMinterName = "MinterSetPriceERC20V1";
     const minterFactory = await ethers.getContractFactory(
-      "MinterSetPriceERC20V1"
+      this.targetMinterName
     );
     this.minter = await minterFactory.deploy(
       this.genArt721Core.address,

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V2.test.ts
@@ -45,8 +45,9 @@ for (const coreContractName of coreContractsToTest) {
         "MinterFilterV1"
       ));
 
+      this.targetMinterName = "MinterSetPriceERC20V2";
       const minterFactory = await ethers.getContractFactory(
-        "MinterSetPriceERC20V2"
+        this.targetMinterName
       );
       this.minter = await minterFactory.deploy(
         this.genArt721Core.address,


### PR DESCRIPTION
Add an additional test common to all minters to verify that the contract is returning the intended `minterType`.

This patches a minor hole in our testing. The bug would never make it to mainnet (since it becomes obvious when the dev subgraph is deployed), but this improves our test to catch the issue earlier.

The new test would have caught the bug patched in #399 