### PR TITLE
Improve memoization code organization in purchase sequence

### DIFF
--- a/contracts/minter-suite/Minters/MinterDAExpSettlement/MinterDAExpSettlementV0.sol
+++ b/contracts/minter-suite/Minters/MinterDAExpSettlement/MinterDAExpSettlementV0.sol
@@ -615,8 +615,8 @@ contract MinterDAExpSettlementV0 is
         Receipt storage receipt = receipts[msg.sender][_projectId];
 
         // in memory copy + update
-        uint256 netPosted = receipt.netPosted + msg.value; // <= In memory copy + update
-        uint256 numPurchased = receipt.numPurchased + 1; // <= In memory copy + update
+        uint256 netPosted = receipt.netPosted + msg.value;
+        uint256 numPurchased = receipt.numPurchased + 1;
 
         // require sufficient payment on project
         require(
@@ -711,12 +711,12 @@ contract MinterDAExpSettlementV0 is
     ) public nonReentrant {
         ProjectConfig storage _projectConfig = projectConfig[_projectId];
         Receipt storage receipt = receipts[msg.sender][_projectId];
-        uint256 receiptNumPurchased = receipt.numPurchased;
+        uint256 numPurchased = receipt.numPurchased;
         // CHECKS
         // input validation
         require(_to != address(0), "No claiming to the zero address");
         // require that a user has purchased at least one token on this project
-        require(receiptNumPurchased > 0, "No purchases made by this address");
+        require(numPurchased > 0, "No purchases made by this address");
         // get the latestPurchasePrice, which returns the sellout price if the
         // auction sold out before reaching base price, or returns the base
         // price if auction has reached base price and artist has withdrawn
@@ -729,18 +729,16 @@ contract MinterDAExpSettlementV0 is
         // EFFECTS
         // calculate the excess settlement funds amount
         // implicit overflow/underflow checks in solidity ^0.8
-        uint256 requiredAmountPosted = receiptNumPurchased *
-            currentSettledTokenPrice;
+        uint256 requiredAmountPosted = numPurchased * currentSettledTokenPrice;
         uint256 excessSettlementFunds = receipt.netPosted -
             requiredAmountPosted;
-        // reduce the netPosted (in storage) to value after excess settlement is
-        // deducted
+        // update Receipt in storage
         receipt.netPosted = requiredAmountPosted.toUint232();
         // emit event indicating new receipt state
         emit ReceiptUpdated(
             msg.sender,
             _projectId,
-            receiptNumPurchased,
+            numPurchased,
             requiredAmountPosted
         );
 
@@ -806,13 +804,10 @@ contract MinterDAExpSettlementV0 is
             uint256 projectId = _projectIds[i];
             ProjectConfig storage _projectConfig = projectConfig[projectId];
             Receipt storage receipt = receipts[msg.sender][projectId];
-            uint256 receiptNumPurchased = receipt.numPurchased;
+            uint256 numPurchased = receipt.numPurchased;
             // input validation
             // require that a user has purchased at least one token on this project
-            require(
-                receiptNumPurchased > 0,
-                "No purchases made by this address"
-            );
+            require(numPurchased > 0, "No purchases made by this address");
             // get the latestPurchasePrice, which returns the sellout price if the
             // auction sold out before reaching base price, or returns the base
             // price if auction has reached base price and artist has withdrawn
@@ -824,7 +819,7 @@ contract MinterDAExpSettlementV0 is
                 .latestPurchasePrice;
             // calculate the excessSettlementFunds amount
             // implicit overflow/underflow checks in solidity ^0.8
-            uint256 requiredAmountPosted = receiptNumPurchased *
+            uint256 requiredAmountPosted = numPurchased *
                 currentSettledTokenPrice;
             excessSettlementFunds += (receipt.netPosted - requiredAmountPosted);
             // reduce the netPosted (in storage) to value after excess settlement
@@ -834,7 +829,7 @@ contract MinterDAExpSettlementV0 is
             emit ReceiptUpdated(
                 msg.sender,
                 projectId,
-                receiptNumPurchased,
+                numPurchased,
                 requiredAmountPosted
             );
             // gas efficiently increment i

--- a/test/minter-suite-minters/DA/MinterDAExpSettlement/MinterDAExpSettlementV0.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExpSettlement/MinterDAExpSettlementV0.test.ts
@@ -176,7 +176,7 @@ for (const coreContractName of coreContractsToTest) {
           "ETH"
         );
         expect(txCost.toString()).to.equal(
-          ethers.utils.parseEther("0.0159205")
+          ethers.utils.parseEther("0.0158702")
         ); // assuming a cost of 100 GWEI
       });
     });


### PR DESCRIPTION
Implement some additional code-review refactoring thanks to feedback from Opcodes in DA w/Settlement minter.

This very slightly decreases average mint gas costs. The reduction is due to a change away from safe-casting `receipt.netPosted` and `receipt.numPurchased`, and instead relying on how they are being used to ensure overflow will not occur while casting to shortened uint types.