### PR TITLE
Change param order for Receipt Updated

### DIFF
--- a/contracts/interfaces/0.8.x/IFilteredMinterDAExpSettlementV0.sol
+++ b/contracts/interfaces/0.8.x/IFilteredMinterDAExpSettlementV0.sol
@@ -57,8 +57,8 @@ interface IFilteredMinterDAExpSettlementV0 is IFilteredMinterV1 {
     event ReceiptUpdated(
         address indexed _purchaser,
         uint256 indexed _projectId,
-        uint256 _netPosted,
-        uint256 _numPurchased
+        uint256 _numPurchased,
+        uint256 _netPosted
     );
 
     /// returns latest purchase price for project `_projectId`, or 0 if no


### PR DESCRIPTION
The ordering in the interface was out of sync with that in the concrete usage.