### PR TITLE
use appropriate DALin Interface in minters

### DIFF
--- a/contracts/minter-suite/Minters/MinterDALin/MinterDALinV2.sol
+++ b/contracts/minter-suite/Minters/MinterDALin/MinterDALinV2.sol
@@ -3,7 +3,7 @@
 
 import "../../../interfaces/0.8.x/IGenArt721CoreContractV3.sol";
 import "../../../interfaces/0.8.x/IMinterFilterV0.sol";
-import "../../../interfaces/0.8.x/IFilteredMinterV0.sol";
+import "../../../interfaces/0.8.x/IFilteredMinterDALinV0.sol";
 
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/math/SafeCast.sol";
@@ -45,25 +45,8 @@ pragma solidity 0.8.17;
  * meaningfully impact price given the minimum allowable price decay rate that
  * this minter intends to support.
  */
-contract MinterDALinV2 is ReentrancyGuard, IFilteredMinterV0 {
+contract MinterDALinV2 is ReentrancyGuard, IFilteredMinterDALinV0 {
     using SafeCast for uint256;
-
-    /// Auction details updated for project `projectId`.
-    event SetAuctionDetails(
-        uint256 indexed projectId,
-        uint256 _auctionTimestampStart,
-        uint256 _auctionTimestampEnd,
-        uint256 _startPrice,
-        uint256 _basePrice
-    );
-
-    /// Auction details cleared for project `projectId`.
-    event ResetAuctionDetails(uint256 indexed projectId);
-
-    /// Minimum allowed auction length updated
-    event MinimumAuctionLengthSecondsUpdated(
-        uint256 _minimumAuctionLengthSeconds
-    );
 
     /// Core contract address this minter interacts with
     address public immutable genArt721CoreAddress;

--- a/contracts/minter-suite/Minters/MinterDALin/MinterDALinV3.sol
+++ b/contracts/minter-suite/Minters/MinterDALin/MinterDALinV3.sol
@@ -3,7 +3,7 @@
 
 import "../../../interfaces/0.8.x/IGenArt721CoreContractV3.sol";
 import "../../../interfaces/0.8.x/IMinterFilterV0.sol";
-import "../../../interfaces/0.8.x/IFilteredMinterV2.sol";
+import "../../../interfaces/0.8.x/IFilteredMinterDALinV1.sol";
 
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/math/SafeCast.sol";
@@ -47,25 +47,8 @@ pragma solidity 0.8.17;
  * meaningfully impact price given the minimum allowable price decay rate that
  * this minter intends to support.
  */
-contract MinterDALinV3 is ReentrancyGuard, IFilteredMinterV2 {
+contract MinterDALinV3 is ReentrancyGuard, IFilteredMinterDALinV1 {
     using SafeCast for uint256;
-
-    /// Auction details updated for project `projectId`.
-    event SetAuctionDetails(
-        uint256 indexed projectId,
-        uint256 _auctionTimestampStart,
-        uint256 _auctionTimestampEnd,
-        uint256 _startPrice,
-        uint256 _basePrice
-    );
-
-    /// Auction details cleared for project `projectId`.
-    event ResetAuctionDetails(uint256 indexed projectId);
-
-    /// Minimum allowed auction length updated
-    event MinimumAuctionLengthSecondsUpdated(
-        uint256 _minimumAuctionLengthSeconds
-    );
 
     /// Core contract address this minter interacts with
     address public immutable genArt721CoreAddress;


### PR DESCRIPTION
## Description of the change

Refactor DALin active minters to use appropriate interfaces, ensuring that all events are defined in the interfaces instead of the minter contract itself.

This is something that must have been unintentionally missed when writing DALinV2, because the Interfaces were already appropriately created, but were not being used.

This is a refactor and does not affect minter logic. It is implemented to clean up some of the subgraph work.

Cc @lyaunzbe 
