### PR TITLE
Organize engine registry contracts, keep currently deployed version (V0)

### DIFF
--- a/contracts/engine-registry/EngineRegistryV0.sol
+++ b/contracts/engine-registry/EngineRegistryV0.sol
@@ -2,7 +2,7 @@
 
 pragma solidity 0.8.17;
 
-import "./interfaces/0.8.x/IEngineRegistryV0.sol";
+import "../interfaces/0.8.x/IEngineRegistryV0.sol";
 import "@openzeppelin-4.7/contracts/utils/introspection/ERC165.sol";
 
 /**
@@ -43,14 +43,10 @@ contract EngineRegistryV0 is IEngineRegistryV0, ERC165 {
             tx.origin == deployerAddress,
             "Only allowed deployer-address TX origin"
         );
-        // Prevent registration of a contract by an unrelated contract
-        require(
-            msg.sender == _contractAddress || msg.sender == deployerAddress,
-            "Only call by deployerAddress or _contractAddress"
-        );
+
         // EFFECTS
-        registeredContractAddresses[_contractAddress] = true;
         emit ContractRegistered(_contractAddress, _coreVersion, _coreType);
+        registeredContractAddresses[_contractAddress] = true;
     }
 
     /**
@@ -64,18 +60,13 @@ contract EngineRegistryV0 is IEngineRegistryV0, ERC165 {
             tx.origin == deployerAddress,
             "Only allowed deployer-address TX origin"
         );
-        // Prevent unregistration of a contract by an unrelated contract
-        require(
-            msg.sender == _contractAddress || msg.sender == deployerAddress,
-            "Only call by deployerAddress or _contractAddress"
-        );
         require(
             registeredContractAddresses[_contractAddress],
             "Only unregister already registered contracts"
         );
 
         // EFFECTS
-        registeredContractAddresses[_contractAddress] = false;
         emit ContractUnregistered(_contractAddress);
+        registeredContractAddresses[_contractAddress] = false;
     }
 }

--- a/contracts/engine-registry/future/EngineRegistryV1.sol
+++ b/contracts/engine-registry/future/EngineRegistryV1.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.17;
+
+import "../../interfaces/0.8.x/IEngineRegistryV0.sol";
+import "@openzeppelin-4.7/contracts/utils/introspection/ERC165.sol";
+
+/**
+ * @title Engine Registry contract, V1.
+ * @author Art Blocks Inc.
+ * @notice Privileged Roles and Ownership:
+ * This contract intentionally has no owners or admins, and is intended
+ * to be deployed with a permissioned `deployerAddress` that may speak
+ * to this registry. If in the future multiple deployer addresses are
+ * needed to interact with this registry, a new registry version with
+ * more complex logic should be implemented and deployed to replace this.
+ * @dev TODO This contract contains only minor security improvements relative
+ * to the V0 version, and is intended to only be deployed in the future if an
+ * upgrade to the registry is needed. The V0 version should be considered the
+ * canonical version of the registry while this future version is not yet
+ * deployed.
+ */
+contract EngineRegistryV1 is IEngineRegistryV0, ERC165 {
+    /// configuration variable (determined at time of deployment)
+    /// that determines what address may perform registration actions.
+    address internal immutable deployerAddress;
+
+    /// internal mapping for managing known list of registered contracts.
+    mapping(address => bool) internal registeredContractAddresses;
+
+    constructor() {
+        // The deployer of the registry becomes the permissioned deployer for speaking to the registry.
+        deployerAddress = tx.origin;
+    }
+
+    /**
+     * @inheritdoc IEngineRegistryV0
+     */
+    function registerContract(
+        address _contractAddress,
+        bytes32 _coreVersion,
+        bytes32 _coreType
+    ) external {
+        // CHECKS
+        // Validate against `tx.origin` rather than `msg.sender` as it is intended that this registration be
+        // performed in an automated fashion *at the time* of contract deployment for the `_contractAddress`.
+        require(
+            tx.origin == deployerAddress,
+            "Only allowed deployer-address TX origin"
+        );
+        // Prevent registration of a contract by an unrelated contract
+        require(
+            msg.sender == _contractAddress || msg.sender == deployerAddress,
+            "Only call by deployerAddress or _contractAddress"
+        );
+        // EFFECTS
+        registeredContractAddresses[_contractAddress] = true;
+        emit ContractRegistered(_contractAddress, _coreVersion, _coreType);
+    }
+
+    /**
+     * @inheritdoc IEngineRegistryV0
+     */
+    function unregisterContract(address _contractAddress) external {
+        // CHECKS
+        // Validate against `tx.origin` rather than `msg.sender` for consistency with the above approach,
+        // as we expect in usage of this contract `msg.sender == tx.origin` to be a true assessment.
+        require(
+            tx.origin == deployerAddress,
+            "Only allowed deployer-address TX origin"
+        );
+        // Prevent unregistration of a contract by an unrelated contract
+        require(
+            msg.sender == _contractAddress || msg.sender == deployerAddress,
+            "Only call by deployerAddress or _contractAddress"
+        );
+        require(
+            registeredContractAddresses[_contractAddress],
+            "Only unregister already registered contracts"
+        );
+
+        // EFFECTS
+        registeredContractAddresses[_contractAddress] = false;
+        emit ContractUnregistered(_contractAddress);
+    }
+}

--- a/contracts/engine-registry/future/readme.md
+++ b/contracts/engine-registry/future/readme.md
@@ -1,0 +1,1 @@
+This directory contains future versions of the Engine Registry contract. These are not yet deployed, but if future deployments and/or changes to the Engine Registry are required, these contracts will be used.


### PR DESCRIPTION
Don't deploy a new EngineRegistryV0 contract, and instead capture future (minor) changes in a `./future/` directory.

Deploying a new EngineRegistryV1 contract would add a decent amount of complexity to our Subgraph codebase, so opt to not deploy a new EngineRegistry contract, and instead continue to use the currently deployed EngineRegistryV0. The subgraph must be aware of a core contract immediately when it is deployed, so retroactively deploying an EngineRegistry after a core is already deployed is not a viable deployment pattern. Instead, the core contracts would need to be added to the subgraph configuration file directly.

Since EngineRegistryV1 only contains very minor security improvements relative to EngineRegistryV0, capture the new version in a `./future/` directory, and only include the improvements if a future deployment of a EngineRegistry is required.

Note that EngineRegistryV0 is reverted from changes applied in #416 to match the code as deployed on mainnet: https://etherscan.io/address/0x652490c8BB6e7ec3Fd798537D2F348D7904BBbc2#code 
(except for a new import path due to new file structure in this repo)