### PR TITLE
archive n-1 minters, move active minters into single directory

### DIFF
--- a/contracts/archive/minter-suite/Minters/MinterHolder/MinterHolderV3.sol
+++ b/contracts/archive/minter-suite/Minters/MinterHolder/MinterHolderV3.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Created By: Art Blocks Inc.
 
-import "../../../interfaces/0.8.x/IGenArt721CoreContractV3.sol";
-import "../../../interfaces/0.8.x/IMinterFilterV0.sol";
-import "../../../interfaces/0.8.x/IFilteredMinterHolderV2.sol";
-import "../../../interfaces/0.8.x/IDelegationRegistry.sol";
+import "../../../../interfaces/0.8.x/IGenArt721CoreContractV3.sol";
+import "../../../../interfaces/0.8.x/IMinterFilterV0.sol";
+import "../../../../interfaces/0.8.x/IFilteredMinterHolderV2.sol";
+import "../../../../interfaces/0.8.x/IDelegationRegistry.sol";
 
 import "@openzeppelin-4.5/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin-4.5/contracts/token/ERC20/IERC20.sol";

--- a/contracts/archive/minter-suite/Minters/MinterMerkle/MinterMerkleV4.sol
+++ b/contracts/archive/minter-suite/Minters/MinterMerkle/MinterMerkleV4.sol
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Created By: Art Blocks Inc.
 
-import "../../../interfaces/0.8.x/IGenArt721CoreContractV3_Base.sol";
-import "../../../interfaces/0.8.x/IMinterFilterV0.sol";
-import "../../../interfaces/0.8.x/IFilteredMinterMerkleV2.sol";
-import "../../../interfaces/0.8.x/IDelegationRegistry.sol";
-import "../MinterBase_v0_1_1.sol";
+import "../../../../interfaces/0.8.x/IGenArt721CoreContractV3.sol";
+import "../../../../interfaces/0.8.x/IMinterFilterV0.sol";
+import "../../../../interfaces/0.8.x/IFilteredMinterMerkleV2.sol";
+import "../../../../interfaces/0.8.x/IDelegationRegistry.sol";
 
 import "@openzeppelin-4.7/contracts/utils/cryptography/MerkleProof.sol";
 import "@openzeppelin-4.7/contracts/token/ERC20/IERC20.sol";
@@ -16,8 +15,7 @@ pragma solidity 0.8.17;
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH
  * for addresses in a Merkle allowlist.
- * This is designed to be used with GenArt721CoreContractV3 flagship or
- * engine contracts.
+ * This is designed to be used with IGenArt721CoreContractV3 contracts.
  * @author Art Blocks Inc.
  * @notice Privileged Roles and Ownership:
  * This contract is designed to be managed, with limited powers.
@@ -51,11 +49,7 @@ pragma solidity 0.8.17;
  * level delegations must be configured for the core token contract as returned
  * by the public immutable variable `genArt721CoreAddress`.
  */
