### PR TITLE
Add deployment script for DA w/ settlement

### DIFF
--- a/scripts/minter-deployments/1_reference_goerli-dev_minter-dutch-auction-settlement_deployer.ts
+++ b/scripts/minter-deployments/1_reference_goerli-dev_minter-dutch-auction-settlement_deployer.ts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Created By: Art Blocks Inc.
+
+import { ethers } from "hardhat";
+// explorations
+import { MinterDAExpSettlementV0__factory } from "../contracts/factories/MinterDAExpSettlementV0__factory";
+
+// delay to avoid issues with reorgs and tx failures
+import { delay } from "../util/utils";
+const EXTRA_DELAY_BETWEEN_TX = 5000; // ms
+
+/**
+ * This script was created to deploy the MinterDAExpSettlementV0 contract to the Ethereum
+ * Goerli testnet, for the Art Blocks dev environment.
+ * It is intended to document the deployment process and provide a reference
+ * for the steps required to deploy the MinterDAExpSettlementV0 contract.
+ */
+//////////////////////////////////////////////////////////////////////////////
+// CONFIG BEGINS HERE
+//////////////////////////////////////////////////////////////////////////////
+const genArt721V3Core_Flagship = "0xF396C180bb2f92EE28535D23F5224A5b9425ceca";
+const minterFilter_Flagship = "0x7EcFFfc1A3Eb7Ce76D4b29Df3e5098D2D921D367";
+const genArt721V3Core_Explorations =
+  "0x7244352F6C7aFbB74D4b63Bd7e8189e84a83f179";
+const minterFilter_Explorations = "0x6600e8d744aa7545A8757eF928117866cF431A26";
+//////////////////////////////////////////////////////////////////////////////
+// CONFIG ENDS HERE
+//////////////////////////////////////////////////////////////////////////////
+
+async function main() {
+  const [deployer] = await ethers.getSigners();
+  const network = await ethers.provider.getNetwork();
+  const networkName = network.name == "homestead" ? "mainnet" : network.name;
+  if (networkName != "goerli") {
+    throw new Error("This script is intended to be run on mainnet only");
+  }
+  //////////////////////////////////////////////////////////////////////////////
+  // DEPLOYMENT BEGINS HERE
+  //////////////////////////////////////////////////////////////////////////////
+
+  // Deploy Minter contract(s)
+  const minterHolderFactory = new MinterDAExpSettlementV0__factory(deployer);
+  // flagship
+  const minterHolderFlagship = await minterHolderFactory.deploy(
+    genArt721V3Core_Flagship,
+    minterFilter_Flagship
+  );
+  await minterHolderFlagship.deployed();
+  const minterHolderFlagshipAddress = minterHolderFlagship.address;
+  console.log(
+    `MinterDAExpSettlementV0 (flagship) deployed at ${minterHolderFlagshipAddress}`
+  );
+  await delay(EXTRA_DELAY_BETWEEN_TX);
+  // explorations
+  const minterHolderExplorations = await minterHolderFactory.deploy(
+    genArt721V3Core_Explorations,
+    minterFilter_Explorations
+  );
+  await minterHolderExplorations.deployed();
+  const minterHolderExplorationsAddress = minterHolderExplorations.address;
+  console.log(
+    `MinterDAExpSettlementV0 (explorations) deployed at ${minterHolderExplorationsAddress}`
+  );
+  await delay(EXTRA_DELAY_BETWEEN_TX);
+
+  //////////////////////////////////////////////////////////////////////////////
+  // DEPLOYMENT ENDS HERE
+  //////////////////////////////////////////////////////////////////////////////
+
+  //////////////////////////////////////////////////////////////////////////////
+  // SETUP BEGINS HERE
+  //////////////////////////////////////////////////////////////////////////////
+
+  // DO NOT allowlist the minters on the minter filter here. If a new minter type
+  // is added to the minter filter, it will need to be added to the minter filter
+  // enum in the subgraph first. Otherwise, the subgraph will fail to progress.
+
+  // Output instructions for manual Etherscan verification.
+  const standardVerify = "yarn hardhat verify";
+  console.log(`Verify MinterDAExpSettlementV0 (flagship) contract deployment with:`);
+  console.log(
+    `${standardVerify} --network ${networkName} ${minterHolderFlagshipAddress} ${genArt721V3Core_Flagship} ${minterFilter_Flagship}`
+  );
+  console.log(`Verify MinterDAExpSettlementV0 (explorations) contract deployment with:`);
+  console.log(
+    `${standardVerify} --network ${networkName} ${minterHolderExplorationsAddress} ${genArt721V3Core_Explorations} ${minterFilter_Explorations}`
+  );
+
+  //////////////////////////////////////////////////////////////////////////////
+  // SETUP ENDS HERE
+  //////////////////////////////////////////////////////////////////////////////
+
+  console.log("Next Steps:");
+  console.log(
+    "1. Verify Admin ACL V1 contract deployment on Etherscan (see above)"
+  );
+  console.log(
+    "2. WAIT for subgraph to sync, and ensure enum with new minter type is added to subgraph"
+  );
+  console.log(
+    "3. AFTER subgraph syncs with type MinterDAExpSettlementV0 included in MinterType enum, allowlist the new minters type on their corresponding minter filters"
+  );
+  console.log(
+    `3a. e.g. Call addApprovedMinter on ${minterFilter_Flagship} with arg ${minterHolderFlagshipAddress}`
+  );
+  console.log(
+    `3b. e.g. Call addApprovedMinter on ${minterFilter_Explorations} with arg ${minterHolderExplorationsAddress}`
+  );
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/minter-deployments/1_reference_goerli-dev_minter-dutch-auction-settlement_deployer.ts
+++ b/scripts/minter-deployments/1_reference_goerli-dev_minter-dutch-auction-settlement_deployer.ts
@@ -77,11 +77,15 @@ async function main() {
 
   // Output instructions for manual Etherscan verification.
   const standardVerify = "yarn hardhat verify";
-  console.log(`Verify MinterDAExpSettlementV0 (flagship) contract deployment with:`);
+  console.log(
+    `Verify MinterDAExpSettlementV0 (flagship) contract deployment with:`
+  );
   console.log(
     `${standardVerify} --network ${networkName} ${minterHolderFlagshipAddress} ${genArt721V3Core_Flagship} ${minterFilter_Flagship}`
   );
-  console.log(`Verify MinterDAExpSettlementV0 (explorations) contract deployment with:`);
+  console.log(
+    `Verify MinterDAExpSettlementV0 (explorations) contract deployment with:`
+  );
   console.log(
     `${standardVerify} --network ${networkName} ${minterHolderExplorationsAddress} ${genArt721V3Core_Explorations} ${minterFilter_Explorations}`
   );


### PR DESCRIPTION
Deployed DA w/ settlement minter for both flagship core contracts (Curated/Presents + Explorations) on `dev-goerli`:

```
yarn run v1.22.19
$ /Users/jakerockland/Code/artblocks-contracts/node_modules/.bin/hardhat run scripts/minter-deployments/1_reference_goerli-dev_minter-dutch-auction-settlement_deployer.ts --network goerli
Duplicate definition of ConfigValueAddedToSet (ConfigValueAddedToSet(uint256,bytes32,uint256), ConfigValueAddedToSet(uint256,bytes32,address), ConfigValueAddedToSet(uint256,bytes32,bytes32))
Duplicate definition of ConfigValueRemovedFromSet (ConfigValueRemovedFromSet(uint256,bytes32,uint256), ConfigValueRemovedFromSet(uint256,bytes32,address), ConfigValueRemovedFromSet(uint256,bytes32,bytes32))
Duplicate definition of ConfigValueSet (ConfigValueSet(uint256,bytes32,bool), ConfigValueSet(uint256,bytes32,uint256), ConfigValueSet(uint256,bytes32,address), ConfigValueSet(uint256,bytes32,bytes32))
MinterDAExpSettlementV0 (flagship) deployed at 0xaC85613A8C8b39a713175bC0F54630199A40D2D8
Duplicate definition of ConfigValueAddedToSet (ConfigValueAddedToSet(uint256,bytes32,uint256), ConfigValueAddedToSet(uint256,bytes32,address), ConfigValueAddedToSet(uint256,bytes32,bytes32))
Duplicate definition of ConfigValueRemovedFromSet (ConfigValueRemovedFromSet(uint256,bytes32,uint256), ConfigValueRemovedFromSet(uint256,bytes32,address), ConfigValueRemovedFromSet(uint256,bytes32,bytes32))
Duplicate definition of ConfigValueSet (ConfigValueSet(uint256,bytes32,bool), ConfigValueSet(uint256,bytes32,uint256), ConfigValueSet(uint256,bytes32,address), ConfigValueSet(uint256,bytes32,bytes32))
MinterDAExpSettlementV0 (explorations) deployed at 0x5663463849Dfb8D9c3ea7046cb1D55b504DeCe5C
Verify MinterDAExpSettlementV0 (flagship) contract deployment with:
yarn hardhat verify --network goerli 0xaC85613A8C8b39a713175bC0F54630199A40D2D8 0xF396C180bb2f92EE28535D23F5224A5b9425ceca 0x7EcFFfc1A3Eb7Ce76D4b29Df3e5098D2D921D367
Verify MinterDAExpSettlementV0 (explorations) contract deployment with:
yarn hardhat verify --network goerli 0x5663463849Dfb8D9c3ea7046cb1D55b504DeCe5C 0x7244352F6C7aFbB74D4b63Bd7e8189e84a83f179 0x6600e8d744aa7545A8757eF928117866cF431A26
Next Steps:
1. Verify Admin ACL V1 contract deployment on Etherscan (see above)
2. WAIT for subgraph to sync, and ensure enum with new minter type is added to subgraph
3. AFTER subgraph syncs with type MinterDAExpSettlementV0 included in MinterType enum, allowlist the new minters type on their corresponding minter filters
3a. e.g. Call addApprovedMinter on 0x7EcFFfc1A3Eb7Ce76D4b29Df3e5098D2D921D367 with arg 0xaC85613A8C8b39a713175bC0F54630199A40D2D8
3b. e.g. Call addApprovedMinter on 0x6600e8d744aa7545A8757eF928117866cF431A26 with arg 0x5663463849Dfb8D9c3ea7046cb1D55b504DeCe5C
✨  Done in 27.42s.
```

Verification performed:

Successfully verified contract MinterDAExpSettlementV0 on Etherscan.
https://goerli.etherscan.io/address/0xaC85613A8C8b39a713175bC0F54630199A40D2D8#code

Successfully verified contract MinterDAExpSettlementV0 on Etherscan.
https://goerli.etherscan.io/address/0x5663463849Dfb8D9c3ea7046cb1D55b504DeCe5C#code


