### PR TITLE
Add minor, internal-only changes to V3_Engine & Registry contracts

### DIFF
--- a/contracts/EngineRegistryV0.sol
+++ b/contracts/EngineRegistryV0.sol
@@ -43,7 +43,11 @@ contract EngineRegistryV0 is IEngineRegistryV0, ERC165 {
             tx.origin == deployerAddress,
             "Only allowed deployer-address TX origin"
         );
-
+        // Prevent registration of a contract by an unrelated contract
+        require(
+            msg.sender == _contractAddress || msg.sender == deployerAddress,
+            "Only call by deployerAddress or _contractAddress"
+        );
         // EFFECTS
         emit ContractRegistered(_contractAddress, _coreVersion, _coreType);
         registeredContractAddresses[_contractAddress] = true;
@@ -59,6 +63,11 @@ contract EngineRegistryV0 is IEngineRegistryV0, ERC165 {
         require(
             tx.origin == deployerAddress,
             "Only allowed deployer-address TX origin"
+        );
+        // Prevent unregistration of a contract by an unrelated contract
+        require(
+            msg.sender == _contractAddress || msg.sender == deployerAddress,
+            "Only call by deployerAddress or _contractAddress"
         );
         require(
             registeredContractAddresses[_contractAddress],

--- a/contracts/GenArt721CoreV3_Engine.sol
+++ b/contracts/GenArt721CoreV3_Engine.sol
@@ -767,10 +767,11 @@ contract GenArt721CoreV3_Engine is
             _additionalPayeeSecondarySalesPercentage
         );
         // automatically accept if no proposed addresses modifications, or if
-        // the proposal only removes payee addresses.
+        // the proposal only removes payee addresses, or if contract is set to
+        // always auto-approve.
         // store proposal hash on-chain, only if not automatic accept
-        bool automaticAccept;
-        {
+        bool automaticAccept = autoApproveArtistSplitProposals;
+        if (!automaticAccept) {
             // block scope to avoid stack too deep error
             bool artistUnchanged = _artistAddress ==
                 projectFinance.artistAddress;
@@ -785,10 +786,6 @@ contract GenArt721CoreV3_Engine is
                 additionalPrimaryUnchangedOrRemoved &&
                 additionalSecondaryUnchangedOrRemoved;
         }
-        // if `autoApproveArtistSplitProposals` is `true`, always override
-        // `automaticAccept` to be `true` as admin approvals are not
-        // expected from a process perspective.
-        automaticAccept = automaticAccept || autoApproveArtistSplitProposals;
         if (automaticAccept) {
             // clear any previously proposed values
             proposedArtistAddressesAndSplitsHash[_projectId] = bytes32(0);
@@ -1336,7 +1333,9 @@ contract GenArt721CoreV3_Engine is
     }
 
     /**
-     * @notice Returns token hash **seed** for token ID `_tokenId`.
+     * @notice Returns token hash **seed** for token ID `_tokenId`. Returns
+     * null if hash seed has not been set. The hash seed id the bytes12 value
+     * which is hashed to produce the token hash.
      * @param _tokenId Token ID to be queried.
      * @return bytes12 Token hash seed.
      * @dev token hash seed is keccak256 hashed to give the token hash


### PR DESCRIPTION
These changes are minor and in no way invalidate already-deployed V3_Engine contracts referenced in PR #415.

It may be worth the added security benefit to deploy a new EngineRegistryV0 and just add the engine contracts in PR #415 manually from the deployer wallet.

### EngineRegistryV0
The changes here prevent the case where our deployer wallet calls some unrelated, malicious contract, and the malicious contract adds/removes engine contracts from the EngineRegistry. This is a low-level vulnerability (since it could be remedied via subgraph changes), but may be worth patching and re-deploying.

### V3_Engine (Core)
Changes are limited to very minor internal nits.