### PR TITLE
Add interfaces for shared events for existing minters to simplify subgraph logic

### DIFF
--- a/contracts/interfaces/0.8.x/IFilteredMinterDAExpV0.sol
+++ b/contracts/interfaces/0.8.x/IFilteredMinterDAExpV0.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Created By: Art Blocks Inc.
+
+import "./IFilteredMinterV0.sol";
+
+pragma solidity ^0.8.0;
+
+/**
+ * @title This interface extends the IFilteredMinterV0 interface in order to
+ * add support for exponential descending auctions.
+ * @author Art Blocks Inc.
+ */
+interface IFilteredMinterDAExpV0 is IFilteredMinterV0 {
+    /// Auction details updated for project `projectId`.
+    event SetAuctionDetails(
+        uint256 indexed projectId,
+        uint256 _auctionTimestampStart,
+        uint256 _priceDecayHalfLifeSeconds,
+        uint256 _startPrice,
+        uint256 _basePrice
+    );
+
+    /// Auction details cleared for project `projectId`.
+    event ResetAuctionDetails(uint256 indexed projectId);
+
+    /// Maximum and minimum allowed price decay half lifes updated.
+    event AuctionHalfLifeRangeSecondsUpdated(
+        uint256 _minimumPriceDecayHalfLifeSeconds,
+        uint256 _maximumPriceDecayHalfLifeSeconds
+    );
+}

--- a/contracts/interfaces/0.8.x/IFilteredMinterDALinV0.sol
+++ b/contracts/interfaces/0.8.x/IFilteredMinterDALinV0.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Created By: Art Blocks Inc.
+
+import "./IFilteredMinterV0.sol";
+
+pragma solidity ^0.8.0;
+
+/**
+ * @title This interface extends the IFilteredMinterV0 interface in order to
+ * add support for linear descending auctions.
+ * @author Art Blocks Inc.
+ */
+interface IFilteredMinterDALinV0 is IFilteredMinterV0 {
+    /// Auction details updated for project `projectId`.
+    event SetAuctionDetails(
+        uint256 indexed projectId,
+        uint256 _auctionTimestampStart,
+        uint256 _auctionTimestampEnd,
+        uint256 _startPrice,
+        uint256 _basePrice
+    );
+
+    /// Auction details cleared for project `projectId`.
+    event ResetAuctionDetails(uint256 indexed projectId);
+
+    /// Minimum allowed auction length updated
+    event MinimumAuctionLengthSecondsUpdated(
+        uint256 _minimumAuctionLengthSeconds
+    );
+}