-contract MinterMerkleV5 is
-    ReentrancyGuard,
-    MinterBase,
-    IFilteredMinterMerkleV2
-{
+contract MinterMerkleV4 is ReentrancyGuard, IFilteredMinterMerkleV2 {
     using MerkleProof for bytes32[];
 
     /// Delegation registry address
@@ -67,8 +61,8 @@ contract MinterMerkleV5 is
     /// Core contract address this minter interacts with
     address public immutable genArt721CoreAddress;
 
-    /// The core contract integrates with V3 contracts
-    IGenArt721CoreContractV3_Base private immutable genArtCoreContract_Base;
+    /// This contract handles cores with interface IV3
+    IGenArt721CoreContractV3 private immutable genArtCoreContract;
 
     /// Minter filter address this minter interacts with
     address public immutable minterFilterAddress;
@@ -77,7 +71,7 @@ contract MinterMerkleV5 is
     IMinterFilterV0 private immutable minterFilter;
 
     /// minterType for this minter
-    string public constant minterType = "MinterMerkleV5";
+    string public constant minterType = "MinterMerkleV4";
 
     /// project minter configuration keys used by this minter
     bytes32 private constant CONFIG_MERKLE_ROOT = "merkleRoot";
@@ -115,7 +109,7 @@ contract MinterMerkleV5 is
     modifier onlyArtist(uint256 _projectId) {
         require(
             msg.sender ==
-                genArtCoreContract_Base.projectIdToArtistAddress(_projectId),
+                genArtCoreContract.projectIdToArtistAddress(_projectId),
             "Only Artist"
         );
         _;
@@ -136,13 +130,9 @@ contract MinterMerkleV5 is
         address _genArt721Address,
         address _minterFilter,
         address _delegationRegistryAddress
-    ) ReentrancyGuard() MinterBase(_genArt721Address) {
+    ) ReentrancyGuard() {
         genArt721CoreAddress = _genArt721Address;
-        // always populate immutable engine contracts, but only use appropriate
-        // interface based on isEngine in the rest of the contract
-        genArtCoreContract_Base = IGenArt721CoreContractV3_Base(
-            _genArt721Address
-        );
+        genArtCoreContract = IGenArt721CoreContractV3(_genArt721Address);
         delegationRegistryAddress = _delegationRegistryAddress;
         emit DelegationRegistryUpdated(_delegationRegistryAddress);
         delegationRegistryContract = IDelegationRegistry(
@@ -255,7 +245,7 @@ contract MinterMerkleV5 is
     ) external onlyArtist(_projectId) {
         uint256 maxInvocations;
         uint256 invocations;
-        (invocations, maxInvocations, , , , ) = genArtCoreContract_Base
+        (invocations, maxInvocations, , , , ) = genArtCoreContract
             .projectStateData(_projectId);
         // update storage with results
         projectConfig[_projectId].maxInvocations = uint24(maxInvocations);
@@ -289,7 +279,7 @@ contract MinterMerkleV5 is
         // ensure that the manually set maxInvocations is not greater than what is set on the core contract
         uint256 maxInvocations;
         uint256 invocations;
-        (invocations, maxInvocations, , , , ) = genArtCoreContract_Base
+        (invocations, maxInvocations, , , , ) = genArtCoreContract
             .projectStateData(_projectId);
         require(
             _maxInvocations <= maxInvocations,
@@ -485,10 +475,10 @@ contract MinterMerkleV5 is
         );
 
         // load price of token into memory
-        uint256 pricePerTokenInWei = _projectConfig.pricePerTokenInWei;
+        uint256 _pricePerTokenInWei = _projectConfig.pricePerTokenInWei;
 
         require(
-            msg.value >= pricePerTokenInWei,
+            msg.value >= _pricePerTokenInWei,
             "Must send minimum value to mint!"
         );
 
@@ -560,9 +550,64 @@ contract MinterMerkleV5 is
         }
 
         // INTERACTIONS
-        splitFundsETH(_projectId, pricePerTokenInWei, genArt721CoreAddress);
+        _splitFundsETH(_projectId, _pricePerTokenInWei);
 
         return tokenId;
+    }
+
+    /**
+     * @dev splits ETH funds between sender (if refund), foundation,
+     * artist, and artist's additional payee for a token purchased on
+     * project `_projectId`.
+     * @dev possible DoS during splits is acknowledged, and mitigated by
+     * business practices, including end-to-end testing on mainnet, and
+     * admin-accepted artist payment addresses.
+     */
+    function _splitFundsETH(
+        uint256 _projectId,
+        uint256 _pricePerTokenInWei
+    ) internal {
+        if (msg.value > 0) {
+            bool success_;
+            // send refund to sender
+            uint256 refund = msg.value - _pricePerTokenInWei;
+            if (refund > 0) {
+                (success_, ) = msg.sender.call{value: refund}("");
+                require(success_, "Refund failed");
+            }
+            // split remaining funds between foundation, artist, and artist's
+            // additional payee
+            (
+                uint256 artblocksRevenue_,
+                address payable artblocksAddress_,
+                uint256 artistRevenue_,
+                address payable artistAddress_,
+                uint256 additionalPayeePrimaryRevenue_,
+                address payable additionalPayeePrimaryAddress_
+            ) = genArtCoreContract.getPrimaryRevenueSplits(
+                    _projectId,
+                    _pricePerTokenInWei
+                );
+            // Art Blocks payment
+            if (artblocksRevenue_ > 0) {
+                (success_, ) = artblocksAddress_.call{value: artblocksRevenue_}(
+                    ""
+                );
+                require(success_, "Art Blocks payment failed");
+            }
+            // artist payment
+            if (artistRevenue_ > 0) {
+                (success_, ) = artistAddress_.call{value: artistRevenue_}("");
+                require(success_, "Artist payment failed");
+            }
+            // additional payee payment
+            if (additionalPayeePrimaryRevenue_ > 0) {
+                (success_, ) = additionalPayeePrimaryAddress_.call{
+                    value: additionalPayeePrimaryRevenue_
+                }("");
+                require(success_, "Additional Payee payment failed");
+            }
+        }
     }
 
     /**

--- a/contracts/archive/minter-suite/Minters/MinterSetPrice/MinterSetPriceV3.sol
+++ b/contracts/archive/minter-suite/Minters/MinterSetPrice/MinterSetPriceV3.sol
@@ -1,55 +1,35 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Created By: Art Blocks Inc.
 
-import "../../../interfaces/0.8.x/IGenArt721CoreContractV3.sol";
-import "../../../interfaces/0.8.x/IMinterFilterV0.sol";
-import "../../../interfaces/0.8.x/IFilteredMinterDAExpV1.sol";
+import "../../../../interfaces/0.8.x/IGenArt721CoreContractV3.sol";
+import "../../../../interfaces/0.8.x/IMinterFilterV0.sol";
+import "../../../../interfaces/0.8.x/IFilteredMinterV2.sol";
 
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
-import "@openzeppelin-4.5/contracts/utils/math/SafeCast.sol";
 
 pragma solidity 0.8.17;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.
- * Pricing is achieved using an automated Dutch-auction mechanism.
  * This is designed to be used with IGenArt721CoreContractV3 contracts.
  * @author Art Blocks Inc.
  * @notice Privileged Roles and Ownership:
  * This contract is designed to be managed, with limited powers.
- * Privileged roles and abilities are controlled by the core contract's Admin
- * ACL contract and a project's artist. Both of these roles hold extensive
- * power and can modify minter details.
+ * Privileged roles and abilities are controlled by the project's artist, which
+ * can be modified by the core contract's Admin ACL contract. Both of these
+ * roles hold extensive power and can modify minter details.
  * Care must be taken to ensure that the admin ACL contract and artist
  * addresses are secure behind a multi-sig or other access control mechanism.
  * ----------------------------------------------------------------------------
- * The following functions are restricted to the core contract's Admin ACL
- * contract:
- * - setAllowablePriceDecayHalfLifeRangeSeconds (note: this range is only
- *   enforced when creating new auctions)
- * - resetAuctionDetails (note: this will prevent minting until a new auction
- *   is created)
- * ----------------------------------------------------------------------------
  * The following functions are restricted to a project's artist:
- * - setAuctionDetails (note: this may only be called when there is no active
- *   auction)
+ * - updatePricePerTokenInWei
  * - setProjectMaxInvocations
  * - manuallyLimitProjectMaxInvocations
  * ----------------------------------------------------------------------------
  * Additional admin and artist privileged roles may be described on other
  * contracts that this minter integrates with.
- *
- * @dev Note that while this minter makes use of `block.timestamp` and it is
- * technically possible that this value is manipulated by block producers, such
- * manipulation will not have material impact on the price values of this minter
- * given the business practices for how pricing is congfigured for this minter
- * and that variations on the order of less than a minute should not
- * meaningfully impact price given the minimum allowable price decay rate that
- * this minter intends to support.
  */
-contract MinterDAExpV3 is ReentrancyGuard, IFilteredMinterDAExpV1 {
-    using SafeCast for uint256;
-
+contract MinterSetPriceV3 is ReentrancyGuard, IFilteredMinterV2 {
     /// Core contract address this minter interacts with
     address public immutable genArt721CoreAddress;
 
@@ -63,47 +43,23 @@ contract MinterDAExpV3 is ReentrancyGuard, IFilteredMinterDAExpV1 {
     IMinterFilterV0 private immutable minterFilter;
 
     /// minterType for this minter
-    string public constant minterType = "MinterDAExpV3";
+    string public constant minterType = "MinterSetPriceV3";
 
     uint256 constant ONE_MILLION = 1_000_000;
 
     struct ProjectConfig {
         bool maxHasBeenInvoked;
+        bool priceIsConfigured;
         uint24 maxInvocations;
-        // max uint64 ~= 1.8e19 sec ~= 570 billion years
-        uint64 timestampStart;
-        uint64 priceDecayHalfLifeSeconds;
-        uint256 startPrice;
-        uint256 basePrice;
+        uint256 pricePerTokenInWei;
     }
 
     mapping(uint256 => ProjectConfig) public projectConfig;
 
-    /// Minimum price decay half life: price must decay with a half life of at
-    /// least this amount (must cut in half at least every N seconds).
-    uint256 public minimumPriceDecayHalfLifeSeconds = 300; // 5 minutes
-    /// Maximum price decay half life: price may decay with a half life of no
-    /// more than this amount (may cut in half at no more than every N seconds).
-    uint256 public maximumPriceDecayHalfLifeSeconds = 3600; // 60 minutes
-
-    // modifier to restrict access to only AdminACL allowed calls
-    // @dev defers which ACL contract is used to the core contract
-    modifier onlyCoreAdminACL(bytes4 _selector) {
-        require(
-            genArtCoreContract.adminACLAllowed(
-                msg.sender,
-                address(this),
-                _selector
-            ),
-            "Only Core AdminACL allowed"
-        );
-        _;
-    }
-
     modifier onlyArtist(uint256 _projectId) {
         require(
-            (msg.sender ==
-                genArtCoreContract.projectIdToArtistAddress(_projectId)),
+            msg.sender ==
+                genArtCoreContract.projectIdToArtistAddress(_projectId),
             "Only Artist"
         );
         _;
@@ -115,8 +71,8 @@ contract MinterDAExpV3 is ReentrancyGuard, IFilteredMinterDAExpV1 {
      * at address `_genArt721Address`.
      * @param _genArt721Address Art Blocks core contract address for
      * which this contract will be a minter.
-     * @param _minterFilter Minter filter for which
-     * this will a filtered minter.
+     * @param _minterFilter Minter filter for which this will be a
+     * filtered minter.
      */
     constructor(
         address _genArt721Address,
@@ -146,7 +102,6 @@ contract MinterDAExpV3 is ReentrancyGuard, IFilteredMinterDAExpV1 {
         uint256 invocations;
         (invocations, maxInvocations, , , , ) = genArtCoreContract
             .projectStateData(_projectId);
-
         // update storage with results
         projectConfig[_projectId].maxInvocations = uint24(maxInvocations);
 
@@ -189,6 +144,7 @@ contract MinterDAExpV3 is ReentrancyGuard, IFilteredMinterDAExpV1 {
             _maxInvocations >= invocations,
             "Cannot set project max invocations to less than current invocations"
         );
+
         // EFFECTS
         // update storage with results
         projectConfig[_projectId].maxInvocations = uint24(_maxInvocations);
@@ -222,7 +178,6 @@ contract MinterDAExpV3 is ReentrancyGuard, IFilteredMinterDAExpV1 {
      * to be reduced, not increased. Based on this rationale, we intentionally
      * do not do input validation in this method as to whether or not the input
      * `_projectId` is an existing project ID.
-     *
      */
     function projectMaxHasBeenInvoked(
         uint256 _projectId
@@ -255,136 +210,20 @@ contract MinterDAExpV3 is ReentrancyGuard, IFilteredMinterDAExpV1 {
     }
 
     /**
-     * @notice projectId => auction parameters
-     */
-    function projectAuctionParameters(
-        uint256 _projectId
-    )
-        external
-        view
-        returns (
-            uint256 timestampStart,
-            uint256 priceDecayHalfLifeSeconds,
-            uint256 startPrice,
-            uint256 basePrice
-        )
-    {
-        ProjectConfig storage _projectConfig = projectConfig[_projectId];
-        return (
-            _projectConfig.timestampStart,
-            _projectConfig.priceDecayHalfLifeSeconds,
-            _projectConfig.startPrice,
-            _projectConfig.basePrice
-        );
-    }
-
-    /**
-     * @notice Sets the minimum and maximum values that are settable for
-     * `_priceDecayHalfLifeSeconds` across all projects.
-     * @param _minimumPriceDecayHalfLifeSeconds Minimum price decay half life
-     * (in seconds).
-     * @param _maximumPriceDecayHalfLifeSeconds Maximum price decay half life
-     * (in seconds).
-     */
-    function setAllowablePriceDecayHalfLifeRangeSeconds(
-        uint256 _minimumPriceDecayHalfLifeSeconds,
-        uint256 _maximumPriceDecayHalfLifeSeconds
-    )
-        external
-        onlyCoreAdminACL(
-            this.setAllowablePriceDecayHalfLifeRangeSeconds.selector
-        )
-    {
-        require(
-            _maximumPriceDecayHalfLifeSeconds >
-                _minimumPriceDecayHalfLifeSeconds,
-            "Maximum half life must be greater than minimum"
-        );
-        require(
-            _minimumPriceDecayHalfLifeSeconds > 0,
-            "Half life of zero not allowed"
-        );
-        minimumPriceDecayHalfLifeSeconds = _minimumPriceDecayHalfLifeSeconds;
-        maximumPriceDecayHalfLifeSeconds = _maximumPriceDecayHalfLifeSeconds;
-        emit AuctionHalfLifeRangeSecondsUpdated(
-            _minimumPriceDecayHalfLifeSeconds,
-            _maximumPriceDecayHalfLifeSeconds
-        );
-    }
-
-    ////// Auction Functions
-    /**
-     * @notice Sets auction details for project `_projectId`.
-     * @param _projectId Project ID to set auction details for.
-     * @param _auctionTimestampStart Timestamp at which to start the auction.
-     * @param _priceDecayHalfLifeSeconds The half life with which to decay the
-     *  price (in seconds).
-     * @param _startPrice Price at which to start the auction, in Wei.
-     * @param _basePrice Resting price of the auction, in Wei.
+     * @notice Updates this minter's price per token of project `_projectId`
+     * to be '_pricePerTokenInWei`, in Wei.
+     * This price supersedes any legacy core contract price per token value.
      * @dev Note that it is intentionally supported here that the configured
      * price may be explicitly set to `0`.
      */
-    function setAuctionDetails(
+    function updatePricePerTokenInWei(
         uint256 _projectId,
-        uint256 _auctionTimestampStart,
-        uint256 _priceDecayHalfLifeSeconds,
-        uint256 _startPrice,
-        uint256 _basePrice
+        uint256 _pricePerTokenInWei
     ) external onlyArtist(_projectId) {
-        // CHECKS
         ProjectConfig storage _projectConfig = projectConfig[_projectId];
-        require(
-            _projectConfig.timestampStart == 0 ||
-                block.timestamp < _projectConfig.timestampStart,
-            "No modifications mid-auction"
-        );
-        require(
-            block.timestamp < _auctionTimestampStart,
-            "Only future auctions"
-        );
-        require(
-            _startPrice > _basePrice,
-            "Auction start price must be greater than auction end price"
-        );
-        require(
-            (_priceDecayHalfLifeSeconds >= minimumPriceDecayHalfLifeSeconds) &&
-                (_priceDecayHalfLifeSeconds <=
-                    maximumPriceDecayHalfLifeSeconds),
-            "Price decay half life must fall between min and max allowable values"
-        );
-        // EFFECTS
-        _projectConfig.timestampStart = _auctionTimestampStart.toUint64();
-        _projectConfig.priceDecayHalfLifeSeconds = _priceDecayHalfLifeSeconds
-            .toUint64();
-        _projectConfig.startPrice = _startPrice;
-        _projectConfig.basePrice = _basePrice;
-
-        emit SetAuctionDetails(
-            _projectId,
-            _auctionTimestampStart,
-            _priceDecayHalfLifeSeconds,
-            _startPrice,
-            _basePrice
-        );
-    }
-
-    /**
-     * @notice Resets auction details for project `_projectId`, zero-ing out all
-     * relevant auction fields. Not intended to be used in normal auction
-     * operation, but rather only in case of the need to halt an auction.
-     * @param _projectId Project ID to set auction details for.
-     */
-    function resetAuctionDetails(
-        uint256 _projectId
-    ) external onlyCoreAdminACL(this.resetAuctionDetails.selector) {
-        ProjectConfig storage _projectConfig = projectConfig[_projectId];
-        // reset to initial values
-        _projectConfig.timestampStart = 0;
-        _projectConfig.priceDecayHalfLifeSeconds = 0;
-        _projectConfig.startPrice = 0;
-        _projectConfig.basePrice = 0;
-
-        emit ResetAuctionDetails(_projectId);
+        _projectConfig.pricePerTokenInWei = _pricePerTokenInWei;
+        _projectConfig.priceIsConfigured = true;
+        emit PricePerTokenInWeiUpdated(_projectId, _pricePerTokenInWei);
     }
 
     /**
@@ -444,10 +283,14 @@ contract MinterDAExpV3 is ReentrancyGuard, IFilteredMinterDAExpV1 {
             "Maximum number of invocations reached"
         );
 
-        // _getPrice reverts if auction is unconfigured or has not started
-        uint256 currentPriceInWei = _getPrice(_projectId);
+        // require artist to have configured price of token on this minter
+        require(_projectConfig.priceIsConfigured, "Price not configured");
+
+        // load price of token into memory
+        uint256 _pricePerTokenInWei = _projectConfig.pricePerTokenInWei;
+
         require(
-            msg.value >= currentPriceInWei,
+            msg.value >= _pricePerTokenInWei,
             "Must send minimum value to mint!"
         );
 
@@ -463,7 +306,8 @@ contract MinterDAExpV3 is ReentrancyGuard, IFilteredMinterDAExpV1 {
         }
 
         // INTERACTIONS
-        _splitFundsETHAuction(_projectId, currentPriceInWei);
+        _splitFundsETH(_projectId, _pricePerTokenInWei);
+
         return tokenId;
     }
 
@@ -474,17 +318,15 @@ contract MinterDAExpV3 is ReentrancyGuard, IFilteredMinterDAExpV1 {
      * @dev possible DoS during splits is acknowledged, and mitigated by
      * business practices, including end-to-end testing on mainnet, and
      * admin-accepted artist payment addresses.
-     * @param _projectId Project ID for which funds shall be split.
-     * @param _currentPriceInWei Current price of token, in Wei.
      */
-    function _splitFundsETHAuction(
+    function _splitFundsETH(
         uint256 _projectId,
-        uint256 _currentPriceInWei
+        uint256 _pricePerTokenInWei
     ) internal {
         if (msg.value > 0) {
             bool success_;
             // send refund to sender
-            uint256 refund = msg.value - _currentPriceInWei;
+            uint256 refund = msg.value - _pricePerTokenInWei;
             if (refund > 0) {
                 (success_, ) = msg.sender.call{value: refund}("");
                 require(success_, "Refund failed");
@@ -500,7 +342,7 @@ contract MinterDAExpV3 is ReentrancyGuard, IFilteredMinterDAExpV1 {
                 address payable additionalPayeePrimaryAddress_
             ) = genArtCoreContract.getPrimaryRevenueSplits(
                     _projectId,
-                    _currentPriceInWei
+                    _pricePerTokenInWei
                 );
             // Art Blocks payment
             if (artblocksRevenue_ > 0) {
@@ -525,66 +367,14 @@ contract MinterDAExpV3 is ReentrancyGuard, IFilteredMinterDAExpV1 {
     }
 
     /**
-     * @notice Gets price of minting a token on project `_projectId` given
-     * the project's AuctionParameters and current block timestamp.
-     * Reverts if auction has not yet started or auction is unconfigured.
-     * @param _projectId Project ID to get price of token for.
-     * @return current price of token in Wei
-     * @dev This method calculates price decay using a linear interpolation
-     * of exponential decay based on the artist-provided half-life for price
-     * decay, `_priceDecayHalfLifeSeconds`.
-     */
-    function _getPrice(uint256 _projectId) private view returns (uint256) {
-        ProjectConfig storage _projectConfig = projectConfig[_projectId];
-        // move parameters to memory if used more than once
-        uint256 _timestampStart = uint256(_projectConfig.timestampStart);
-        uint256 _priceDecayHalfLifeSeconds = uint256(
-            _projectConfig.priceDecayHalfLifeSeconds
-        );
-        uint256 _basePrice = _projectConfig.basePrice;
-
-        require(block.timestamp > _timestampStart, "Auction not yet started");
-        require(_priceDecayHalfLifeSeconds > 0, "Only configured auctions");
-        uint256 decayedPrice = _projectConfig.startPrice;
-        uint256 elapsedTimeSeconds;
-        unchecked {
-            // already checked that block.timestamp > _timestampStart above
-            elapsedTimeSeconds = block.timestamp - _timestampStart;
-        }
-        // Divide by two (via bit-shifting) for the number of entirely completed
-        // half-lives that have elapsed since auction start time.
-        unchecked {
-            // already required _priceDecayHalfLifeSeconds > 0
-            decayedPrice >>= elapsedTimeSeconds / _priceDecayHalfLifeSeconds;
-        }
-        // Perform a linear interpolation between partial half-life points, to
-        // approximate the current place on a perfect exponential decay curve.
-        unchecked {
-            // value of expression is provably always less than decayedPrice,
-            // so no underflow is possible when the subtraction assignment
-            // operator is used on decayedPrice.
-            decayedPrice -=
-                (decayedPrice *
-                    (elapsedTimeSeconds % _priceDecayHalfLifeSeconds)) /
-                _priceDecayHalfLifeSeconds /
-                2;
-        }
-        if (decayedPrice < _basePrice) {
-            // Price may not decay below stay `basePrice`.
-            return _basePrice;
-        }
-        return decayedPrice;
-    }
-
-    /**
      * @notice Gets if price of token is configured, price of minting a
      * token on project `_projectId`, and currency symbol and address to be
      * used as payment. Supersedes any core contract price information.
      * @param _projectId Project ID to get price information for.
-     * @return isConfigured true only if project's auction parameters have been
-     * configured on this minter
+     * @return isConfigured true only if token price has been configured on
+     * this minter
      * @return tokenPriceInWei current price of token on this minter - invalid
-     * if auction has not yet been configured
+     * if price has not yet been configured
      * @return currencySymbol currency symbol for purchases of project on this
      * minter. This minter always returns "ETH"
      * @return currencyAddress currency address for purchases of project on
@@ -603,19 +393,8 @@ contract MinterDAExpV3 is ReentrancyGuard, IFilteredMinterDAExpV1 {
         )
     {
         ProjectConfig storage _projectConfig = projectConfig[_projectId];
-
-        isConfigured = (_projectConfig.startPrice > 0);
-        if (block.timestamp <= _projectConfig.timestampStart) {
-            // Provide a reasonable value for `tokenPriceInWei` when it would
-            // otherwise revert, using the starting price before auction starts.
-            tokenPriceInWei = _projectConfig.startPrice;
-        } else if (_projectConfig.startPrice == 0) {
-            // In the case of unconfigured auction, return price of zero when
-            // it would otherwise revert
-            tokenPriceInWei = 0;
-        } else {
-            tokenPriceInWei = _getPrice(_projectId);
-        }
+        isConfigured = _projectConfig.priceIsConfigured;
+        tokenPriceInWei = _projectConfig.pricePerTokenInWei;
         currencySymbol = "ETH";
         currencyAddress = address(0);
     }

--- a/contracts/archive/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V3.sol
+++ b/contracts/archive/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V3.sol
@@ -1,62 +1,43 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Created By: Art Blocks Inc.
 
-import "../../../interfaces/0.8.x/IGenArt721CoreContractV3_Base.sol";
-import "../../../interfaces/0.8.x/IMinterFilterV0.sol";
-import "../../../interfaces/0.8.x/IFilteredMinterDALinV1.sol";
-import "../MinterBase_v0_1_1.sol";
+import "../../../../interfaces/0.8.x/IGenArt721CoreContractV3.sol";
+import "../../../../interfaces/0.8.x/IMinterFilterV0.sol";
+import "../../../../interfaces/0.8.x/IFilteredMinterV2.sol";
 
+import "@openzeppelin-4.5/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
-import "@openzeppelin-4.5/contracts/utils/math/SafeCast.sol";
 
 pragma solidity 0.8.17;
 
 /**
- * @title Filtered Minter contract that allows tokens to be minted with ETH.
- * Pricing is achieved using an automated Dutch-auction mechanism.
- * This is designed to be used with GenArt721CoreContractV3 flagship or
- * engine contracts.
+ * @title Filtered Minter contract that allows tokens to be minted with ETH
+ * This is designed to be used with IGenArt721CoreContractV3 contracts.
+ * or any ERC-20 token.
  * @author Art Blocks Inc.
  * @notice Privileged Roles and Ownership:
  * This contract is designed to be managed, with limited powers.
- * Privileged roles and abilities are controlled by the core contract's Admin
- * ACL contract and a project's artist. Both of these roles hold extensive
- * power and can modify minter details.
+ * Privileged roles and abilities are controlled by the project's artist, which
+ * can be modified by the core contract's Admin ACL contract. Both of these
+ * roles hold extensive power and can modify minter details.
  * Care must be taken to ensure that the admin ACL contract and artist
  * addresses are secure behind a multi-sig or other access control mechanism.
  * ----------------------------------------------------------------------------
- * The following functions are restricted to the core contract's Admin ACL
- * contract:
- * - setMinimumAuctionLengthSeconds (note: this is only enforced when creating
- *   new auctions)
- * - resetAuctionDetails (note: this will prevent minting until a new auction
- *   is created)
- * ----------------------------------------------------------------------------
  * The following functions are restricted to a project's artist:
- * - setAuctionDetails (note: this may only be called when there is no active
- *   auction)
+ * - updatePricePerTokenInWei
+ * - updateProjectCurrencyInfo
  * - setProjectMaxInvocations
  * - manuallyLimitProjectMaxInvocations
  * ----------------------------------------------------------------------------
  * Additional admin and artist privileged roles may be described on other
  * contracts that this minter integrates with.
- *
- * @dev Note that while this minter makes use of `block.timestamp` and it is
- * technically possible that this value is manipulated by block producers, such
- * manipulation will not have material impact on the price values of this minter
- * given the business practices for how pricing is congfigured for this minter
- * and that variations on the order of less than a minute should not
- * meaningfully impact price given the minimum allowable price decay rate that
- * this minter intends to support.
  */
-contract MinterDALinV4 is ReentrancyGuard, MinterBase, IFilteredMinterDALinV1 {
-    using SafeCast for uint256;
-
+contract MinterSetPriceERC20V3 is ReentrancyGuard, IFilteredMinterV2 {
     /// Core contract address this minter interacts with
     address public immutable genArt721CoreAddress;
 
-    /// The core contract integrates with V3 contracts
-    IGenArt721CoreContractV3_Base private immutable genArtCoreContract_Base;
+    /// This contract handles cores with interface IV3
+    IGenArt721CoreContractV3 private immutable genArtCoreContract;
 
     /// Minter filter address this minter interacts with
     address public immutable minterFilterAddress;
@@ -65,43 +46,30 @@ contract MinterDALinV4 is ReentrancyGuard, MinterBase, IFilteredMinterDALinV1 {
     IMinterFilterV0 private immutable minterFilter;
 
     /// minterType for this minter
-    string public constant minterType = "MinterDALinV4";
+    string public constant minterType = "MinterSetPriceERC20V3";
 
     uint256 constant ONE_MILLION = 1_000_000;
 
     struct ProjectConfig {
         bool maxHasBeenInvoked;
+        bool priceIsConfigured;
         uint24 maxInvocations;
-        // max uint64 ~= 1.8e19 sec ~= 570 billion years
-        uint64 timestampStart;
-        uint64 timestampEnd;
-        uint256 startPrice;
-        uint256 basePrice;
+        address currencyAddress;
+        uint256 pricePerTokenInWei;
+        string currencySymbol;
     }
 
     mapping(uint256 => ProjectConfig) public projectConfig;
 
-    /// Minimum auction length in seconds
-    uint256 public minimumAuctionLengthSeconds = 3600;
-
-    // modifier to restrict access to only AdminACL allowed calls
-    // @dev defers which ACL contract is used to the core contract
-    modifier onlyCoreAdminACL(bytes4 _selector) {
-        require(
-            genArtCoreContract_Base.adminACLAllowed(
-                msg.sender,
-                address(this),
-                _selector
-            ),
-            "Only Core AdminACL allowed"
-        );
-        _;
-    }
+    // /// projectId => currency symbol - supersedes any defined core value
+    // mapping(uint256 => string) private projectIdToCurrencySymbol;
+    // /// projectId => currency address - supersedes any defined core value
+    // mapping(uint256 => address) private projectIdToCurrencyAddress;
 
     modifier onlyArtist(uint256 _projectId) {
         require(
-            (msg.sender ==
-                genArtCoreContract_Base.projectIdToArtistAddress(_projectId)),
+            msg.sender ==
+                genArtCoreContract.projectIdToArtistAddress(_projectId),
             "Only Artist"
         );
         _;
@@ -111,27 +79,55 @@ contract MinterDALinV4 is ReentrancyGuard, MinterBase, IFilteredMinterDALinV1 {
      * @notice Initializes contract to be a Filtered Minter for
      * `_minterFilter`, integrated with Art Blocks core contract
      * at address `_genArt721Address`.
-     * @param _genArt721Address Art Blocks core contract address for
-     * which this contract will be a minter.
+     * @param _genArt721Address Art Blocks core contract for which this
+     * contract will be a minter.
      * @param _minterFilter Minter filter for which
      * this will a filtered minter.
      */
     constructor(
         address _genArt721Address,
         address _minterFilter
-    ) ReentrancyGuard() MinterBase(_genArt721Address) {
+    ) ReentrancyGuard() {
         genArt721CoreAddress = _genArt721Address;
-        // always populate immutable engine contracts, but only use appropriate
-        // interface based on isEngine in the rest of the contract
-        genArtCoreContract_Base = IGenArt721CoreContractV3_Base(
-            _genArt721Address
-        );
+        genArtCoreContract = IGenArt721CoreContractV3(_genArt721Address);
         minterFilterAddress = _minterFilter;
         minterFilter = IMinterFilterV0(_minterFilter);
         require(
             minterFilter.genArt721CoreAddress() == _genArt721Address,
             "Illegal contract pairing"
         );
+    }
+
+    /**
+     * @notice Gets your balance of the ERC-20 token currently set
+     * as the payment currency for project `_projectId`.
+     * @param _projectId Project ID to be queried.
+     * @return balance Balance of ERC-20
+     */
+    function getYourBalanceOfProjectERC20(
+        uint256 _projectId
+    ) external view returns (uint256 balance) {
+        balance = IERC20(projectConfig[_projectId].currencyAddress).balanceOf(
+            msg.sender
+        );
+        return balance;
+    }
+
+    /**
+     * @notice Gets your allowance for this minter of the ERC-20
+     * token currently set as the payment currency for project
+     * `_projectId`.
+     * @param _projectId Project ID to be queried.
+     * @return remaining Remaining allowance of ERC-20
+     */
+    function checkYourAllowanceOfProjectERC20(
+        uint256 _projectId
+    ) external view returns (uint256 remaining) {
+        remaining = IERC20(projectConfig[_projectId].currencyAddress).allowance(
+            msg.sender,
+            address(this)
+        );
+        return remaining;
     }
 
     /**
@@ -146,7 +142,7 @@ contract MinterDALinV4 is ReentrancyGuard, MinterBase, IFilteredMinterDALinV1 {
     ) external onlyArtist(_projectId) {
         uint256 maxInvocations;
         uint256 invocations;
-        (invocations, maxInvocations, , , , ) = genArtCoreContract_Base
+        (invocations, maxInvocations, , , , ) = genArtCoreContract
             .projectStateData(_projectId);
         // update storage with results
         projectConfig[_projectId].maxInvocations = uint24(maxInvocations);
@@ -180,7 +176,7 @@ contract MinterDALinV4 is ReentrancyGuard, MinterBase, IFilteredMinterDALinV1 {
         // ensure that the manually set maxInvocations is not greater than what is set on the core contract
         uint256 maxInvocations;
         uint256 invocations;
-        (invocations, maxInvocations, , , , ) = genArtCoreContract_Base
+        (invocations, maxInvocations, , , , ) = genArtCoreContract
             .projectStateData(_projectId);
         require(
             _maxInvocations <= maxInvocations,
@@ -194,6 +190,8 @@ contract MinterDALinV4 is ReentrancyGuard, MinterBase, IFilteredMinterDALinV1 {
         // EFFECTS
         // update storage with results
         projectConfig[_projectId].maxInvocations = uint24(_maxInvocations);
+        // We need to ensure maxHasBeenInvoked is correctly set after manually setting the
+        // local maxInvocations value.
         projectConfig[_projectId].maxHasBeenInvoked =
             invocations == _maxInvocations;
 
@@ -254,114 +252,46 @@ contract MinterDALinV4 is ReentrancyGuard, MinterBase, IFilteredMinterDALinV1 {
     }
 
     /**
-     * @notice projectId => auction parameters
+     * @notice Updates this minter's price per token of project `_projectId`
+     * to be '_pricePerTokenInWei`, in Wei.
+     * This price supersedes any legacy core contract price per token value.
      */
-    function projectAuctionParameters(
-        uint256 _projectId
-    )
-        external
-        view
-        returns (
-            uint256 timestampStart,
-            uint256 timestampEnd,
-            uint256 startPrice,
-            uint256 basePrice
-        )
-    {
-        ProjectConfig storage _projectConfig = projectConfig[_projectId];
-        return (
-            _projectConfig.timestampStart,
-            _projectConfig.timestampEnd,
-            _projectConfig.startPrice,
-            _projectConfig.basePrice
-        );
-    }
-
-    /**
-     * @notice Sets minimum auction length to `_minimumAuctionLengthSeconds`
-     * for all projects.
-     * @param _minimumAuctionLengthSeconds Minimum auction length in seconds.
-     */
-    function setMinimumAuctionLengthSeconds(
-        uint256 _minimumAuctionLengthSeconds
-    ) external onlyCoreAdminACL(this.setMinimumAuctionLengthSeconds.selector) {
-        minimumAuctionLengthSeconds = _minimumAuctionLengthSeconds;
-        emit MinimumAuctionLengthSecondsUpdated(_minimumAuctionLengthSeconds);
-    }
-
-    ////// Auction Functions
-    /**
-     * @notice Sets auction details for project `_projectId`.
-     * @param _projectId Project ID to set auction details for.
-     * @param _auctionTimestampStart Timestamp at which to start the auction.
-     * @param _auctionTimestampEnd Timestamp at which to end the auction.
-     * @param _startPrice Price at which to start the auction, in Wei.
-     * @param _basePrice Resting price of the auction, in Wei.
-     * @dev Note that it is intentionally supported here that the configured
-     * price may be explicitly set to `0`.
-     */
-    function setAuctionDetails(
+    function updatePricePerTokenInWei(
         uint256 _projectId,
-        uint256 _auctionTimestampStart,
-        uint256 _auctionTimestampEnd,
-        uint256 _startPrice,
-        uint256 _basePrice
+        uint256 _pricePerTokenInWei
     ) external onlyArtist(_projectId) {
-        // CHECKS
-        ProjectConfig storage _projectConfig = projectConfig[_projectId];
-        require(
-            _projectConfig.timestampStart == 0 ||
-                block.timestamp < _projectConfig.timestampStart,
-            "No modifications mid-auction"
-        );
-        require(
-            block.timestamp < _auctionTimestampStart,
-            "Only future auctions"
-        );
-        require(
-            _auctionTimestampEnd > _auctionTimestampStart,
-            "Auction end must be greater than auction start"
-        );
-        require(
-            _auctionTimestampEnd >=
-                _auctionTimestampStart + minimumAuctionLengthSeconds,
-            "Auction length must be at least minimumAuctionLengthSeconds"
-        );
-        require(
-            _startPrice > _basePrice,
-            "Auction start price must be greater than auction end price"
-        );
-        // EFFECTS
-        _projectConfig.timestampStart = _auctionTimestampStart.toUint64();
-        _projectConfig.timestampEnd = _auctionTimestampEnd.toUint64();
-        _projectConfig.startPrice = _startPrice;
-        _projectConfig.basePrice = _basePrice;
-        emit SetAuctionDetails(
-            _projectId,
-            _auctionTimestampStart,
-            _auctionTimestampEnd,
-            _startPrice,
-            _basePrice
-        );
+        require(_pricePerTokenInWei > 0, "Price may not be 0");
+        projectConfig[_projectId].pricePerTokenInWei = _pricePerTokenInWei;
+        projectConfig[_projectId].priceIsConfigured = true;
+        emit PricePerTokenInWeiUpdated(_projectId, _pricePerTokenInWei);
     }
 
     /**
-     * @notice Resets auction details for project `_projectId`, zero-ing out all
-     * relevant auction fields. Not intended to be used in normal auction
-     * operation, but rather only in case of the need to halt an auction.
-     * @param _projectId Project ID to set auction details for.
+     * @notice Updates payment currency of project `_projectId` to be
+     * `_currencySymbol` at address `_currencyAddress`.
+     * @param _projectId Project ID to update.
+     * @param _currencySymbol Currency symbol.
+     * @param _currencyAddress Currency address.
      */
-    function resetAuctionDetails(
-        uint256 _projectId
-    ) external onlyCoreAdminACL(this.resetAuctionDetails.selector) {
-        ProjectConfig storage _projectConfig = projectConfig[_projectId];
-        // reset to initial values
-        _projectConfig.timestampStart = 0;
-        _projectConfig.timestampEnd = 0;
-        _projectConfig.startPrice = 0;
-        _projectConfig.basePrice = 0;
-
-        emit ResetAuctionDetails(_projectId);
+    function updateProjectCurrencyInfo(
+        uint256 _projectId,
+        string memory _currencySymbol,
+        address _currencyAddress
+    ) external onlyArtist(_projectId) {
+        // require null address if symbol is "ETH"
+        require(
+            (keccak256(abi.encodePacked(_currencySymbol)) ==
+                keccak256(abi.encodePacked("ETH"))) ==
+                (_currencyAddress == address(0)),
+            "ETH is only null address"
+        );
+        projectConfig[_projectId].currencySymbol = _currencySymbol;
+        projectConfig[_projectId].currencyAddress = _currencyAddress;
+        emit ProjectCurrencyInfoUpdated(
+            _projectId,
+            _currencyAddress,
+            _currencySymbol
+        );
     }
 
     /**
@@ -421,12 +351,8 @@ contract MinterDALinV4 is ReentrancyGuard, MinterBase, IFilteredMinterDALinV1 {
             "Maximum number of invocations reached"
         );
 
-        // _getPrice reverts if auction is unconfigured or has not started
-        uint256 pricePerTokenInWei = _getPrice(_projectId);
-        require(
-            msg.value >= pricePerTokenInWei,
-            "Must send minimum value to mint!"
-        );
+        // require artist to have configured price of token on this minter
+        require(_projectConfig.priceIsConfigured, "Price not configured");
 
         // EFFECTS
         tokenId = minterFilter.mint(_to, _projectId, msg.sender);
@@ -440,43 +366,140 @@ contract MinterDALinV4 is ReentrancyGuard, MinterBase, IFilteredMinterDALinV1 {
         }
 
         // INTERACTIONS
-        splitFundsETH(_projectId, pricePerTokenInWei, genArt721CoreAddress);
+        uint256 _pricePerTokenInWei = _projectConfig.pricePerTokenInWei;
+        address _currencyAddress = _projectConfig.currencyAddress;
+        if (_currencyAddress != address(0)) {
+            require(
+                msg.value == 0,
+                "this project accepts a different currency and cannot accept ETH"
+            );
+            require(
+                IERC20(_currencyAddress).allowance(msg.sender, address(this)) >=
+                    _pricePerTokenInWei,
+                "Insufficient Funds Approved for TX"
+            );
+            require(
+                IERC20(_currencyAddress).balanceOf(msg.sender) >=
+                    _pricePerTokenInWei,
+                "Insufficient balance."
+            );
+            _splitFundsERC20(_projectId, _pricePerTokenInWei, _currencyAddress);
+        } else {
+            require(
+                msg.value >= _pricePerTokenInWei,
+                "Must send minimum value to mint!"
+            );
+            _splitFundsETH(_projectId, _pricePerTokenInWei);
+        }
 
         return tokenId;
     }
 
     /**
-     * @notice Gets price of minting a token on project `_projectId` given
-     * the project's AuctionParameters and current block timestamp.
-     * Reverts if auction has not yet started or auction is unconfigured.
-     * @param _projectId Project ID to get price of token for.
-     * @return current price of token in Wei
+     * @dev splits ETH funds between sender (if refund), foundation,
+     * artist, and artist's additional payee for a token purchased on
+     * project `_projectId`.
+     * @dev possible DoS during splits is acknowledged, and mitigated by
+     * business practices, including end-to-end testing on mainnet, and
+     * admin-accepted artist payment addresses.
      */
-    function _getPrice(uint256 _projectId) private view returns (uint256) {
-        ProjectConfig storage _projectConfig = projectConfig[_projectId];
-        // move parameters to memory if used more than once
-        uint256 _timestampStart = uint256(_projectConfig.timestampStart);
-        uint256 _timestampEnd = uint256(_projectConfig.timestampEnd);
-        uint256 _startPrice = _projectConfig.startPrice;
-        uint256 _basePrice = _projectConfig.basePrice;
+    function _splitFundsETH(
+        uint256 _projectId,
+        uint256 _pricePerTokenInWei
+    ) internal {
+        if (msg.value > 0) {
+            bool success_;
+            // send refund to sender
+            uint256 refund = msg.value - _pricePerTokenInWei;
+            if (refund > 0) {
+                (success_, ) = msg.sender.call{value: refund}("");
+                require(success_, "Refund failed");
+            }
+            // split remaining funds between foundation, artist, and artist's
+            // additional payee
+            (
+                uint256 artblocksRevenue_,
+                address payable artblocksAddress_,
+                uint256 artistRevenue_,
+                address payable artistAddress_,
+                uint256 additionalPayeePrimaryRevenue_,
+                address payable additionalPayeePrimaryAddress_
+            ) = genArtCoreContract.getPrimaryRevenueSplits(
+                    _projectId,
+                    _pricePerTokenInWei
+                );
+            // Art Blocks payment
+            if (artblocksRevenue_ > 0) {
+                (success_, ) = artblocksAddress_.call{value: artblocksRevenue_}(
+                    ""
+                );
+                require(success_, "Art Blocks payment failed");
+            }
+            // artist payment
+            if (artistRevenue_ > 0) {
+                (success_, ) = artistAddress_.call{value: artistRevenue_}("");
+                require(success_, "Artist payment failed");
+            }
+            // additional payee payment
+            if (additionalPayeePrimaryRevenue_ > 0) {
+                (success_, ) = additionalPayeePrimaryAddress_.call{
+                    value: additionalPayeePrimaryRevenue_
+                }("");
+                require(success_, "Additional Payee payment failed");
+            }
+        }
+    }
 
-        require(block.timestamp > _timestampStart, "Auction not yet started");
-        if (block.timestamp >= _timestampEnd) {
-            require(_timestampEnd > 0, "Only configured auctions");
-            return _basePrice;
+    /**
+     * @dev splits ERC-20 funds between foundation, artist, and artist's
+     * additional payee, for a token purchased on project `_projectId`.
+     * @dev possible DoS during splits is acknowledged, and mitigated by
+     * business practices, including end-to-end testing on mainnet, and
+     * admin-accepted artist payment addresses.
+     */
+    function _splitFundsERC20(
+        uint256 _projectId,
+        uint256 _pricePerTokenInWei,
+        address _currencyAddress
+    ) internal {
+        // split remaining funds between foundation, artist, and artist's
+        // additional payee
+        (
+            uint256 artblocksRevenue_,
+            address payable artblocksAddress_,
+            uint256 artistRevenue_,
+            address payable artistAddress_,
+            uint256 additionalPayeePrimaryRevenue_,
+            address payable additionalPayeePrimaryAddress_
+        ) = genArtCoreContract.getPrimaryRevenueSplits(
+                _projectId,
+                _pricePerTokenInWei
+            );
+        IERC20 _projectCurrency = IERC20(_currencyAddress);
+        // Art Blocks payment
+        if (artblocksRevenue_ > 0) {
+            _projectCurrency.transferFrom(
+                msg.sender,
+                artblocksAddress_,
+                artblocksRevenue_
+            );
         }
-        uint256 elapsedTime;
-        uint256 duration;
-        uint256 startToEndDiff;
-        unchecked {
-            // already checked that block.timestamp > _timestampStart
-            elapsedTime = block.timestamp - _timestampStart;
-            // _timestampEnd > _timestampStart enforced during assignment
-            duration = _timestampEnd - _timestampStart;
-            // _startPrice > _basePrice enforced during assignment
-            startToEndDiff = _startPrice - _basePrice;
+        // artist payment
+        if (artistRevenue_ > 0) {
+            _projectCurrency.transferFrom(
+                msg.sender,
+                artistAddress_,
+                artistRevenue_
+            );
         }
-        return _startPrice - ((elapsedTime * startToEndDiff) / duration);
+        // additional payee payment
+        if (additionalPayeePrimaryRevenue_ > 0) {
+            _projectCurrency.transferFrom(
+                msg.sender,
+                additionalPayeePrimaryAddress_,
+                additionalPayeePrimaryRevenue_
+            );
+        }
     }
 
     /**
@@ -484,14 +507,14 @@ contract MinterDALinV4 is ReentrancyGuard, MinterBase, IFilteredMinterDALinV1 {
      * token on project `_projectId`, and currency symbol and address to be
      * used as payment. Supersedes any core contract price information.
      * @param _projectId Project ID to get price information for.
-     * @return isConfigured true only if project's auction parameters have been
-     * configured on this minter
+     * @return isConfigured true only if token price has been configured on
+     * this minter
      * @return tokenPriceInWei current price of token on this minter - invalid
-     * if auction has not yet been configured
+     * if price has not yet been configured
      * @return currencySymbol currency symbol for purchases of project on this
-     * minter. This minter always returns "ETH"
+     * minter. "ETH" reserved for ether.
      * @return currencyAddress currency address for purchases of project on
-     * this minter. This minter always returns null address, reserved for ether
+     * this minter. Null address reserved for ether.
      */
     function getPriceInfo(
         uint256 _projectId
@@ -506,20 +529,14 @@ contract MinterDALinV4 is ReentrancyGuard, MinterBase, IFilteredMinterDALinV1 {
         )
     {
         ProjectConfig storage _projectConfig = projectConfig[_projectId];
-
-        isConfigured = (_projectConfig.startPrice > 0);
-        if (block.timestamp <= _projectConfig.timestampStart) {
-            // Provide a reasonable value for `tokenPriceInWei` when it would
-            // otherwise revert, using the starting price before auction starts.
-            tokenPriceInWei = _projectConfig.startPrice;
-        } else if (_projectConfig.timestampEnd == 0) {
-            // In the case of unconfigured auction, return price of zero when
-            // it would otherwise revert
-            tokenPriceInWei = 0;
+        isConfigured = _projectConfig.priceIsConfigured;
+        tokenPriceInWei = _projectConfig.pricePerTokenInWei;
+        currencyAddress = _projectConfig.currencyAddress;
+        if (currencyAddress == address(0)) {
+            // defaults to ETH
+            currencySymbol = "ETH";
         } else {
-            tokenPriceInWei = _getPrice(_projectId);
+            currencySymbol = _projectConfig.currencySymbol;
         }
-        currencySymbol = "ETH";
-        currencyAddress = address(0);
     }
 }

--- a/contracts/minter-suite/Minters/MinterDAExpSettlementV1.sol
+++ b/contracts/minter-suite/Minters/MinterDAExpSettlementV1.sol
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Created By: Art Blocks Inc.
 
-import "../../../interfaces/0.8.x/IGenArt721CoreContractV3.sol";
-import "../../../interfaces/0.8.x/IMinterFilterV0.sol";
-import "../../../interfaces/0.8.x/IFilteredMinterDAExpSettlementV0.sol";
+import "../../interfaces/0.8.x/IGenArt721CoreContractV3_Base.sol";
+import "../../interfaces/0.8.x/IMinterFilterV0.sol";
+import "../../interfaces/0.8.x/IFilteredMinterDAExpSettlementV0.sol";
+import "./MinterBase_v0_1_1.sol";
 
 import "@openzeppelin-4.7/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.7/contracts/utils/math/SafeCast.sol";
@@ -14,7 +15,8 @@ pragma solidity 0.8.17;
  * @title Filtered Minter contract that allows tokens to be minted with ETH.
  * Pricing is achieved using an automated Dutch-auction mechanism, with a
  * settlement mechanism for tokens purchased before the auction ends.
- * This is designed to be used with IGenArt721CoreContractV3 contracts.
+ * This is designed to be used with GenArt721CoreContractV3 flagship or
+ * engine contracts.
  * @author Art Blocks Inc.
  * @notice Privileged Roles and Ownership:
  * This contract is designed to be managed, with limited powers.
@@ -61,17 +63,17 @@ pragma solidity 0.8.17;
  * less than a minute should not meaningfully impact price given the minimum
  * allowable price decay rate that this minter intends to support.
  */
-contract MinterDAExpSettlementV0 is
+contract MinterDAExpSettlementV1 is
     ReentrancyGuard,
+    MinterBase,
     IFilteredMinterDAExpSettlementV0
 {
     using SafeCast for uint256;
 
     /// Core contract address this minter interacts with
     address public immutable genArt721CoreAddress;
-
-    /// This contract handles cores with interface IV3
-    IGenArt721CoreContractV3 private immutable genArtCoreContract;
+    /// The core contract integrates with V3 contracts
+    IGenArt721CoreContractV3_Base private immutable genArtCoreContract_Base;
 
     /// Minter filter address this minter interacts with
     address public immutable minterFilterAddress;
@@ -80,7 +82,7 @@ contract MinterDAExpSettlementV0 is
     IMinterFilterV0 private immutable minterFilter;
 
     /// minterType for this minter
-    string public constant minterType = "MinterDAExpSettlementV0";
+    string public constant minterType = "MinterDAExpSettlementV1";
 
     uint256 constant ONE_MILLION = 1_000_000;
 
@@ -136,9 +138,9 @@ contract MinterDAExpSettlementV0 is
     modifier onlyCoreAdminACLOrArtist(uint256 _projectId, bytes4 _selector) {
         require(
             (msg.sender ==
-                genArtCoreContract.projectIdToArtistAddress(_projectId)) ||
+                genArtCoreContract_Base.projectIdToArtistAddress(_projectId)) ||
                 (
-                    genArtCoreContract.adminACLAllowed(
+                    genArtCoreContract_Base.adminACLAllowed(
                         msg.sender,
                         address(this),
                         _selector
@@ -153,7 +155,7 @@ contract MinterDAExpSettlementV0 is
     // @dev defers which ACL contract is used to the core contract
     modifier onlyCoreAdminACL(bytes4 _selector) {
         require(
-            genArtCoreContract.adminACLAllowed(
+            genArtCoreContract_Base.adminACLAllowed(
                 msg.sender,
                 address(this),
                 _selector
@@ -166,7 +168,7 @@ contract MinterDAExpSettlementV0 is
     modifier onlyArtist(uint256 _projectId) {
         require(
             (msg.sender ==
-                genArtCoreContract.projectIdToArtistAddress(_projectId)),
+                genArtCoreContract_Base.projectIdToArtistAddress(_projectId)),
             "Only Artist"
         );
         _;
@@ -184,9 +186,13 @@ contract MinterDAExpSettlementV0 is
     constructor(
         address _genArt721Address,
         address _minterFilter
-    ) ReentrancyGuard() {
+    ) ReentrancyGuard() MinterBase(_genArt721Address) {
         genArt721CoreAddress = _genArt721Address;
-        genArtCoreContract = IGenArt721CoreContractV3(_genArt721Address);
+        // always populate immutable engine contracts, but only use appropriate
+        // interface based on isEngine in the rest of the contract
+        genArtCoreContract_Base = IGenArt721CoreContractV3_Base(
+            _genArt721Address
+        );
         minterFilterAddress = _minterFilter;
         minterFilter = IMinterFilterV0(_minterFilter);
         require(
@@ -545,7 +551,7 @@ contract MinterDAExpSettlementV0 is
         // calculate the artist and admin revenues (no check requuired)
         uint256 netRevenues = _projectConfig.numSettleableInvocations * _price;
         // INTERACTIONS
-        _splitETHRevenues(_projectId, netRevenues);
+        splitRevenuesETH(_projectId, netRevenues, genArt721CoreAddress);
         emit ArtistAndAdminRevenuesWithdrawn(_projectId);
     }
 
@@ -644,7 +650,7 @@ contract MinterDAExpSettlementV0 is
         // be accurate to ensure that the minters maxHasBeenInvoked is
         // accurate, so we get the value from the core contract directly.
         uint256 maxInvocations;
-        (, maxInvocations, , , , ) = genArtCoreContract.projectStateData(
+        (, maxInvocations, , , , ) = genArtCoreContract_Base.projectStateData(
             _projectId
         );
         // okay if this underflows because if statement will always eval false.
@@ -665,7 +671,11 @@ contract MinterDAExpSettlementV0 is
             // note that we don't refund msg.sender here, since a separate
             // settlement mechanism is provided on this minter, unrelated to
             // msg.value
-            _splitETHRevenues(_projectId, currentPriceInWei);
+            splitRevenuesETH(
+                _projectId,
+                currentPriceInWei,
+                genArt721CoreAddress
+            );
         } else {
             // increment the number of settleable invocations that will be
             // claimable by the artist and admin once auction is validated.
@@ -845,56 +855,6 @@ contract MinterDAExpSettlementV0 is
         bool success_;
         (success_, ) = _to.call{value: excessSettlementFunds}("");
         require(success_, "Reclaiming failed");
-    }
-
-    /**
-     * @dev splits ETH revenues between foundation, artist, and artist's
-     * additional payee for revenue generated by project `_projectId`.
-     * @dev possible DoS during splits is acknowledged, and mitigated by
-     * business practices, including end-to-end testing on mainnet, and
-     * admin-accepted artist payment addresses.
-     * @param _projectId Project ID for which funds shall be split.
-     * @param _valueInWei Value to be split, in Wei.
-     */
-    function _splitETHRevenues(
-        uint256 _projectId,
-        uint256 _valueInWei
-    ) internal {
-        if (_valueInWei > 0) {
-            bool success_;
-            // split funds between foundation, artist, and artist's
-            // additional payee
-            (
-                uint256 artblocksRevenue_,
-                address payable artblocksAddress_,
-                uint256 artistRevenue_,
-                address payable artistAddress_,
-                uint256 additionalPayeePrimaryRevenue_,
-                address payable additionalPayeePrimaryAddress_
-            ) = genArtCoreContract.getPrimaryRevenueSplits(
-                    _projectId,
-                    _valueInWei
-                );
-            // Art Blocks payment
-            if (artblocksRevenue_ > 0) {
-                (success_, ) = artblocksAddress_.call{value: artblocksRevenue_}(
-                    ""
-                );
-                require(success_, "Art Blocks payment failed");
-            }
-            // artist payment
-            if (artistRevenue_ > 0) {
-                (success_, ) = artistAddress_.call{value: artistRevenue_}("");
-                require(success_, "Artist payment failed");
-            }
-            // additional payee payment
-            if (additionalPayeePrimaryRevenue_ > 0) {
-                (success_, ) = additionalPayeePrimaryAddress_.call{
-                    value: additionalPayeePrimaryRevenue_
-                }("");
-                require(success_, "Additional Payee payment failed");
-            }
-        }
     }
 
     /**

--- a/contracts/minter-suite/Minters/MinterHolderV4.sol
+++ b/contracts/minter-suite/Minters/MinterHolderV4.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Created By: Art Blocks Inc.
 
-import "../../../interfaces/0.8.x/IGenArt721CoreContractV3_Base.sol";
-import "../../../interfaces/0.8.x/IMinterFilterV0.sol";
-import "../../../interfaces/0.8.x/IFilteredMinterHolderV2.sol";
-import "../MinterBase_v0_1_1.sol";
-import "../../../interfaces/0.8.x/IDelegationRegistry.sol";
+import "../../interfaces/0.8.x/IGenArt721CoreContractV3_Base.sol";
+import "../../interfaces/0.8.x/IMinterFilterV0.sol";
+import "../../interfaces/0.8.x/IFilteredMinterHolderV2.sol";
+import "./MinterBase_v0_1_1.sol";
+import "../../interfaces/0.8.x/IDelegationRegistry.sol";
 
 import "@openzeppelin-4.5/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";

--- a/contracts/minter-suite/Minters/MinterSetPriceV4.sol
+++ b/contracts/minter-suite/Minters/MinterSetPriceV4.sol
@@ -1,60 +1,42 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Created By: Art Blocks Inc.
 
-import "../../../interfaces/0.8.x/IGenArt721CoreContractV3.sol";
-import "../../../interfaces/0.8.x/IMinterFilterV0.sol";
-import "../../../interfaces/0.8.x/IFilteredMinterDALinV1.sol";
+import "../../interfaces/0.8.x/IGenArt721CoreContractV3_Base.sol";
+import "../../interfaces/0.8.x/IMinterFilterV0.sol";
+import "../../interfaces/0.8.x/IFilteredMinterV2.sol";
+import "./MinterBase_v0_1_1.sol";
 
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
-import "@openzeppelin-4.5/contracts/utils/math/SafeCast.sol";
 
 pragma solidity 0.8.17;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.
- * Pricing is achieved using an automated Dutch-auction mechanism.
- * This is designed to be used with IGenArt721CoreContractV3 contracts.
+ * This is designed to be used with GenArt721CoreContractV3 flagship or
+ * engine contracts.
  * @author Art Blocks Inc.
  * @notice Privileged Roles and Ownership:
  * This contract is designed to be managed, with limited powers.
- * Privileged roles and abilities are controlled by the core contract's Admin
- * ACL contract and a project's artist. Both of these roles hold extensive
- * power and can modify minter details.
+ * Privileged roles and abilities are controlled by the project's artist, which
+ * can be modified by the core contract's Admin ACL contract. Both of these
+ * roles hold extensive power and can modify minter details.
  * Care must be taken to ensure that the admin ACL contract and artist
  * addresses are secure behind a multi-sig or other access control mechanism.
  * ----------------------------------------------------------------------------
- * The following functions are restricted to the core contract's Admin ACL
- * contract:
- * - setMinimumAuctionLengthSeconds (note: this is only enforced when creating
- *   new auctions)
- * - resetAuctionDetails (note: this will prevent minting until a new auction
- *   is created)
- * ----------------------------------------------------------------------------
  * The following functions are restricted to a project's artist:
- * - setAuctionDetails (note: this may only be called when there is no active
- *   auction)
+ * - updatePricePerTokenInWei
  * - setProjectMaxInvocations
  * - manuallyLimitProjectMaxInvocations
  * ----------------------------------------------------------------------------
  * Additional admin and artist privileged roles may be described on other
  * contracts that this minter integrates with.
- *
- * @dev Note that while this minter makes use of `block.timestamp` and it is
- * technically possible that this value is manipulated by block producers, such
- * manipulation will not have material impact on the price values of this minter
- * given the business practices for how pricing is congfigured for this minter
- * and that variations on the order of less than a minute should not
- * meaningfully impact price given the minimum allowable price decay rate that
- * this minter intends to support.
  */
-contract MinterDALinV3 is ReentrancyGuard, IFilteredMinterDALinV1 {
-    using SafeCast for uint256;
-
+contract MinterSetPriceV4 is ReentrancyGuard, MinterBase, IFilteredMinterV2 {
     /// Core contract address this minter interacts with
     address public immutable genArt721CoreAddress;
 
-    /// This contract handles cores with interface IV
-    IGenArt721CoreContractV3 private immutable genArtCoreContract;
+    /// The core contract integrates with V3 contracts
+    IGenArt721CoreContractV3_Base private immutable genArtCoreContract_Base;
 
     /// Minter filter address this minter interacts with
     address public immutable minterFilterAddress;
@@ -63,43 +45,23 @@ contract MinterDALinV3 is ReentrancyGuard, IFilteredMinterDALinV1 {
     IMinterFilterV0 private immutable minterFilter;
 
     /// minterType for this minter
-    string public constant minterType = "MinterDALinV3";
+    string public constant minterType = "MinterSetPriceV4";
 
     uint256 constant ONE_MILLION = 1_000_000;
 
     struct ProjectConfig {
         bool maxHasBeenInvoked;
+        bool priceIsConfigured;
         uint24 maxInvocations;
-        // max uint64 ~= 1.8e19 sec ~= 570 billion years
-        uint64 timestampStart;
-        uint64 timestampEnd;
-        uint256 startPrice;
-        uint256 basePrice;
+        uint256 pricePerTokenInWei;
     }
 
     mapping(uint256 => ProjectConfig) public projectConfig;
 
-    /// Minimum auction length in seconds
-    uint256 public minimumAuctionLengthSeconds = 3600;
-
-    // modifier to restrict access to only AdminACL allowed calls
-    // @dev defers which ACL contract is used to the core contract
-    modifier onlyCoreAdminACL(bytes4 _selector) {
-        require(
-            genArtCoreContract.adminACLAllowed(
-                msg.sender,
-                address(this),
-                _selector
-            ),
-            "Only Core AdminACL allowed"
-        );
-        _;
-    }
-
     modifier onlyArtist(uint256 _projectId) {
         require(
-            (msg.sender ==
-                genArtCoreContract.projectIdToArtistAddress(_projectId)),
+            msg.sender ==
+                genArtCoreContract_Base.projectIdToArtistAddress(_projectId),
             "Only Artist"
         );
         _;
@@ -111,15 +73,19 @@ contract MinterDALinV3 is ReentrancyGuard, IFilteredMinterDALinV1 {
      * at address `_genArt721Address`.
      * @param _genArt721Address Art Blocks core contract address for
      * which this contract will be a minter.
-     * @param _minterFilter Minter filter for which
-     * this will a filtered minter.
+     * @param _minterFilter Minter filter for which this will be a
+     * filtered minter.
      */
     constructor(
         address _genArt721Address,
         address _minterFilter
-    ) ReentrancyGuard() {
+    ) ReentrancyGuard() MinterBase(_genArt721Address) {
         genArt721CoreAddress = _genArt721Address;
-        genArtCoreContract = IGenArt721CoreContractV3(_genArt721Address);
+        // always populate immutable engine contracts, but only use appropriate
+        // interface based on isEngine in the rest of the contract
+        genArtCoreContract_Base = IGenArt721CoreContractV3_Base(
+            _genArt721Address
+        );
         minterFilterAddress = _minterFilter;
         minterFilter = IMinterFilterV0(_minterFilter);
         require(
@@ -140,7 +106,7 @@ contract MinterDALinV3 is ReentrancyGuard, IFilteredMinterDALinV1 {
     ) external onlyArtist(_projectId) {
         uint256 maxInvocations;
         uint256 invocations;
-        (invocations, maxInvocations, , , , ) = genArtCoreContract
+        (invocations, maxInvocations, , , , ) = genArtCoreContract_Base
             .projectStateData(_projectId);
         // update storage with results
         projectConfig[_projectId].maxInvocations = uint24(maxInvocations);
@@ -174,7 +140,7 @@ contract MinterDALinV3 is ReentrancyGuard, IFilteredMinterDALinV1 {
         // ensure that the manually set maxInvocations is not greater than what is set on the core contract
         uint256 maxInvocations;
         uint256 invocations;
-        (invocations, maxInvocations, , , , ) = genArtCoreContract
+        (invocations, maxInvocations, , , , ) = genArtCoreContract_Base
             .projectStateData(_projectId);
         require(
             _maxInvocations <= maxInvocations,
@@ -188,6 +154,8 @@ contract MinterDALinV3 is ReentrancyGuard, IFilteredMinterDALinV1 {
         // EFFECTS
         // update storage with results
         projectConfig[_projectId].maxInvocations = uint24(_maxInvocations);
+        // We need to ensure maxHasBeenInvoked is correctly set after manually setting the
+        // local maxInvocations value.
         projectConfig[_projectId].maxHasBeenInvoked =
             invocations == _maxInvocations;
 
@@ -248,114 +216,20 @@ contract MinterDALinV3 is ReentrancyGuard, IFilteredMinterDALinV1 {
     }
 
     /**
-     * @notice projectId => auction parameters
-     */
-    function projectAuctionParameters(
-        uint256 _projectId
-    )
-        external
-        view
-        returns (
-            uint256 timestampStart,
-            uint256 timestampEnd,
-            uint256 startPrice,
-            uint256 basePrice
-        )
-    {
-        ProjectConfig storage _projectConfig = projectConfig[_projectId];
-        return (
-            _projectConfig.timestampStart,
-            _projectConfig.timestampEnd,
-            _projectConfig.startPrice,
-            _projectConfig.basePrice
-        );
-    }
-
-    /**
-     * @notice Sets minimum auction length to `_minimumAuctionLengthSeconds`
-     * for all projects.
-     * @param _minimumAuctionLengthSeconds Minimum auction length in seconds.
-     */
-    function setMinimumAuctionLengthSeconds(
-        uint256 _minimumAuctionLengthSeconds
-    ) external onlyCoreAdminACL(this.setMinimumAuctionLengthSeconds.selector) {
-        minimumAuctionLengthSeconds = _minimumAuctionLengthSeconds;
-        emit MinimumAuctionLengthSecondsUpdated(_minimumAuctionLengthSeconds);
-    }
-
-    ////// Auction Functions
-    /**
-     * @notice Sets auction details for project `_projectId`.
-     * @param _projectId Project ID to set auction details for.
-     * @param _auctionTimestampStart Timestamp at which to start the auction.
-     * @param _auctionTimestampEnd Timestamp at which to end the auction.
-     * @param _startPrice Price at which to start the auction, in Wei.
-     * @param _basePrice Resting price of the auction, in Wei.
+     * @notice Updates this minter's price per token of project `_projectId`
+     * to be '_pricePerTokenInWei`, in Wei.
+     * This price supersedes any legacy core contract price per token value.
      * @dev Note that it is intentionally supported here that the configured
      * price may be explicitly set to `0`.
      */
-    function setAuctionDetails(
+    function updatePricePerTokenInWei(
         uint256 _projectId,
-        uint256 _auctionTimestampStart,
-        uint256 _auctionTimestampEnd,
-        uint256 _startPrice,
-        uint256 _basePrice
+        uint256 _pricePerTokenInWei
     ) external onlyArtist(_projectId) {
-        // CHECKS
         ProjectConfig storage _projectConfig = projectConfig[_projectId];
-        require(
-            _projectConfig.timestampStart == 0 ||
-                block.timestamp < _projectConfig.timestampStart,
-            "No modifications mid-auction"
-        );
-        require(
-            block.timestamp < _auctionTimestampStart,
-            "Only future auctions"
-        );
-        require(
-            _auctionTimestampEnd > _auctionTimestampStart,
-            "Auction end must be greater than auction start"
-        );
-        require(
-            _auctionTimestampEnd >=
-                _auctionTimestampStart + minimumAuctionLengthSeconds,
-            "Auction length must be at least minimumAuctionLengthSeconds"
-        );
-        require(
-            _startPrice > _basePrice,
-            "Auction start price must be greater than auction end price"
-        );
-        // EFFECTS
-        _projectConfig.timestampStart = _auctionTimestampStart.toUint64();
-        _projectConfig.timestampEnd = _auctionTimestampEnd.toUint64();
-        _projectConfig.startPrice = _startPrice;
-        _projectConfig.basePrice = _basePrice;
-        emit SetAuctionDetails(
-            _projectId,
-            _auctionTimestampStart,
-            _auctionTimestampEnd,
-            _startPrice,
-            _basePrice
-        );
-    }
-
-    /**
-     * @notice Resets auction details for project `_projectId`, zero-ing out all
-     * relevant auction fields. Not intended to be used in normal auction
-     * operation, but rather only in case of the need to halt an auction.
-     * @param _projectId Project ID to set auction details for.
-     */
-    function resetAuctionDetails(
-        uint256 _projectId
-    ) external onlyCoreAdminACL(this.resetAuctionDetails.selector) {
-        ProjectConfig storage _projectConfig = projectConfig[_projectId];
-        // reset to initial values
-        _projectConfig.timestampStart = 0;
-        _projectConfig.timestampEnd = 0;
-        _projectConfig.startPrice = 0;
-        _projectConfig.basePrice = 0;
-
-        emit ResetAuctionDetails(_projectId);
+        _projectConfig.pricePerTokenInWei = _pricePerTokenInWei;
+        _projectConfig.priceIsConfigured = true;
+        emit PricePerTokenInWeiUpdated(_projectId, _pricePerTokenInWei);
     }
 
     /**
@@ -415,10 +289,14 @@ contract MinterDALinV3 is ReentrancyGuard, IFilteredMinterDALinV1 {
             "Maximum number of invocations reached"
         );
 
-        // _getPrice reverts if auction is unconfigured or has not started
-        uint256 currentPriceInWei = _getPrice(_projectId);
+        // require artist to have configured price of token on this minter
+        require(_projectConfig.priceIsConfigured, "Price not configured");
+
+        // load price of token into memory
+        uint256 pricePerTokenInWei = _projectConfig.pricePerTokenInWei;
+
         require(
-            msg.value >= currentPriceInWei,
+            msg.value >= pricePerTokenInWei,
             "Must send minimum value to mint!"
         );
 
@@ -434,100 +312,9 @@ contract MinterDALinV3 is ReentrancyGuard, IFilteredMinterDALinV1 {
         }
 
         // INTERACTIONS
-        _splitFundsETHAuction(_projectId, currentPriceInWei);
+        splitFundsETH(_projectId, pricePerTokenInWei, genArt721CoreAddress);
 
         return tokenId;
-    }
-
-    /**
-     * @dev splits ETH funds between sender (if refund), foundation,
-     * artist, and artist's additional payee for a token purchased on
-     * project `_projectId`.
-     * @dev possible DoS during splits is acknowledged, and mitigated by
-     * business practices, including end-to-end testing on mainnet, and
-     * admin-accepted artist payment addresses.
-     * @param _projectId Project ID for which funds shall be split.
-     * @param _currentPriceInWei Current price of token, in Wei.
-     */
-    function _splitFundsETHAuction(
-        uint256 _projectId,
-        uint256 _currentPriceInWei
-    ) internal {
-        if (msg.value > 0) {
-            bool success_;
-            // send refund to sender
-            uint256 refund = msg.value - _currentPriceInWei;
-            if (refund > 0) {
-                (success_, ) = msg.sender.call{value: refund}("");
-                require(success_, "Refund failed");
-            }
-            // split remaining funds between foundation, artist, and artist's
-            // additional payee
-            (
-                uint256 artblocksRevenue_,
-                address payable artblocksAddress_,
-                uint256 artistRevenue_,
-                address payable artistAddress_,
-                uint256 additionalPayeePrimaryRevenue_,
-                address payable additionalPayeePrimaryAddress_
-            ) = genArtCoreContract.getPrimaryRevenueSplits(
-                    _projectId,
-                    _currentPriceInWei
-                );
-            // Art Blocks payment
-            if (artblocksRevenue_ > 0) {
-                (success_, ) = artblocksAddress_.call{value: artblocksRevenue_}(
-                    ""
-                );
-                require(success_, "Art Blocks payment failed");
-            }
-            // artist payment
-            if (artistRevenue_ > 0) {
-                (success_, ) = artistAddress_.call{value: artistRevenue_}("");
-                require(success_, "Artist payment failed");
-            }
-            // additional payee payment
-            if (additionalPayeePrimaryRevenue_ > 0) {
-                (success_, ) = additionalPayeePrimaryAddress_.call{
-                    value: additionalPayeePrimaryRevenue_
-                }("");
-                require(success_, "Additional Payee payment failed");
-            }
-        }
-    }
-
-    /**
-     * @notice Gets price of minting a token on project `_projectId` given
-     * the project's AuctionParameters and current block timestamp.
-     * Reverts if auction has not yet started or auction is unconfigured.
-     * @param _projectId Project ID to get price of token for.
-     * @return current price of token in Wei
-     */
-    function _getPrice(uint256 _projectId) private view returns (uint256) {
-        ProjectConfig storage _projectConfig = projectConfig[_projectId];
-        // move parameters to memory if used more than once
-        uint256 _timestampStart = uint256(_projectConfig.timestampStart);
-        uint256 _timestampEnd = uint256(_projectConfig.timestampEnd);
-        uint256 _startPrice = _projectConfig.startPrice;
-        uint256 _basePrice = _projectConfig.basePrice;
-
-        require(block.timestamp > _timestampStart, "Auction not yet started");
-        if (block.timestamp >= _timestampEnd) {
-            require(_timestampEnd > 0, "Only configured auctions");
-            return _basePrice;
-        }
-        uint256 elapsedTime;
-        uint256 duration;
-        uint256 startToEndDiff;
-        unchecked {
-            // already checked that block.timestamp > _timestampStart
-            elapsedTime = block.timestamp - _timestampStart;
-            // _timestampEnd > _timestampStart enforced during assignment
-            duration = _timestampEnd - _timestampStart;
-            // _startPrice > _basePrice enforced during assignment
-            startToEndDiff = _startPrice - _basePrice;
-        }
-        return _startPrice - ((elapsedTime * startToEndDiff) / duration);
     }
 
     /**
@@ -535,10 +322,10 @@ contract MinterDALinV3 is ReentrancyGuard, IFilteredMinterDALinV1 {
      * token on project `_projectId`, and currency symbol and address to be
      * used as payment. Supersedes any core contract price information.
      * @param _projectId Project ID to get price information for.
-     * @return isConfigured true only if project's auction parameters have been
-     * configured on this minter
+     * @return isConfigured true only if token price has been configured on
+     * this minter
      * @return tokenPriceInWei current price of token on this minter - invalid
-     * if auction has not yet been configured
+     * if price has not yet been configured
      * @return currencySymbol currency symbol for purchases of project on this
      * minter. This minter always returns "ETH"
      * @return currencyAddress currency address for purchases of project on
@@ -557,19 +344,8 @@ contract MinterDALinV3 is ReentrancyGuard, IFilteredMinterDALinV1 {
         )
     {
         ProjectConfig storage _projectConfig = projectConfig[_projectId];
-
-        isConfigured = (_projectConfig.startPrice > 0);
-        if (block.timestamp <= _projectConfig.timestampStart) {
-            // Provide a reasonable value for `tokenPriceInWei` when it would
-            // otherwise revert, using the starting price before auction starts.
-            tokenPriceInWei = _projectConfig.startPrice;
-        } else if (_projectConfig.timestampEnd == 0) {
-            // In the case of unconfigured auction, return price of zero when
-            // it would otherwise revert
-            tokenPriceInWei = 0;
-        } else {
-            tokenPriceInWei = _getPrice(_projectId);
-        }
+        isConfigured = _projectConfig.priceIsConfigured;
+        tokenPriceInWei = _projectConfig.pricePerTokenInWei;
         currencySymbol = "ETH";
         currencyAddress = address(0);
     }


### PR DESCRIPTION
## Description of the change

This archives the version n-1 minters that will not be deployed to testnet or mainnet. It also moves active minters out of subdirectories into a shared directory, since there is now only a single version of each minter planned to be in the overall Minters directory.

No changes to solidity code logic.