### PR TITLE
Add excess settlement funds getter to DA w/Settlement

### DIFF
--- a/contracts/interfaces/0.8.x/IFilteredMinterDAExpSettlementV0.sol
+++ b/contracts/interfaces/0.8.x/IFilteredMinterDAExpSettlementV0.sol
@@ -74,8 +74,9 @@ interface IFilteredMinterDAExpSettlementV0 is IFilteredMinterV1 {
         view
         returns (uint256 numSettleableInvocations);
 
-    /// returns
-    function estimateProjectExcessSettlementFunds(
+    /// Returns the current excess settlement funds on project `_projectId`
+    /// for address `_walletAddress`.
+    function getProjectExcessSettlementFunds(
         uint256 _projectId,
         address _walletAddress
     ) external view returns (uint256 excessSettlementFundsInWei);

--- a/contracts/interfaces/0.8.x/IFilteredMinterDAExpSettlementV0.sol
+++ b/contracts/interfaces/0.8.x/IFilteredMinterDAExpSettlementV0.sol
@@ -73,4 +73,10 @@ interface IFilteredMinterDAExpSettlementV0 is IFilteredMinterV1 {
         external
         view
         returns (uint256 numSettleableInvocations);
+
+    /// returns
+    function estimateProjectExcessSettlementFunds(
+        uint256 _projectId,
+        address _walletAddress
+    ) external view returns (uint256 excessSettlementFundsInWei);
 }

--- a/contracts/minter-suite/Minters/MinterDAExpSettlement/MinterDAExpSettlementV0.sol
+++ b/contracts/minter-suite/Minters/MinterDAExpSettlement/MinterDAExpSettlementV0.sol
@@ -970,10 +970,10 @@ contract MinterDAExpSettlementV0 is
         address _walletAddress
     ) external view returns (uint256 excessSettlementFundsInWei) {
         // input validation
-        require(_walletAddress != address(0), "No zero wallet address");
+        require(_walletAddress != address(0), "No zero address");
         // load struct from storage
         ProjectConfig storage _projectConfig = projectConfig[_projectId];
-        Receipt storage receipt = receipts[msg.sender][_projectId];
+        Receipt storage receipt = receipts[_walletAddress][_projectId];
         // require that a user has purchased at least one token on this project
         require(receipt.numPurchased > 0, "No purchases made by this address");
         // get the latestPurchasePrice, which returns the sellout price if the

--- a/contracts/minter-suite/Minters/MinterDAExpSettlement/MinterDAExpSettlementV0.sol
+++ b/contracts/minter-suite/Minters/MinterDAExpSettlement/MinterDAExpSettlementV0.sol
@@ -953,6 +953,48 @@ contract MinterDAExpSettlementV0 is
     }
 
     /**
+     * @notice Gets the current excess settlement funds on project `_projectId`
+     * for address `_walletAddress`. The returned value is expected to change
+     * throughtout an auction, since the latest purchase price is used when
+     * determining excess settlement funds.
+     * A user may claim excess settlement funds by calling the function
+     * `reclaimProjectExcessSettlementFunds(_projectId)`.
+     * @param _projectId Project ID to query.
+     * @param _walletAddress Account address for which the excess posted funds
+     * is being queried.
+     * @return excessSettlementFundsInWei Amount of excess settlement funds, in
+     * wei
+     */
+    function estimateProjectExcessSettlementFunds(
+        uint256 _projectId,
+        address _walletAddress
+    ) external view returns (uint256 excessSettlementFundsInWei) {
+        // input validation
+        require(_walletAddress != address(0), "No zero wallet address");
+        // load struct from storage
+        ProjectConfig storage _projectConfig = projectConfig[_projectId];
+        Receipt storage receipt = receipts[msg.sender][_projectId];
+        // require that a user has purchased at least one token on this project
+        require(receipt.numPurchased > 0, "No purchases made by this address");
+        // get the latestPurchasePrice, which returns the sellout price if the
+        // auction sold out before reaching base price, or returns the base
+        // price if auction has reached base price and artist has withdrawn
+        // revenues.
+        // @dev if user is eligible for a reclaiming, they have purchased a
+        // token, therefore we are guaranteed to have a populated
+        // latestPurchasePrice
+        uint256 currentSettledTokenPrice = _projectConfig.latestPurchasePrice;
+
+        // EFFECTS
+        // calculate the excess settlement funds amount and return
+        // implicit overflow/underflow checks in solidity ^0.8
+        uint256 requiredAmountPosted = receipt.numPurchased *
+            currentSettledTokenPrice;
+        excessSettlementFundsInWei = receipt.netPosted - requiredAmountPosted;
+        return excessSettlementFundsInWei;
+    }
+
+    /**
      * @notice Gets the latest purchase price for project `_projectId`, or 0 if
      * no purchases have been made.
      */

--- a/contracts/minter-suite/Minters/MinterDAExpSettlement/MinterDAExpSettlementV0.sol
+++ b/contracts/minter-suite/Minters/MinterDAExpSettlement/MinterDAExpSettlementV0.sol
@@ -965,7 +965,7 @@ contract MinterDAExpSettlementV0 is
      * @return excessSettlementFundsInWei Amount of excess settlement funds, in
      * wei
      */
-    function estimateProjectExcessSettlementFunds(
+    function getProjectExcessSettlementFunds(
         uint256 _projectId,
         address _walletAddress
     ) external view returns (uint256 excessSettlementFundsInWei) {

--- a/test/minter-suite-minters/DA/MinterDAExpSettlement/MinterDAExpSettlement.common.ts
+++ b/test/minter-suite-minters/DA/MinterDAExpSettlement/MinterDAExpSettlement.common.ts
@@ -1978,10 +1978,10 @@ export const MinterDAExpSettlement_Common = async () => {
     });
   });
 