--- a/contracts/interfaces/0.8.x/IFilteredMinterHolderV0.sol
+++ b/contracts/interfaces/0.8.x/IFilteredMinterHolderV0.sol
@@ -11,6 +11,44 @@ pragma solidity ^0.8.0;
  * @author Art Blocks Inc.
  */
 interface IFilteredMinterHolderV0 is IFilteredMinterV0 {
+    /**
+     * @notice Registered holders of NFTs at address `_NFTAddress` to be
+     * considered for minting.
+     */
+    event RegisteredNFTAddress(address indexed _NFTAddress);
+
+    /**
+     * @notice Unregistered holders of NFTs at address `_NFTAddress` to be
+     * considered for minting.
+     */
+    event UnregisteredNFTAddress(address indexed _NFTAddress);
+
+    /**
+     * @notice Allow holders of NFTs at addresses `_ownedNFTAddresses`, project
+     * IDs `_ownedNFTProjectIds` to mint on project `_projectId`.
+     * `_ownedNFTAddresses` assumed to be aligned with `_ownedNFTProjectIds`.
+     * e.g. Allows holders of project `_ownedNFTProjectIds[0]` on token
+     * contract `_ownedNFTAddresses[0]` to mint.
+     */
+    event AllowedHoldersOfProjects(
+        uint256 indexed _projectId,
+        address[] _ownedNFTAddresses,
+        uint256[] _ownedNFTProjectIds
+    );
+
+    /**
+     * @notice Remove holders of NFTs at addresses `_ownedNFTAddresses`,
+     * project IDs `_ownedNFTProjectIds` to mint on project `_projectId`.
+     * `_ownedNFTAddresses` assumed to be aligned with `_ownedNFTProjectIds`.
+     * e.g. Removes holders of project `_ownedNFTProjectIds[0]` on token
+     * contract `_ownedNFTAddresses[0]` from mint allowlist.
+     */
+    event RemovedHoldersOfProjects(
+        uint256 indexed _projectId,
+        address[] _ownedNFTAddresses,
+        uint256[] _ownedNFTProjectIds
+    );
+
     // Triggers a purchase of a token from the desired project, to the
     // TX-sending address, using owned ERC-721 NFT to claim right to purchase.
     function purchase(

--- a/contracts/interfaces/0.8.x/IFilteredMinterHolderV1.sol
+++ b/contracts/interfaces/0.8.x/IFilteredMinterHolderV1.sol
@@ -16,42 +16,4 @@ interface IFilteredMinterHolderV1 is IFilteredMinterHolderV0 {
      * address.
      */
     event DelegationRegistryUpdated(address delegationRegistryAddress);
-
-    /**
-     * @notice Registered holders of NFTs at address `_NFTAddress` to be
-     * considered for minting.
-     */
-    event RegisteredNFTAddress(address indexed _NFTAddress);
-
-    /**
-     * @notice Unregistered holders of NFTs at address `_NFTAddress` to be
-     * considered for minting.
-     */
-    event UnregisteredNFTAddress(address indexed _NFTAddress);
-
-    /**
-     * @notice Allow holders of NFTs at addresses `_ownedNFTAddresses`, project
-     * IDs `_ownedNFTProjectIds` to mint on project `_projectId`.
-     * `_ownedNFTAddresses` assumed to be aligned with `_ownedNFTProjectIds`.
-     * e.g. Allows holders of project `_ownedNFTProjectIds[0]` on token
-     * contract `_ownedNFTAddresses[0]` to mint.
-     */
-    event AllowedHoldersOfProjects(
-        uint256 indexed _projectId,
-        address[] _ownedNFTAddresses,
-        uint256[] _ownedNFTProjectIds
-    );
-
-    /**
-     * @notice Remove holders of NFTs at addresses `_ownedNFTAddresses`,
-     * project IDs `_ownedNFTProjectIds` to mint on project `_projectId`.
-     * `_ownedNFTAddresses` assumed to be aligned with `_ownedNFTProjectIds`.
-     * e.g. Removes holders of project `_ownedNFTProjectIds[0]` on token
-     * contract `_ownedNFTAddresses[0]` from mint allowlist.
-     */
-    event RemovedHoldersOfProjects(
-        uint256 indexed _projectId,
-        address[] _ownedNFTAddresses,
-        uint256[] _ownedNFTProjectIds
-    );
 }

--- a/contracts/minter-suite/Minters/MinterDAExp/MinterDAExpV2.sol
+++ b/contracts/minter-suite/Minters/MinterDAExp/MinterDAExpV2.sol
@@ -3,7 +3,7 @@
 
 import "../../../interfaces/0.8.x/IGenArt721CoreContractV3.sol";
 import "../../../interfaces/0.8.x/IMinterFilterV0.sol";
-import "../../../interfaces/0.8.x/IFilteredMinterV0.sol";
+import "../../../interfaces/0.8.x/IFilteredMinterDAExpV0.sol";
 
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/math/SafeCast.sol";
@@ -45,26 +45,8 @@ pragma solidity 0.8.17;
  * meaningfully impact price given the minimum allowable price decay rate that
  * this minter intends to support.
  */
-contract MinterDAExpV2 is ReentrancyGuard, IFilteredMinterV0 {
+contract MinterDAExpV2 is ReentrancyGuard, IFilteredMinterDAExpV0 {
     using SafeCast for uint256;
-
-    /// Auction details updated for project `projectId`.
-    event SetAuctionDetails(
-        uint256 indexed projectId,
-        uint256 _auctionTimestampStart,
-        uint256 _priceDecayHalfLifeSeconds,
-        uint256 _startPrice,
-        uint256 _basePrice
-    );
-
-    /// Auction details cleared for project `projectId`.
-    event ResetAuctionDetails(uint256 indexed projectId);
-
-    /// Maximum and minimum allowed price decay half lifes updated.
-    event AuctionHalfLifeRangeSecondsUpdated(
-        uint256 _minimumPriceDecayHalfLifeSeconds,
-        uint256 _maximumPriceDecayHalfLifeSeconds
-    );
 
     /// Core contract address this minter interacts with
     address public immutable genArt721CoreAddress;

--- a/contracts/minter-suite/Minters/MinterDALin/MinterDALinV0.sol
+++ b/contracts/minter-suite/Minters/MinterDALin/MinterDALinV0.sol
@@ -3,7 +3,7 @@
 
 import "../../../interfaces/0.8.x/IGenArt721CoreContractV1.sol";
 import "../../../interfaces/0.8.x/IMinterFilterV0.sol";
-import "../../../interfaces/0.8.x/IFilteredMinterV0.sol";
+import "../../../interfaces/0.8.x/IFilteredMinterDALinV0.sol";
 
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 
@@ -14,24 +14,7 @@ pragma solidity 0.8.9;
  * Pricing is achieved using an automated Dutch-auction mechanism.
  * @author Art Blocks Inc.
  */
-contract MinterDALinV0 is ReentrancyGuard, IFilteredMinterV0 {
-    /// Auction details updated for project `projectId`.
-    event SetAuctionDetails(
-        uint256 indexed projectId,
-        uint256 _auctionTimestampStart,
-        uint256 _auctionTimestampEnd,
-        uint256 _startPrice,
-        uint256 _basePrice
-    );
-
-    /// Auction details cleared for project `projectId`.
-    event ResetAuctionDetails(uint256 indexed projectId);
-
-    /// Minimum allowed auction length updated
-    event MinimumAuctionLengthSecondsUpdated(
-        uint256 _minimumAuctionLengthSeconds
-    );
-
+contract MinterDALinV0 is ReentrancyGuard, IFilteredMinterDALinV0 {
     /// Core contract address this minter interacts with
     address public immutable genArt721CoreAddress;
 

--- a/contracts/minter-suite/Minters/MinterHolder/MinterHolderV0.sol
+++ b/contracts/minter-suite/Minters/MinterHolder/MinterHolderV0.sol
@@ -19,44 +19,6 @@ pragma solidity 0.8.9;
  * @author Art Blocks Inc.
  */
 contract MinterHolderV0 is ReentrancyGuard, IFilteredMinterHolderV0 {
-    /**
-     * @notice Registered holders of NFTs at address `_NFTAddress` to be
-     * considered for minting.
-     */
-    event RegisteredNFTAddress(address indexed _NFTAddress);
-
-    /**
-     * @notice Unregistered holders of NFTs at address `_NFTAddress` to be
-     * considered for minting.
-     */
-    event UnregisteredNFTAddress(address indexed _NFTAddress);
-
-    /**
-     * @notice Allow holders of NFTs at addresses `_ownedNFTAddresses`, project
-     * IDs `_ownedNFTProjectIds` to mint on project `_projectId`.
-     * `_ownedNFTAddresses` assumed to be aligned with `_ownedNFTProjectIds`.
-     * e.g. Allows holders of project `_ownedNFTProjectIds[0]` on token
-     * contract `_ownedNFTAddresses[0]` to mint.
-     */
-    event AllowedHoldersOfProjects(
-        uint256 indexed _projectId,
-        address[] _ownedNFTAddresses,
-        uint256[] _ownedNFTProjectIds
-    );
-
-    /**
-     * @notice Remove holders of NFTs at addresses `_ownedNFTAddresses`,
-     * project IDs `_ownedNFTProjectIds` to mint on project `_projectId`.
-     * `_ownedNFTAddresses` assumed to be aligned with `_ownedNFTProjectIds`.
-     * e.g. Removes holders of project `_ownedNFTProjectIds[0]` on token
-     * contract `_ownedNFTAddresses[0]` from mint allowlist.
-     */
-    event RemovedHoldersOfProjects(
-        uint256 indexed _projectId,
-        address[] _ownedNFTAddresses,
-        uint256[] _ownedNFTProjectIds
-    );
-
     // add Enumerable Set methods
     using EnumerableSet for EnumerableSet.AddressSet;
 

--- a/contracts/minter-suite/Minters/MinterHolder/MinterHolderV1.sol
+++ b/contracts/minter-suite/Minters/MinterHolder/MinterHolderV1.sol
@@ -41,44 +41,6 @@ pragma solidity 0.8.17;
  * contracts that this minter integrates with.
  */
 contract MinterHolderV1 is ReentrancyGuard, IFilteredMinterHolderV0 {
-    /**
-     * @notice Registered holders of NFTs at address `_NFTAddress` to be
-     * considered for minting.
-     */
-    event RegisteredNFTAddress(address indexed _NFTAddress);
-
-    /**
-     * @notice Unregistered holders of NFTs at address `_NFTAddress` to be
-     * considered for minting.
-     */
-    event UnregisteredNFTAddress(address indexed _NFTAddress);
-
-    /**
-     * @notice Allow holders of NFTs at addresses `_ownedNFTAddresses`, project
-     * IDs `_ownedNFTProjectIds` to mint on project `_projectId`.
-     * `_ownedNFTAddresses` assumed to be aligned with `_ownedNFTProjectIds`.
-     * e.g. Allows holders of project `_ownedNFTProjectIds[0]` on token
-     * contract `_ownedNFTAddresses[0]` to mint.
-     */
-    event AllowedHoldersOfProjects(
-        uint256 indexed _projectId,
-        address[] _ownedNFTAddresses,
-        uint256[] _ownedNFTProjectIds
-    );
-
-    /**
-     * @notice Remove holders of NFTs at addresses `_ownedNFTAddresses`,
-     * project IDs `_ownedNFTProjectIds` to mint on project `_projectId`.
-     * `_ownedNFTAddresses` assumed to be aligned with `_ownedNFTProjectIds`.
-     * e.g. Removes holders of project `_ownedNFTProjectIds[0]` on token
-     * contract `_ownedNFTAddresses[0]` from mint allowlist.
-     */
-    event RemovedHoldersOfProjects(
-        uint256 indexed _projectId,
-        address[] _ownedNFTAddresses,
-        uint256[] _ownedNFTProjectIds
-    );
-
     // add Enumerable Set methods
     using EnumerableSet for EnumerableSet.AddressSet;
 


### PR DESCRIPTION
This updates/adds interfaces for all of the existing IFilteredMinters that have shared events. This should enable us to implement a single handler for common events rather than multiple events that then call a generic handler.