### PR TITLE
Bug fix on MinterHolder

### DIFF
--- a/contracts/minter-suite/Minters/MinterHolder/MinterHolderV2.sol
+++ b/contracts/minter-suite/Minters/MinterHolder/MinterHolderV2.sol
@@ -55,7 +55,7 @@ pragma solidity 0.8.17;
  * Delegations must be configured by the vault owner prior to purchase. Supported
  * delegation types include token-level, contract-level (via genArt721CoreAddress), or
  * wallet-level delegation. Contract-level delegations must be configured for the core
- * token contract as returned by the public immutable variable `genArt721CoreAddress`.
+ * token contract as returned by owned token's core contract address.
  */
 contract MinterHolderV2 is ReentrancyGuard, IFilteredMinterHolderV1 {
     // add Enumerable Set methods
@@ -599,7 +599,7 @@ contract MinterHolderV2 is ReentrancyGuard, IFilteredMinterHolderV1 {
                 .checkDelegateForToken(
                     msg.sender, // delegate
                     _vault, // vault
-                    genArt721CoreAddress, // contract
+                    _ownedNFTAddress, // contract
                     _ownedNFTTokenId // tokenId
                 );
             require(isValidVault, "Invalid delegate-vault pairing");

--- a/contracts/minter-suite/Minters/MinterHolder/MinterHolderV3.sol
+++ b/contracts/minter-suite/Minters/MinterHolder/MinterHolderV3.sol
@@ -57,7 +57,7 @@ pragma solidity 0.8.17;
  * Delegations must be configured by the vault owner prior to purchase. Supported
  * delegation types include token-level, contract-level (via genArt721CoreAddress), or
  * wallet-level delegation. Contract-level delegations must be configured for the core
- * token contract as returned by the public immutable variable `genArt721CoreAddress`.
+ * token contract as returned by owned token's core contract address.
  */
 contract MinterHolderV3 is ReentrancyGuard, IFilteredMinterHolderV2 {
     // add Enumerable Set methods
@@ -648,7 +648,7 @@ contract MinterHolderV3 is ReentrancyGuard, IFilteredMinterHolderV2 {
                 .checkDelegateForToken(
                     msg.sender, // delegate
                     _vault, // vault
-                    genArt721CoreAddress, // contract
+                    _ownedNFTAddress, // contract
                     _ownedNFTTokenId // tokenId
                 );
             require(isValidVault, "Invalid delegate-vault pairing");


### PR DESCRIPTION
## Description of the change

Delegation registry logic is updated to check delegation for owned token's core contract instead of tokenID on minter's core contract. This is limited to the MinterHolder logic only (MinterMerkle is unaffected)

This contract has not been deployed to mainnet, so no further action is required.

Please triple-check this updated logic to ensure this is the desired logic 🙏 