-  describe("estimateProjectExcessSettlementFunds", async function () {
-    it("reverts when estimating for zero address", async function () {
+  describe("getProjectExcessSettlementFunds", async function () {
+    it("reverts when getting for zero address", async function () {
       await expectRevert(
-        this.minter.estimateProjectExcessSettlementFunds(
+        this.minter.getProjectExcessSettlementFunds(
           this.projectZero,
           constants.ZERO_ADDRESS
         ),
@@ -1989,9 +1989,9 @@ export const MinterDAExpSettlement_Common = async () => {
       );
     });
 
-    it("reverts when estimating before a wallet purchases", async function () {
+    it("reverts when getting before a wallet purchases", async function () {
       await expectRevert(
-        this.minter.estimateProjectExcessSettlementFunds(
+        this.minter.getProjectExcessSettlementFunds(
           this.projectZero,
           this.accounts.user.address
         ),
@@ -2002,7 +2002,7 @@ export const MinterDAExpSettlement_Common = async () => {
     it("returns expected values for project after purchases", async function () {
       await purchaseTokensMidAuction.call(this, this.projectZero);
       const excessSettlementFunds =
-        await this.minter.estimateProjectExcessSettlementFunds(
+        await this.minter.getProjectExcessSettlementFunds(
           this.projectZero,
           this.accounts.user.address
         );
@@ -2013,7 +2013,7 @@ export const MinterDAExpSettlement_Common = async () => {
         .reclaimProjectExcessSettlementFunds(this.projectZero);
       // check that excess settlement funds are zero
       const excessSettlementFundsAfterReclaim =
-        await this.minter.estimateProjectExcessSettlementFunds(
+        await this.minter.getProjectExcessSettlementFunds(
           this.projectZero,
           this.accounts.user.address
         );

--- a/test/minter-suite-minters/DA/MinterDAExpSettlement/MinterDAExpSettlementV0.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExpSettlement/MinterDAExpSettlementV0.test.ts
@@ -175,7 +175,7 @@ for (const coreContractName of coreContractsToTest) {
           "ETH"
         );
         expect(txCost.toString()).to.equal(
-          ethers.utils.parseEther("0.0183211")
+          ethers.utils.parseEther("0.0182969")
         ); // assuming a cost of 100 GWEI
       });
     });


### PR DESCRIPTION
Add excess settlement funds getter to DA w/Settlement to reduce latency on frontend.

This should allow our frontend to reduce latency associated with sync times when a user is reclaiming excess funds posted to the DA w/Settlement for a given project.

Cc @Jbern16 

note: subgraph PRs have been updated with abis as of commit e5ba0a1