### PR TITLE
Reduce size of V3_Engine_Flex & V3_Engine

### DIFF
--- a/contracts/GenArt721CoreV3_Engine.sol
+++ b/contracts/GenArt721CoreV3_Engine.sol
@@ -273,46 +273,46 @@ contract GenArt721CoreV3_Engine is
     /// default base URI to initialize all new project projectBaseURI values to
     string public defaultBaseURI;
 
-    function onlyNonZeroAddress(address _address) internal pure {
+    function _onlyNonZeroAddress(address _address) internal pure {
         require(_address != address(0), "Must input non-zero address");
     }
 
-    function onlyNonEmptyString(string memory _string) internal pure {
+    function _onlyNonEmptyString(string memory _string) internal pure {
         require(bytes(_string).length != 0, "Must input non-empty string");
     }
 
-    function onlyValidTokenId(uint256 _tokenId) internal view {
+    function _onlyValidTokenId(uint256 _tokenId) internal view {
         require(_exists(_tokenId), "Token ID does not exist");
     }
 
-    function onlyValidProjectId(uint256 _projectId) internal view {
+    function _onlyValidProjectId(uint256 _projectId) internal view {
         require(
             (_projectId >= startingProjectId) && (_projectId < _nextProjectId),
             "Project ID does not exist"
         );
     }
 
-    function onlyUnlocked(uint256 _projectId) internal view {
+    function _onlyUnlocked(uint256 _projectId) internal view {
         // Note: calling `_projectUnlocked` enforces that the `_projectId`
         //       passed in is valid.`
         require(_projectUnlocked(_projectId), "Only if unlocked");
     }
 
-    function onlyAdminACL(bytes4 _selector) internal {
+    function _onlyAdminACL(bytes4 _selector) internal {
         require(
             adminACLAllowed(msg.sender, address(this), _selector),
             "Only Admin ACL allowed"
         );
     }
 
-    function onlyArtist(uint256 _projectId) internal view {
+    function _onlyArtist(uint256 _projectId) internal view {
         require(
             msg.sender == projectIdToFinancials[_projectId].artistAddress,
             "Only artist"
         );
     }
 
-    function onlyArtistOrAdminACL(
+    function _onlyArtistOrAdminACL(
         uint256 _projectId,
         bytes4 _selector
     ) internal {
@@ -329,7 +329,7 @@ contract GenArt721CoreV3_Engine is
      * contract to continue to function if the owner decides to renounce
      * ownership.
      */
-    function onlyAdminACLOrRenouncedArtist(
+    function _onlyAdminACLOrRenouncedArtist(
         uint256 _projectId,
         bytes4 _selector
     ) internal {
@@ -368,10 +368,10 @@ contract GenArt721CoreV3_Engine is
         bool _autoApproveArtistSplitProposals,
         address _engineRegistryContract
     ) ERC721_PackedHashSeed(_tokenName, _tokenSymbol) {
-        onlyNonZeroAddress(_renderProviderAddress);
-        onlyNonZeroAddress(_platformProviderAddress);
-        onlyNonZeroAddress(_randomizerContract);
-        onlyNonZeroAddress(_adminACLContract);
+        _onlyNonZeroAddress(_renderProviderAddress);
+        _onlyNonZeroAddress(_platformProviderAddress);
+        _onlyNonZeroAddress(_randomizerContract);
+        _onlyNonZeroAddress(_adminACLContract);
         // setup immutable `autoApproveArtistSplitProposals` config
         autoApproveArtistSplitProposals = _autoApproveArtistSplitProposals;
         // record contracts starting project ID
@@ -494,7 +494,7 @@ contract GenArt721CoreV3_Engine is
      * minimize gas when minting.
      */
     function setTokenHash_8PT(uint256 _tokenId, bytes32 _hashSeed) external {
-        onlyValidTokenId(_tokenId);
+        _onlyValidTokenId(_tokenId);
 
         OwnerAndHashSeed storage ownerAndHashSeed = _ownersAndHashSeeds[
             _tokenId
@@ -546,8 +546,8 @@ contract GenArt721CoreV3_Engine is
     function updateArtblocksDependencyRegistryAddress(
         address _artblocksDependencyRegistryAddress
     ) external {
-        onlyAdminACL(this.updateArtblocksDependencyRegistryAddress.selector);
-        onlyNonZeroAddress(_artblocksDependencyRegistryAddress);
+        _onlyAdminACL(this.updateArtblocksDependencyRegistryAddress.selector);
+        _onlyNonZeroAddress(_artblocksDependencyRegistryAddress);
         artblocksDependencyRegistryAddress = _artblocksDependencyRegistryAddress;
         emit PlatformUpdated(FIELD_ARTBLOCKS_DEPENDENCY_REGISTRY_ADDRESS);
     }
@@ -570,11 +570,11 @@ contract GenArt721CoreV3_Engine is
         address payable _platformProviderPrimarySalesAddress,
         address payable _platformProviderSecondarySalesAddress
     ) external {
-        onlyAdminACL(this.updateProviderSalesAddresses.selector);
-        onlyNonZeroAddress(_renderProviderPrimarySalesAddress);
-        onlyNonZeroAddress(_renderProviderSecondarySalesAddress);
-        onlyNonZeroAddress(_platformProviderPrimarySalesAddress);
-        onlyNonZeroAddress(_platformProviderSecondarySalesAddress);
+        _onlyAdminACL(this.updateProviderSalesAddresses.selector);
+        _onlyNonZeroAddress(_renderProviderPrimarySalesAddress);
+        _onlyNonZeroAddress(_renderProviderSecondarySalesAddress);
+        _onlyNonZeroAddress(_platformProviderPrimarySalesAddress);
+        _onlyNonZeroAddress(_platformProviderSecondarySalesAddress);
         _updateProviderSalesAddresses(
             _renderProviderPrimarySalesAddress,
             _renderProviderSecondarySalesAddress,
@@ -594,7 +594,7 @@ contract GenArt721CoreV3_Engine is
         uint256 renderProviderPrimarySalesPercentage_,
         uint256 platformProviderPrimarySalesPercentage_
     ) external {
-        onlyAdminACL(this.updateProviderPrimarySalesPercentages.selector);
+        _onlyAdminACL(this.updateProviderPrimarySalesPercentages.selector);
 
         // Validate that the sum of the proposed %s, does not exceed 100%.
         require(
@@ -630,7 +630,7 @@ contract GenArt721CoreV3_Engine is
         uint256 _renderProviderSecondarySalesBPS,
         uint256 _platformProviderSecondarySalesBPS
     ) external {
-        onlyAdminACL(this.updateProviderSecondarySalesBPS.selector);
+        _onlyAdminACL(this.updateProviderSecondarySalesBPS.selector);
         // Validate that the sum of the proposed provider BPS, does not exceed 10_000 BPS.
         require(
             (_renderProviderSecondarySalesBPS +
@@ -648,8 +648,8 @@ contract GenArt721CoreV3_Engine is
      * @param _address Address of new minter.
      */
     function updateMinterContract(address _address) external {
-        onlyAdminACL(this.updateMinterContract.selector);
-        onlyNonZeroAddress(_address);
+        _onlyAdminACL(this.updateMinterContract.selector);
+        _onlyNonZeroAddress(_address);
         minterContract = _address;
         emit MinterUpdated(_address);
     }
@@ -659,8 +659,8 @@ contract GenArt721CoreV3_Engine is
      * @param _randomizerAddress Address of new randomizer.
      */
     function updateRandomizerAddress(address _randomizerAddress) external {
-        onlyAdminACL(this.updateRandomizerAddress.selector);
-        onlyNonZeroAddress(_randomizerAddress);
+        _onlyAdminACL(this.updateRandomizerAddress.selector);
+        _onlyNonZeroAddress(_randomizerAddress);
         _updateRandomizerAddress(_randomizerAddress);
     }
 
@@ -669,8 +669,8 @@ contract GenArt721CoreV3_Engine is
      * @param _projectId Project ID to be toggled.
      */
     function toggleProjectIsActive(uint256 _projectId) external {
-        onlyAdminACL(this.toggleProjectIsActive.selector);
-        onlyValidProjectId(_projectId);
+        _onlyAdminACL(this.toggleProjectIsActive.selector);
+        _onlyValidProjectId(_projectId);
         projects[_projectId].active = !projects[_projectId].active;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_ACTIVE);
     }
@@ -714,9 +714,9 @@ contract GenArt721CoreV3_Engine is
         address payable _additionalPayeeSecondarySales,
         uint256 _additionalPayeeSecondarySalesPercentage
     ) external {
-        onlyValidProjectId(_projectId);
-        onlyArtist(_projectId);
-        onlyNonZeroAddress(_artistAddress);
+        _onlyValidProjectId(_projectId);
+        _onlyArtist(_projectId);
+        _onlyNonZeroAddress(_artistAddress);
         ProjectFinance storage projectFinance = projectIdToFinancials[
             _projectId
         ];
@@ -835,12 +835,12 @@ contract GenArt721CoreV3_Engine is
         address payable _additionalPayeeSecondarySales,
         uint256 _additionalPayeeSecondarySalesPercentage
     ) external {
-        onlyValidProjectId(_projectId);
-        onlyAdminACLOrRenouncedArtist(
+        _onlyValidProjectId(_projectId);
+        _onlyAdminACLOrRenouncedArtist(
             _projectId,
             this.adminAcceptArtistAddressesAndSplits.selector
         );
-        onlyNonZeroAddress(_artistAddress);
+        _onlyNonZeroAddress(_artistAddress);
         // checks
         require(
             proposedArtistAddressesAndSplitsHash[_projectId] ==
@@ -887,12 +887,12 @@ contract GenArt721CoreV3_Engine is
         uint256 _projectId,
         address payable _artistAddress
     ) external {
-        onlyValidProjectId(_projectId);
-        onlyAdminACLOrRenouncedArtist(
+        _onlyValidProjectId(_projectId);
+        _onlyAdminACLOrRenouncedArtist(
             _projectId,
             this.updateProjectArtistAddress.selector
         );
-        onlyNonZeroAddress(_artistAddress);
+        _onlyNonZeroAddress(_artistAddress);
         projectIdToFinancials[_projectId].artistAddress = _artistAddress;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_ARTIST_ADDRESS);
     }
@@ -902,7 +902,7 @@ contract GenArt721CoreV3_Engine is
      * @param _projectId Project ID to be toggled.
      */
     function toggleProjectIsPaused(uint256 _projectId) external {
-        onlyArtist(_projectId);
+        _onlyArtist(_projectId);
         projects[_projectId].paused = !projects[_projectId].paused;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_PAUSED);
     }
@@ -917,9 +917,9 @@ contract GenArt721CoreV3_Engine is
         string memory _projectName,
         address payable _artistAddress
     ) external {
-        onlyAdminACL(this.addProject.selector);
-        onlyNonEmptyString(_projectName);
-        onlyNonZeroAddress(_artistAddress);
+        _onlyAdminACL(this.addProject.selector);
+        _onlyNonEmptyString(_projectName);
+        _onlyNonZeroAddress(_artistAddress);
         require(!newProjectsForbidden, "New projects forbidden");
         uint256 projectId = _nextProjectId;
         projectIdToFinancials[projectId].artistAddress = _artistAddress;
@@ -936,7 +936,7 @@ contract GenArt721CoreV3_Engine is
      * @notice Forever forbids new projects from being added to this contract.
      */
     function forbidNewProjects() external {
-        onlyAdminACL(this.forbidNewProjects.selector);
+        _onlyAdminACL(this.forbidNewProjects.selector);
         require(!newProjectsForbidden, "Already forbidden");
         _forbidNewProjects();
     }
@@ -950,9 +950,9 @@ contract GenArt721CoreV3_Engine is
         uint256 _projectId,
         string memory _projectName
     ) external {
-        onlyUnlocked(_projectId);
-        onlyArtistOrAdminACL(_projectId, this.updateProjectName.selector);
-        onlyNonEmptyString(_projectName);
+        _onlyUnlocked(_projectId);
+        _onlyArtistOrAdminACL(_projectId, this.updateProjectName.selector);
+        _onlyNonEmptyString(_projectName);
         projects[_projectId].name = _projectName;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_NAME);
     }
@@ -967,9 +967,12 @@ contract GenArt721CoreV3_Engine is
         uint256 _projectId,
         string memory _projectArtistName
     ) external {
-        onlyUnlocked(_projectId);
-        onlyArtistOrAdminACL(_projectId, this.updateProjectArtistName.selector);
-        onlyNonEmptyString(_projectArtistName);
+        _onlyUnlocked(_projectId);
+        _onlyArtistOrAdminACL(
+            _projectId,
+            this.updateProjectArtistName.selector
+        );
+        _onlyNonEmptyString(_projectArtistName);
         projects[_projectId].artist = _projectArtistName;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_ARTIST_NAME);
     }
@@ -989,7 +992,7 @@ contract GenArt721CoreV3_Engine is
         uint256 _projectId,
         uint256 _secondMarketRoyalty
     ) external {
-        onlyArtist(_projectId);
+        _onlyArtist(_projectId);
         require(
             _secondMarketRoyalty <= ARTIST_MAX_SECONDARY_ROYALTY_PERCENTAGE,
             "Over max precent"
@@ -1038,7 +1041,7 @@ contract GenArt721CoreV3_Engine is
         uint256 _projectId,
         string memory _projectWebsite
     ) external {
-        onlyArtist(_projectId);
+        _onlyArtist(_projectId);
         projects[_projectId].website = _projectWebsite;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_WEBSITE);
     }
@@ -1052,9 +1055,9 @@ contract GenArt721CoreV3_Engine is
         uint256 _projectId,
         string memory _projectLicense
     ) external {
-        onlyUnlocked(_projectId);
-        onlyArtistOrAdminACL(_projectId, this.updateProjectLicense.selector);
-        onlyNonEmptyString(_projectLicense);
+        _onlyUnlocked(_projectId);
+        _onlyArtistOrAdminACL(_projectId, this.updateProjectLicense.selector);
+        _onlyNonEmptyString(_projectLicense);
         projects[_projectId].license = _projectLicense;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_LICENSE);
     }
@@ -1072,7 +1075,7 @@ contract GenArt721CoreV3_Engine is
         uint256 _projectId,
         uint24 _maxInvocations
     ) external {
-        onlyArtist(_projectId);
+        _onlyArtist(_projectId);
         // CHECKS
         Project storage project = projects[_projectId];
         uint256 _invocations = project.invocations;
@@ -1101,9 +1104,9 @@ contract GenArt721CoreV3_Engine is
         uint256 _projectId,
         string memory _script
     ) external {
-        onlyUnlocked(_projectId);
-        onlyArtistOrAdminACL(_projectId, this.addProjectScript.selector);
-        onlyNonEmptyString(_script);
+        _onlyUnlocked(_projectId);
+        _onlyArtistOrAdminACL(_projectId, this.addProjectScript.selector);
+        _onlyNonEmptyString(_script);
         Project storage project = projects[_projectId];
         // store script in contract bytecode
         project.scriptBytecodeAddresses[project.scriptCount] = _script
@@ -1124,9 +1127,9 @@ contract GenArt721CoreV3_Engine is
         uint256 _scriptId,
         string memory _script
     ) external {
-        onlyUnlocked(_projectId);
-        onlyArtistOrAdminACL(_projectId, this.updateProjectScript.selector);
-        onlyNonEmptyString(_script);
+        _onlyUnlocked(_projectId);
+        _onlyArtistOrAdminACL(_projectId, this.updateProjectScript.selector);
+        _onlyNonEmptyString(_script);
         Project storage project = projects[_projectId];
         require(_scriptId < project.scriptCount, "scriptId out of range");
 
@@ -1141,8 +1144,11 @@ contract GenArt721CoreV3_Engine is
      * @param _projectId Project to be updated.
      */
     function removeProjectLastScript(uint256 _projectId) external {
-        onlyUnlocked(_projectId);
-        onlyArtistOrAdminACL(_projectId, this.removeProjectLastScript.selector);
+        _onlyUnlocked(_projectId);
+        _onlyArtistOrAdminACL(
+            _projectId,
+            this.removeProjectLastScript.selector
+        );
         Project storage project = projects[_projectId];
         require(project.scriptCount > 0, "No scripts to remove");
 
@@ -1164,8 +1170,11 @@ contract GenArt721CoreV3_Engine is
         uint256 _projectId,
         bytes32 _scriptTypeAndVersion
     ) external {
-        onlyUnlocked(_projectId);
-        onlyArtistOrAdminACL(_projectId, this.updateProjectScriptType.selector);
+        _onlyUnlocked(_projectId);
+        _onlyArtistOrAdminACL(
+            _projectId,
+            this.updateProjectScriptType.selector
+        );
         Project storage project = projects[_projectId];
         // require exactly one @ symbol in _scriptTypeAndVersion
         require(
@@ -1190,12 +1199,12 @@ contract GenArt721CoreV3_Engine is
         uint256 _projectId,
         string memory _aspectRatio
     ) external {
-        onlyUnlocked(_projectId);
-        onlyArtistOrAdminACL(
+        _onlyUnlocked(_projectId);
+        _onlyArtistOrAdminACL(
             _projectId,
             this.updateProjectAspectRatio.selector
         );
-        onlyNonEmptyString(_aspectRatio);
+        _onlyNonEmptyString(_aspectRatio);
         // Perform more detailed input validation for aspect ratio.
         bytes memory aspectRatioBytes = bytes(_aspectRatio);
         uint256 bytesLength = aspectRatioBytes.length;
@@ -1239,8 +1248,8 @@ contract GenArt721CoreV3_Engine is
         uint256 _projectId,
         string memory _newBaseURI
     ) external {
-        onlyArtist(_projectId);
-        onlyNonEmptyString(_newBaseURI);
+        _onlyArtist(_projectId);
+        _onlyNonEmptyString(_newBaseURI);
         projects[_projectId].projectBaseURI = _newBaseURI;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_BASE_URI);
     }
@@ -1252,8 +1261,8 @@ contract GenArt721CoreV3_Engine is
      * @param _defaultBaseURI New default base URI.
      */
     function updateDefaultBaseURI(string memory _defaultBaseURI) external {
-        onlyAdminACL(this.updateDefaultBaseURI.selector);
-        onlyNonEmptyString(_defaultBaseURI);
+        _onlyAdminACL(this.updateDefaultBaseURI.selector);
+        _onlyNonEmptyString(_defaultBaseURI);
         _updateDefaultBaseURI(_defaultBaseURI);
     }
 
@@ -1638,7 +1647,7 @@ contract GenArt721CoreV3_Engine is
         view
         returns (address payable[] memory recipients, uint256[] memory bps)
     {
-        onlyValidTokenId(_tokenId);
+        _onlyValidTokenId(_tokenId);
         // initialize arrays with maximum potential length
         recipients = new address payable[](4);
         bps = new uint256[](4);
@@ -1851,7 +1860,7 @@ contract GenArt721CoreV3_Engine is
     function tokenURI(
         uint256 _tokenId
     ) public view override returns (string memory) {
-        onlyValidTokenId(_tokenId);
+        _onlyValidTokenId(_tokenId);
         string memory _projectBaseURI = projects[tokenIdToProjectId(_tokenId)]
             .projectBaseURI;
         return string.concat(_projectBaseURI, _tokenId.toString());
@@ -1976,7 +1985,7 @@ contract GenArt721CoreV3_Engine is
      * @dev This also enforces that the `_projectId` passed in is valid.
      */
     function _projectUnlocked(uint256 _projectId) internal view returns (bool) {
-        onlyValidProjectId(_projectId);
+        _onlyValidProjectId(_projectId);
 
         uint256 projectCompletedTimestamp = projects[_projectId]
             .completedTimestamp;

--- a/contracts/GenArt721CoreV3_Engine.sol
+++ b/contracts/GenArt721CoreV3_Engine.sol
@@ -273,59 +273,54 @@ contract GenArt721CoreV3_Engine is
     /// default base URI to initialize all new project projectBaseURI values to
     string public defaultBaseURI;
 
-    modifier onlyNonZeroAddress(address _address) {
+    function onlyNonZeroAddress(address _address) internal pure {
         require(_address != address(0), "Must input non-zero address");
-        _;
     }
 
-    modifier onlyNonEmptyString(string memory _string) {
+    function onlyNonEmptyString(string memory _string) internal pure {
         require(bytes(_string).length != 0, "Must input non-empty string");
-        _;
     }
 
-    modifier onlyValidTokenId(uint256 _tokenId) {
+    function onlyValidTokenId(uint256 _tokenId) internal view {
         require(_exists(_tokenId), "Token ID does not exist");
-        _;
     }
 
-    modifier onlyValidProjectId(uint256 _projectId) {
+    function onlyValidProjectId(uint256 _projectId) internal view {
         require(
             (_projectId >= startingProjectId) && (_projectId < _nextProjectId),
             "Project ID does not exist"
         );
-        _;
     }
 
-    modifier onlyUnlocked(uint256 _projectId) {
+    function onlyUnlocked(uint256 _projectId) internal view {
         // Note: calling `_projectUnlocked` enforces that the `_projectId`
         //       passed in is valid.`
         require(_projectUnlocked(_projectId), "Only if unlocked");
-        _;
     }
 
-    modifier onlyAdminACL(bytes4 _selector) {
+    function onlyAdminACL(bytes4 _selector) internal {
         require(
             adminACLAllowed(msg.sender, address(this), _selector),
             "Only Admin ACL allowed"
         );
-        _;
     }
 
-    modifier onlyArtist(uint256 _projectId) {
+    function onlyArtist(uint256 _projectId) internal view {
         require(
             msg.sender == projectIdToFinancials[_projectId].artistAddress,
             "Only artist"
         );
-        _;
     }
 
-    modifier onlyArtistOrAdminACL(uint256 _projectId, bytes4 _selector) {
+    function onlyArtistOrAdminACL(
+        uint256 _projectId,
+        bytes4 _selector
+    ) internal {
         require(
             msg.sender == projectIdToFinancials[_projectId].artistAddress ||
                 adminACLAllowed(msg.sender, address(this), _selector),
             "Only artist or Admin ACL allowed"
         );
-        _;
     }
 
     /**
@@ -334,10 +329,10 @@ contract GenArt721CoreV3_Engine is
      * contract to continue to function if the owner decides to renounce
      * ownership.
      */
-    modifier onlyAdminACLOrRenouncedArtist(
+    function onlyAdminACLOrRenouncedArtist(
         uint256 _projectId,
         bytes4 _selector
-    ) {
+    ) internal {
         require(
             adminACLAllowed(msg.sender, address(this), _selector) ||
                 (owner() == address(0) &&
@@ -345,7 +340,6 @@ contract GenArt721CoreV3_Engine is
                     projectIdToFinancials[_projectId].artistAddress),
             "Only Admin ACL allowed, or artist if owner has renounced"
         );
-        _;
     }
 
     /**
@@ -373,13 +367,11 @@ contract GenArt721CoreV3_Engine is
         uint248 _startingProjectId,
         bool _autoApproveArtistSplitProposals,
         address _engineRegistryContract
-    )
-        ERC721_PackedHashSeed(_tokenName, _tokenSymbol)
-        onlyNonZeroAddress(_renderProviderAddress)
-        onlyNonZeroAddress(_platformProviderAddress)
-        onlyNonZeroAddress(_randomizerContract)
-        onlyNonZeroAddress(_adminACLContract)
-    {
+    ) ERC721_PackedHashSeed(_tokenName, _tokenSymbol) {
+        onlyNonZeroAddress(_renderProviderAddress);
+        onlyNonZeroAddress(_platformProviderAddress);
+        onlyNonZeroAddress(_randomizerContract);
+        onlyNonZeroAddress(_adminACLContract);
         // setup immutable `autoApproveArtistSplitProposals` config
         autoApproveArtistSplitProposals = _autoApproveArtistSplitProposals;
         // record contracts starting project ID
@@ -501,10 +493,9 @@ contract GenArt721CoreV3_Engine is
      * for indexing purposes, it must be emitted by the randomizer. This is to
      * minimize gas when minting.
      */
-    function setTokenHash_8PT(
-        uint256 _tokenId,
-        bytes32 _hashSeed
-    ) external onlyValidTokenId(_tokenId) {
+    function setTokenHash_8PT(uint256 _tokenId, bytes32 _hashSeed) external {
+        onlyValidTokenId(_tokenId);
+
         OwnerAndHashSeed storage ownerAndHashSeed = _ownersAndHashSeeds[
             _tokenId
         ];
@@ -554,11 +545,9 @@ contract GenArt721CoreV3_Engine is
      */
     function updateArtblocksDependencyRegistryAddress(
         address _artblocksDependencyRegistryAddress
-    )
-        external
-        onlyAdminACL(this.updateArtblocksDependencyRegistryAddress.selector)
-        onlyNonZeroAddress(_artblocksDependencyRegistryAddress)
-    {
+    ) external {
+        onlyAdminACL(this.updateArtblocksDependencyRegistryAddress.selector);
+        onlyNonZeroAddress(_artblocksDependencyRegistryAddress);
         artblocksDependencyRegistryAddress = _artblocksDependencyRegistryAddress;
         emit PlatformUpdated(FIELD_ARTBLOCKS_DEPENDENCY_REGISTRY_ADDRESS);
     }
@@ -580,14 +569,12 @@ contract GenArt721CoreV3_Engine is
         address payable _renderProviderSecondarySalesAddress,
         address payable _platformProviderPrimarySalesAddress,
         address payable _platformProviderSecondarySalesAddress
-    )
-        external
-        onlyAdminACL(this.updateProviderSalesAddresses.selector)
-        onlyNonZeroAddress(_renderProviderPrimarySalesAddress)
-        onlyNonZeroAddress(_renderProviderSecondarySalesAddress)
-        onlyNonZeroAddress(_platformProviderPrimarySalesAddress)
-        onlyNonZeroAddress(_platformProviderSecondarySalesAddress)
-    {
+    ) external {
+        onlyAdminACL(this.updateProviderSalesAddresses.selector);
+        onlyNonZeroAddress(_renderProviderPrimarySalesAddress);
+        onlyNonZeroAddress(_renderProviderSecondarySalesAddress);
+        onlyNonZeroAddress(_platformProviderPrimarySalesAddress);
+        onlyNonZeroAddress(_platformProviderSecondarySalesAddress);
         _updateProviderSalesAddresses(
             _renderProviderPrimarySalesAddress,
             _renderProviderSecondarySalesAddress,
@@ -606,10 +593,9 @@ contract GenArt721CoreV3_Engine is
     function updateProviderPrimarySalesPercentages(
         uint256 renderProviderPrimarySalesPercentage_,
         uint256 platformProviderPrimarySalesPercentage_
-    )
-        external
-        onlyAdminACL(this.updateProviderPrimarySalesPercentages.selector)
-    {
+    ) external {
+        onlyAdminACL(this.updateProviderPrimarySalesPercentages.selector);
+
         // Validate that the sum of the proposed %s, does not exceed 100%.
         require(
             (renderProviderPrimarySalesPercentage_ +
@@ -643,13 +629,14 @@ contract GenArt721CoreV3_Engine is
     function updateProviderSecondarySalesBPS(
         uint256 _renderProviderSecondarySalesBPS,
         uint256 _platformProviderSecondarySalesBPS
-    ) external onlyAdminACL(this.updateProviderSecondarySalesBPS.selector) {
+    ) external {
+        onlyAdminACL(this.updateProviderSecondarySalesBPS.selector);
         // Validate that the sum of the proposed provider BPS, does not exceed 10_000 BPS.
         require(
             (_renderProviderSecondarySalesBPS +
                 _platformProviderSecondarySalesBPS) <=
                 MAX_PROVIDER_SECONDARY_SALES_BPS,
-            "Max sum of MAX_PROVIDER_SECONDARY_SALES_BPS BPS"
+            "Over max sum of BPS"
         );
         renderProviderSecondarySalesBPS = _renderProviderSecondarySalesBPS;
         platformProviderSecondarySalesBPS = _platformProviderSecondarySalesBPS;
@@ -660,13 +647,9 @@ contract GenArt721CoreV3_Engine is
      * @notice Updates minter to `_address`.
      * @param _address Address of new minter.
      */
-    function updateMinterContract(
-        address _address
-    )
-        external
-        onlyAdminACL(this.updateMinterContract.selector)
-        onlyNonZeroAddress(_address)
-    {
+    function updateMinterContract(address _address) external {
+        onlyAdminACL(this.updateMinterContract.selector);
+        onlyNonZeroAddress(_address);
         minterContract = _address;
         emit MinterUpdated(_address);
     }
@@ -675,13 +658,9 @@ contract GenArt721CoreV3_Engine is
      * @notice Updates randomizer to `_randomizerAddress`.
      * @param _randomizerAddress Address of new randomizer.
      */
-    function updateRandomizerAddress(
-        address _randomizerAddress
-    )
-        external
-        onlyAdminACL(this.updateRandomizerAddress.selector)
-        onlyNonZeroAddress(_randomizerAddress)
-    {
+    function updateRandomizerAddress(address _randomizerAddress) external {
+        onlyAdminACL(this.updateRandomizerAddress.selector);
+        onlyNonZeroAddress(_randomizerAddress);
         _updateRandomizerAddress(_randomizerAddress);
     }
 
@@ -689,13 +668,9 @@ contract GenArt721CoreV3_Engine is
      * @notice Toggles project `_projectId` as active/inactive.
      * @param _projectId Project ID to be toggled.
      */
-    function toggleProjectIsActive(
-        uint256 _projectId
-    )
-        external
-        onlyAdminACL(this.toggleProjectIsActive.selector)
-        onlyValidProjectId(_projectId)
-    {
+    function toggleProjectIsActive(uint256 _projectId) external {
+        onlyAdminACL(this.toggleProjectIsActive.selector);
+        onlyValidProjectId(_projectId);
         projects[_projectId].active = !projects[_projectId].active;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_ACTIVE);
     }
@@ -738,12 +713,10 @@ contract GenArt721CoreV3_Engine is
         uint256 _additionalPayeePrimarySalesPercentage,
         address payable _additionalPayeeSecondarySales,
         uint256 _additionalPayeeSecondarySalesPercentage
-    )
-        external
-        onlyValidProjectId(_projectId)
-        onlyArtist(_projectId)
-        onlyNonZeroAddress(_artistAddress)
-    {
+    ) external {
+        onlyValidProjectId(_projectId);
+        onlyArtist(_projectId);
+        onlyNonZeroAddress(_artistAddress);
         ProjectFinance storage projectFinance = projectIdToFinancials[
             _projectId
         ];
@@ -861,15 +834,13 @@ contract GenArt721CoreV3_Engine is
         uint256 _additionalPayeePrimarySalesPercentage,
         address payable _additionalPayeeSecondarySales,
         uint256 _additionalPayeeSecondarySalesPercentage
-    )
-        external
-        onlyValidProjectId(_projectId)
+    ) external {
+        onlyValidProjectId(_projectId);
         onlyAdminACLOrRenouncedArtist(
             _projectId,
             this.adminAcceptArtistAddressesAndSplits.selector
-        )
-        onlyNonZeroAddress(_artistAddress)
-    {
+        );
+        onlyNonZeroAddress(_artistAddress);
         // checks
         require(
             proposedArtistAddressesAndSplitsHash[_projectId] ==
@@ -915,15 +886,13 @@ contract GenArt721CoreV3_Engine is
     function updateProjectArtistAddress(
         uint256 _projectId,
         address payable _artistAddress
-    )
-        external
-        onlyValidProjectId(_projectId)
+    ) external {
+        onlyValidProjectId(_projectId);
         onlyAdminACLOrRenouncedArtist(
             _projectId,
             this.updateProjectArtistAddress.selector
-        )
-        onlyNonZeroAddress(_artistAddress)
-    {
+        );
+        onlyNonZeroAddress(_artistAddress);
         projectIdToFinancials[_projectId].artistAddress = _artistAddress;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_ARTIST_ADDRESS);
     }
@@ -932,9 +901,8 @@ contract GenArt721CoreV3_Engine is
      * @notice Toggles paused state of project `_projectId`.
      * @param _projectId Project ID to be toggled.
      */
-    function toggleProjectIsPaused(
-        uint256 _projectId
-    ) external onlyArtist(_projectId) {
+    function toggleProjectIsPaused(uint256 _projectId) external {
+        onlyArtist(_projectId);
         projects[_projectId].paused = !projects[_projectId].paused;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_PAUSED);
     }
@@ -948,12 +916,10 @@ contract GenArt721CoreV3_Engine is
     function addProject(
         string memory _projectName,
         address payable _artistAddress
-    )
-        external
-        onlyAdminACL(this.addProject.selector)
-        onlyNonEmptyString(_projectName)
-        onlyNonZeroAddress(_artistAddress)
-    {
+    ) external {
+        onlyAdminACL(this.addProject.selector);
+        onlyNonEmptyString(_projectName);
+        onlyNonZeroAddress(_artistAddress);
         require(!newProjectsForbidden, "New projects forbidden");
         uint256 projectId = _nextProjectId;
         projectIdToFinancials[projectId].artistAddress = _artistAddress;
@@ -969,10 +935,8 @@ contract GenArt721CoreV3_Engine is
     /**
      * @notice Forever forbids new projects from being added to this contract.
      */
-    function forbidNewProjects()
-        external
-        onlyAdminACL(this.forbidNewProjects.selector)
-    {
+    function forbidNewProjects() external {
+        onlyAdminACL(this.forbidNewProjects.selector);
         require(!newProjectsForbidden, "Already forbidden");
         _forbidNewProjects();
     }
@@ -985,12 +949,10 @@ contract GenArt721CoreV3_Engine is
     function updateProjectName(
         uint256 _projectId,
         string memory _projectName
-    )
-        external
-        onlyUnlocked(_projectId)
-        onlyArtistOrAdminACL(_projectId, this.updateProjectName.selector)
-        onlyNonEmptyString(_projectName)
-    {
+    ) external {
+        onlyUnlocked(_projectId);
+        onlyArtistOrAdminACL(_projectId, this.updateProjectName.selector);
+        onlyNonEmptyString(_projectName);
         projects[_projectId].name = _projectName;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_NAME);
     }
@@ -1004,12 +966,10 @@ contract GenArt721CoreV3_Engine is
     function updateProjectArtistName(
         uint256 _projectId,
         string memory _projectArtistName
-    )
-        external
-        onlyUnlocked(_projectId)
-        onlyArtistOrAdminACL(_projectId, this.updateProjectArtistName.selector)
-        onlyNonEmptyString(_projectArtistName)
-    {
+    ) external {
+        onlyUnlocked(_projectId);
+        onlyArtistOrAdminACL(_projectId, this.updateProjectArtistName.selector);
+        onlyNonEmptyString(_projectArtistName);
         projects[_projectId].artist = _projectArtistName;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_ARTIST_NAME);
     }
@@ -1028,10 +988,11 @@ contract GenArt721CoreV3_Engine is
     function updateProjectSecondaryMarketRoyaltyPercentage(
         uint256 _projectId,
         uint256 _secondMarketRoyalty
-    ) external onlyArtist(_projectId) {
+    ) external {
+        onlyArtist(_projectId);
         require(
             _secondMarketRoyalty <= ARTIST_MAX_SECONDARY_ROYALTY_PERCENTAGE,
-            "Max of ARTIST_MAX_SECONDARY_ROYALTY_PERCENTAGE percent"
+            "Over max precent"
         );
         projectIdToFinancials[_projectId]
             .secondaryMarketRoyaltyPercentage = uint8(_secondMarketRoyalty);
@@ -1076,7 +1037,8 @@ contract GenArt721CoreV3_Engine is
     function updateProjectWebsite(
         uint256 _projectId,
         string memory _projectWebsite
-    ) external onlyArtist(_projectId) {
+    ) external {
+        onlyArtist(_projectId);
         projects[_projectId].website = _projectWebsite;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_WEBSITE);
     }
@@ -1089,12 +1051,10 @@ contract GenArt721CoreV3_Engine is
     function updateProjectLicense(
         uint256 _projectId,
         string memory _projectLicense
-    )
-        external
-        onlyUnlocked(_projectId)
-        onlyArtistOrAdminACL(_projectId, this.updateProjectLicense.selector)
-        onlyNonEmptyString(_projectLicense)
-    {
+    ) external {
+        onlyUnlocked(_projectId);
+        onlyArtistOrAdminACL(_projectId, this.updateProjectLicense.selector);
+        onlyNonEmptyString(_projectLicense);
         projects[_projectId].license = _projectLicense;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_LICENSE);
     }
@@ -1111,18 +1071,16 @@ contract GenArt721CoreV3_Engine is
     function updateProjectMaxInvocations(
         uint256 _projectId,
         uint24 _maxInvocations
-    ) external onlyArtist(_projectId) {
+    ) external {
+        onlyArtist(_projectId);
         // CHECKS
         Project storage project = projects[_projectId];
         uint256 _invocations = project.invocations;
         require(
             (_maxInvocations < project.maxInvocations),
-            "maxInvocations may only be decreased"
+            "Only maxInvocations decrease"
         );
-        require(
-            _maxInvocations >= _invocations,
-            "Only max invocations gte current invocations"
-        );
+        require(_maxInvocations >= _invocations, "Only gte invocations");
         // EFFECTS
         project.maxInvocations = _maxInvocations;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_MAX_INVOCATIONS);
@@ -1142,12 +1100,10 @@ contract GenArt721CoreV3_Engine is
     function addProjectScript(
         uint256 _projectId,
         string memory _script
-    )
-        external
-        onlyUnlocked(_projectId)
-        onlyArtistOrAdminACL(_projectId, this.addProjectScript.selector)
-        onlyNonEmptyString(_script)
-    {
+    ) external {
+        onlyUnlocked(_projectId);
+        onlyArtistOrAdminACL(_projectId, this.addProjectScript.selector);
+        onlyNonEmptyString(_script);
         Project storage project = projects[_projectId];
         // store script in contract bytecode
         project.scriptBytecodeAddresses[project.scriptCount] = _script
@@ -1167,24 +1123,13 @@ contract GenArt721CoreV3_Engine is
         uint256 _projectId,
         uint256 _scriptId,
         string memory _script
-    )
-        external
-        onlyUnlocked(_projectId)
-        onlyArtistOrAdminACL(_projectId, this.updateProjectScript.selector)
-        onlyNonEmptyString(_script)
-    {
+    ) external {
+        onlyUnlocked(_projectId);
+        onlyArtistOrAdminACL(_projectId, this.updateProjectScript.selector);
+        onlyNonEmptyString(_script);
         Project storage project = projects[_projectId];
         require(_scriptId < project.scriptCount, "scriptId out of range");
-        // purge old contract bytecode contract from the blockchain state
-        // note: Although this does reduce usage of Ethereum state, it does not
-        // reduce the gas costs of removal transactions. We believe this is the
-        // best behavior at the time of writing, and do not expect this to
-        // result in any breaking changes in the future. All current proposals
-        // to change the self-destruct opcode are backwards compatible, but may
-        // result in not removing the bytecode from the blockchain state. This
-        // implementation is compatible with that architecture, as it does not
-        // rely on the bytecode being removed from the blockchain state.
-        project.scriptBytecodeAddresses[_scriptId].purgeBytecode();
+
         // store script in contract bytecode, replacing reference address from
         // the contract that no longer exists with the newly created one
         project.scriptBytecodeAddresses[_scriptId] = _script.writeToBytecode();
@@ -1195,27 +1140,12 @@ contract GenArt721CoreV3_Engine is
      * @notice Removes last script from project `_projectId`.
      * @param _projectId Project to be updated.
      */
-    function removeProjectLastScript(
-        uint256 _projectId
-    )
-        external
-        onlyUnlocked(_projectId)
-        onlyArtistOrAdminACL(_projectId, this.removeProjectLastScript.selector)
-    {
+    function removeProjectLastScript(uint256 _projectId) external {
+        onlyUnlocked(_projectId);
+        onlyArtistOrAdminACL(_projectId, this.removeProjectLastScript.selector);
         Project storage project = projects[_projectId];
-        require(project.scriptCount > 0, "there are no scripts to remove");
-        // purge old contract bytecode contract from the blockchain state
-        // note: Although this does reduce usage of Ethereum state, it does not
-        // reduce the gas costs of removal transactions. We believe this is the
-        // best behavior at the time of writing, and do not expect this to
-        // result in any breaking changes in the future. All current proposals
-        // to change the self-destruct opcode are backwards compatible, but may
-        // result in not removing the bytecode from the blockchain state. This
-        // implementation is compatible with that architecture, as it does not
-        // rely on the bytecode being removed from the blockchain state.
-        project
-            .scriptBytecodeAddresses[project.scriptCount - 1]
-            .purgeBytecode();
+        require(project.scriptCount > 0, "No scripts to remove");
+
         // delete reference to contract address that no longer exists
         delete project.scriptBytecodeAddresses[project.scriptCount - 1];
         unchecked {
@@ -1233,11 +1163,9 @@ contract GenArt721CoreV3_Engine is
     function updateProjectScriptType(
         uint256 _projectId,
         bytes32 _scriptTypeAndVersion
-    )
-        external
-        onlyUnlocked(_projectId)
-        onlyArtistOrAdminACL(_projectId, this.updateProjectScriptType.selector)
-    {
+    ) external {
+        onlyUnlocked(_projectId);
+        onlyArtistOrAdminACL(_projectId, this.updateProjectScriptType.selector);
         Project storage project = projects[_projectId];
         // require exactly one @ symbol in _scriptTypeAndVersion
         require(
@@ -1261,12 +1189,13 @@ contract GenArt721CoreV3_Engine is
     function updateProjectAspectRatio(
         uint256 _projectId,
         string memory _aspectRatio
-    )
-        external
-        onlyUnlocked(_projectId)
-        onlyArtistOrAdminACL(_projectId, this.updateProjectAspectRatio.selector)
-        onlyNonEmptyString(_aspectRatio)
-    {
+    ) external {
+        onlyUnlocked(_projectId);
+        onlyArtistOrAdminACL(
+            _projectId,
+            this.updateProjectAspectRatio.selector
+        );
+        onlyNonEmptyString(_aspectRatio);
         // Perform more detailed input validation for aspect ratio.
         bytes memory aspectRatioBytes = bytes(_aspectRatio);
         uint256 bytesLength = aspectRatioBytes.length;
@@ -1309,7 +1238,9 @@ contract GenArt721CoreV3_Engine is
     function updateProjectBaseURI(
         uint256 _projectId,
         string memory _newBaseURI
-    ) external onlyArtist(_projectId) onlyNonEmptyString(_newBaseURI) {
+    ) external {
+        onlyArtist(_projectId);
+        onlyNonEmptyString(_newBaseURI);
         projects[_projectId].projectBaseURI = _newBaseURI;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_BASE_URI);
     }
@@ -1320,13 +1251,9 @@ contract GenArt721CoreV3_Engine is
      * projects. Token URIs are determined by their project's `projectBaseURI`.
      * @param _defaultBaseURI New default base URI.
      */
-    function updateDefaultBaseURI(
-        string memory _defaultBaseURI
-    )
-        external
-        onlyAdminACL(this.updateDefaultBaseURI.selector)
-        onlyNonEmptyString(_defaultBaseURI)
-    {
+    function updateDefaultBaseURI(string memory _defaultBaseURI) external {
+        onlyAdminACL(this.updateDefaultBaseURI.selector);
+        onlyNonEmptyString(_defaultBaseURI);
         _updateDefaultBaseURI(_defaultBaseURI);
     }
 
@@ -1709,9 +1636,9 @@ contract GenArt721CoreV3_Engine is
     )
         external
         view
-        onlyValidTokenId(_tokenId)
         returns (address payable[] memory recipients, uint256[] memory bps)
     {
+        onlyValidTokenId(_tokenId);
         // initialize arrays with maximum potential length
         recipients = new address payable[](4);
         bps = new uint256[](4);
@@ -1923,7 +1850,8 @@ contract GenArt721CoreV3_Engine is
      */
     function tokenURI(
         uint256 _tokenId
-    ) public view override onlyValidTokenId(_tokenId) returns (string memory) {
+    ) public view override returns (string memory) {
+        onlyValidTokenId(_tokenId);
         string memory _projectBaseURI = projects[tokenIdToProjectId(_tokenId)]
             .projectBaseURI;
         return string.concat(_projectBaseURI, _tokenId.toString());
@@ -2047,9 +1975,9 @@ contract GenArt721CoreV3_Engine is
      * @return bool true if project is unlocked, false otherwise.
      * @dev This also enforces that the `_projectId` passed in is valid.
      */
-    function _projectUnlocked(
-        uint256 _projectId
-    ) internal view onlyValidProjectId(_projectId) returns (bool) {
+    function _projectUnlocked(uint256 _projectId) internal view returns (bool) {
+        onlyValidProjectId(_projectId);
+
         uint256 projectCompletedTimestamp = projects[_projectId]
             .completedTimestamp;
         bool projectOpen = projectCompletedTimestamp == 0;

--- a/contracts/GenArt721CoreV3_Engine_Flex.sol
+++ b/contracts/GenArt721CoreV3_Engine_Flex.sol
@@ -278,7 +278,7 @@ contract GenArt721CoreV3_Engine_Flex is
     /// default base URI to initialize all new project projectBaseURI values to
     string public defaultBaseURI;
 
-    function onlyUnlockedProjectExternalAssetDependencies(
+    function _onlyUnlockedProjectExternalAssetDependencies(
         uint256 _projectId
     ) internal view {
         require(
@@ -287,46 +287,46 @@ contract GenArt721CoreV3_Engine_Flex is
         );
     }
 
-    function onlyNonZeroAddress(address _address) internal pure {
+    function _onlyNonZeroAddress(address _address) internal pure {
         require(_address != address(0), "Must input non-zero address");
     }
 
-    function onlyNonEmptyString(string memory _string) internal pure {
+    function _onlyNonEmptyString(string memory _string) internal pure {
         require(bytes(_string).length != 0, "Must input non-empty string");
     }
 
-    function onlyValidTokenId(uint256 _tokenId) internal view {
+    function _onlyValidTokenId(uint256 _tokenId) internal view {
         require(_exists(_tokenId), "Token ID does not exist");
     }
 
-    function onlyValidProjectId(uint256 _projectId) internal view {
+    function _onlyValidProjectId(uint256 _projectId) internal view {
         require(
             (_projectId >= startingProjectId) && (_projectId < _nextProjectId),
             "Project ID does not exist"
         );
     }
 
-    function onlyUnlocked(uint256 _projectId) internal view {
+    function _onlyUnlocked(uint256 _projectId) internal view {
         // Note: calling `_projectUnlocked` enforces that the `_projectId`
         //       passed in is valid.`
         require(_projectUnlocked(_projectId), "Only if unlocked");
     }
 
-    function onlyAdminACL(bytes4 _selector) internal {
+    function _onlyAdminACL(bytes4 _selector) internal {
         require(
             adminACLAllowed(msg.sender, address(this), _selector),
             "Only Admin ACL allowed"
         );
     }
 
-    function onlyArtist(uint256 _projectId) internal view {
+    function _onlyArtist(uint256 _projectId) internal view {
         require(
             msg.sender == projectIdToFinancials[_projectId].artistAddress,
             "Only artist"
         );
     }
 
-    function onlyArtistOrAdminACL(
+    function _onlyArtistOrAdminACL(
         uint256 _projectId,
         bytes4 _selector
     ) internal {
@@ -343,7 +343,7 @@ contract GenArt721CoreV3_Engine_Flex is
      * contract to continue to function if the owner decides to renounce
      * ownership.
      */
-    function onlyAdminACLOrRenouncedArtist(
+    function _onlyAdminACLOrRenouncedArtist(
         uint256 _projectId,
         bytes4 _selector
     ) internal {
@@ -382,10 +382,10 @@ contract GenArt721CoreV3_Engine_Flex is
         bool _autoApproveArtistSplitProposals,
         address _engineRegistryContract
     ) ERC721_PackedHashSeed(_tokenName, _tokenSymbol) {
-        onlyNonZeroAddress(_renderProviderAddress);
-        onlyNonZeroAddress(_platformProviderAddress);
-        onlyNonZeroAddress(_randomizerContract);
-        onlyNonZeroAddress(_adminACLContract);
+        _onlyNonZeroAddress(_renderProviderAddress);
+        _onlyNonZeroAddress(_platformProviderAddress);
+        _onlyNonZeroAddress(_randomizerContract);
+        _onlyNonZeroAddress(_adminACLContract);
         // setup immutable `autoApproveArtistSplitProposals` config
         autoApproveArtistSplitProposals = _autoApproveArtistSplitProposals;
         // record contracts starting project ID
@@ -423,7 +423,7 @@ contract GenArt721CoreV3_Engine_Flex is
      * @notice Updates preferredIPFSGateway to `_gateway`.
      */
     function updateIPFSGateway(string calldata _gateway) public {
-        onlyAdminACL(this.updateIPFSGateway.selector);
+        _onlyAdminACL(this.updateIPFSGateway.selector);
         preferredIPFSGateway = _gateway;
         emit GatewayUpdated(ExternalAssetDependencyType.IPFS, _gateway);
     }
@@ -432,7 +432,7 @@ contract GenArt721CoreV3_Engine_Flex is
      * @notice Updates preferredArweaveGateway to `_gateway`.
      */
     function updateArweaveGateway(string calldata _gateway) public {
-        onlyAdminACL(this.updateArweaveGateway.selector);
+        _onlyAdminACL(this.updateArweaveGateway.selector);
         preferredArweaveGateway = _gateway;
         emit GatewayUpdated(ExternalAssetDependencyType.ARWEAVE, _gateway);
     }
@@ -441,8 +441,8 @@ contract GenArt721CoreV3_Engine_Flex is
      * @notice Locks external asset dependencies for project `_projectId`.
      */
     function lockProjectExternalAssetDependencies(uint256 _projectId) external {
-        onlyUnlockedProjectExternalAssetDependencies(_projectId);
-        onlyArtistOrAdminACL(
+        _onlyUnlockedProjectExternalAssetDependencies(_projectId);
+        _onlyArtistOrAdminACL(
             _projectId,
             this.lockProjectExternalAssetDependencies.selector
         );
@@ -485,8 +485,8 @@ contract GenArt721CoreV3_Engine_Flex is
         string memory _cidOrData,
         ExternalAssetDependencyType _dependencyType
     ) external {
-        onlyUnlockedProjectExternalAssetDependencies(_projectId);
-        onlyArtistOrAdminACL(
+        _onlyUnlockedProjectExternalAssetDependencies(_projectId);
+        _onlyArtistOrAdminACL(
             _projectId,
             this.updateProjectExternalAssetDependency.selector
         );
@@ -536,8 +536,8 @@ contract GenArt721CoreV3_Engine_Flex is
         uint256 _projectId,
         uint256 _index
     ) external {
-        onlyUnlockedProjectExternalAssetDependencies(_projectId);
-        onlyArtistOrAdminACL(
+        _onlyUnlockedProjectExternalAssetDependencies(_projectId);
+        _onlyArtistOrAdminACL(
             _projectId,
             this.updateProjectExternalAssetDependency.selector
         );
@@ -597,8 +597,8 @@ contract GenArt721CoreV3_Engine_Flex is
         string memory _cidOrData,
         ExternalAssetDependencyType _dependencyType
     ) external {
-        onlyUnlockedProjectExternalAssetDependencies(_projectId);
-        onlyArtistOrAdminACL(
+        _onlyUnlockedProjectExternalAssetDependencies(_projectId);
+        _onlyArtistOrAdminACL(
             _projectId,
             this.updateProjectExternalAssetDependency.selector
         );
@@ -715,7 +715,7 @@ contract GenArt721CoreV3_Engine_Flex is
      * minimize gas when minting.
      */
     function setTokenHash_8PT(uint256 _tokenId, bytes32 _hashSeed) external {
-        onlyValidTokenId(_tokenId);
+        _onlyValidTokenId(_tokenId);
         OwnerAndHashSeed storage ownerAndHashSeed = _ownersAndHashSeeds[
             _tokenId
         ];
@@ -766,8 +766,8 @@ contract GenArt721CoreV3_Engine_Flex is
     function updateArtblocksDependencyRegistryAddress(
         address _artblocksDependencyRegistryAddress
     ) external {
-        onlyNonZeroAddress(_artblocksDependencyRegistryAddress);
-        onlyAdminACL(this.updateArtblocksDependencyRegistryAddress.selector);
+        _onlyNonZeroAddress(_artblocksDependencyRegistryAddress);
+        _onlyAdminACL(this.updateArtblocksDependencyRegistryAddress.selector);
         artblocksDependencyRegistryAddress = _artblocksDependencyRegistryAddress;
         emit PlatformUpdated(FIELD_ARTBLOCKS_DEPENDENCY_REGISTRY_ADDRESS);
     }
@@ -790,11 +790,11 @@ contract GenArt721CoreV3_Engine_Flex is
         address payable _platformProviderPrimarySalesAddress,
         address payable _platformProviderSecondarySalesAddress
     ) external {
-        onlyNonZeroAddress(_renderProviderPrimarySalesAddress);
-        onlyNonZeroAddress(_renderProviderSecondarySalesAddress);
-        onlyNonZeroAddress(_platformProviderPrimarySalesAddress);
-        onlyNonZeroAddress(_platformProviderSecondarySalesAddress);
-        onlyAdminACL(this.updateProviderSalesAddresses.selector);
+        _onlyNonZeroAddress(_renderProviderPrimarySalesAddress);
+        _onlyNonZeroAddress(_renderProviderSecondarySalesAddress);
+        _onlyNonZeroAddress(_platformProviderPrimarySalesAddress);
+        _onlyNonZeroAddress(_platformProviderSecondarySalesAddress);
+        _onlyAdminACL(this.updateProviderSalesAddresses.selector);
         _updateProviderSalesAddresses(
             _renderProviderPrimarySalesAddress,
             _renderProviderSecondarySalesAddress,
@@ -814,7 +814,7 @@ contract GenArt721CoreV3_Engine_Flex is
         uint256 renderProviderPrimarySalesPercentage_,
         uint256 platformProviderPrimarySalesPercentage_
     ) external {
-        onlyAdminACL(this.updateProviderPrimarySalesPercentages.selector);
+        _onlyAdminACL(this.updateProviderPrimarySalesPercentages.selector);
         // Validate that the sum of the proposed %s, does not exceed 100%.
         require(
             (renderProviderPrimarySalesPercentage_ +
@@ -849,7 +849,7 @@ contract GenArt721CoreV3_Engine_Flex is
         uint256 _renderProviderSecondarySalesBPS,
         uint256 _platformProviderSecondarySalesBPS
     ) external {
-        onlyAdminACL(this.updateProviderSecondarySalesBPS.selector);
+        _onlyAdminACL(this.updateProviderSecondarySalesBPS.selector);
         // Validate that the sum of the proposed provider BPS, does not exceed 10_000 BPS.
         require(
             (_renderProviderSecondarySalesBPS +
@@ -867,8 +867,8 @@ contract GenArt721CoreV3_Engine_Flex is
      * @param _address Address of new minter.
      */
     function updateMinterContract(address _address) external {
-        onlyNonZeroAddress(_address);
-        onlyAdminACL(this.updateMinterContract.selector);
+        _onlyNonZeroAddress(_address);
+        _onlyAdminACL(this.updateMinterContract.selector);
         minterContract = _address;
         emit MinterUpdated(_address);
     }
@@ -878,8 +878,8 @@ contract GenArt721CoreV3_Engine_Flex is
      * @param _randomizerAddress Address of new randomizer.
      */
     function updateRandomizerAddress(address _randomizerAddress) external {
-        onlyNonZeroAddress(_randomizerAddress);
-        onlyAdminACL(this.updateRandomizerAddress.selector);
+        _onlyNonZeroAddress(_randomizerAddress);
+        _onlyAdminACL(this.updateRandomizerAddress.selector);
         _updateRandomizerAddress(_randomizerAddress);
     }
 
@@ -888,8 +888,8 @@ contract GenArt721CoreV3_Engine_Flex is
      * @param _projectId Project ID to be toggled.
      */
     function toggleProjectIsActive(uint256 _projectId) external {
-        onlyValidProjectId(_projectId);
-        onlyAdminACL(this.toggleProjectIsActive.selector);
+        _onlyValidProjectId(_projectId);
+        _onlyAdminACL(this.toggleProjectIsActive.selector);
         projects[_projectId].active = !projects[_projectId].active;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_ACTIVE);
     }
@@ -933,9 +933,9 @@ contract GenArt721CoreV3_Engine_Flex is
         address payable _additionalPayeeSecondarySales,
         uint256 _additionalPayeeSecondarySalesPercentage
     ) external {
-        onlyNonZeroAddress(_artistAddress);
-        onlyValidProjectId(_projectId);
-        onlyArtist(_projectId);
+        _onlyNonZeroAddress(_artistAddress);
+        _onlyValidProjectId(_projectId);
+        _onlyArtist(_projectId);
         ProjectFinance storage projectFinance = projectIdToFinancials[
             _projectId
         ];
@@ -1054,9 +1054,9 @@ contract GenArt721CoreV3_Engine_Flex is
         address payable _additionalPayeeSecondarySales,
         uint256 _additionalPayeeSecondarySalesPercentage
     ) external {
-        onlyNonZeroAddress(_artistAddress);
-        onlyValidProjectId(_projectId);
-        onlyAdminACLOrRenouncedArtist(
+        _onlyNonZeroAddress(_artistAddress);
+        _onlyValidProjectId(_projectId);
+        _onlyAdminACLOrRenouncedArtist(
             _projectId,
             this.adminAcceptArtistAddressesAndSplits.selector
         );
@@ -1106,9 +1106,9 @@ contract GenArt721CoreV3_Engine_Flex is
         uint256 _projectId,
         address payable _artistAddress
     ) external {
-        onlyNonZeroAddress(_artistAddress);
-        onlyValidProjectId(_projectId);
-        onlyAdminACLOrRenouncedArtist(
+        _onlyNonZeroAddress(_artistAddress);
+        _onlyValidProjectId(_projectId);
+        _onlyAdminACLOrRenouncedArtist(
             _projectId,
             this.updateProjectArtistAddress.selector
         );
@@ -1121,7 +1121,7 @@ contract GenArt721CoreV3_Engine_Flex is
      * @param _projectId Project ID to be toggled.
      */
     function toggleProjectIsPaused(uint256 _projectId) external {
-        onlyArtist(_projectId);
+        _onlyArtist(_projectId);
         projects[_projectId].paused = !projects[_projectId].paused;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_PAUSED);
     }
@@ -1136,9 +1136,9 @@ contract GenArt721CoreV3_Engine_Flex is
         string memory _projectName,
         address payable _artistAddress
     ) external {
-        onlyNonZeroAddress(_artistAddress);
-        onlyNonEmptyString(_projectName);
-        onlyAdminACL(this.addProject.selector);
+        _onlyNonZeroAddress(_artistAddress);
+        _onlyNonEmptyString(_projectName);
+        _onlyAdminACL(this.addProject.selector);
         require(!newProjectsForbidden, "New projects forbidden");
         uint256 projectId = _nextProjectId;
         projectIdToFinancials[projectId].artistAddress = _artistAddress;
@@ -1155,7 +1155,7 @@ contract GenArt721CoreV3_Engine_Flex is
      * @notice Forever forbids new projects from being added to this contract.
      */
     function forbidNewProjects() external {
-        onlyAdminACL(this.forbidNewProjects.selector);
+        _onlyAdminACL(this.forbidNewProjects.selector);
         require(!newProjectsForbidden, "Already forbidden");
         _forbidNewProjects();
     }
@@ -1169,9 +1169,9 @@ contract GenArt721CoreV3_Engine_Flex is
         uint256 _projectId,
         string memory _projectName
     ) external {
-        onlyNonEmptyString(_projectName);
-        onlyUnlocked(_projectId);
-        onlyArtistOrAdminACL(_projectId, this.updateProjectName.selector);
+        _onlyNonEmptyString(_projectName);
+        _onlyUnlocked(_projectId);
+        _onlyArtistOrAdminACL(_projectId, this.updateProjectName.selector);
         projects[_projectId].name = _projectName;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_NAME);
     }
@@ -1186,9 +1186,12 @@ contract GenArt721CoreV3_Engine_Flex is
         uint256 _projectId,
         string memory _projectArtistName
     ) external {
-        onlyNonEmptyString(_projectArtistName);
-        onlyUnlocked(_projectId);
-        onlyArtistOrAdminACL(_projectId, this.updateProjectArtistName.selector);
+        _onlyNonEmptyString(_projectArtistName);
+        _onlyUnlocked(_projectId);
+        _onlyArtistOrAdminACL(
+            _projectId,
+            this.updateProjectArtistName.selector
+        );
         projects[_projectId].artist = _projectArtistName;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_ARTIST_NAME);
     }
@@ -1208,7 +1211,7 @@ contract GenArt721CoreV3_Engine_Flex is
         uint256 _projectId,
         uint256 _secondMarketRoyalty
     ) external {
-        onlyArtist(_projectId);
+        _onlyArtist(_projectId);
         require(
             _secondMarketRoyalty <= ARTIST_MAX_SECONDARY_ROYALTY_PERCENTAGE,
             "Over max percent"
@@ -1257,7 +1260,7 @@ contract GenArt721CoreV3_Engine_Flex is
         uint256 _projectId,
         string memory _projectWebsite
     ) external {
-        onlyArtist(_projectId);
+        _onlyArtist(_projectId);
         projects[_projectId].website = _projectWebsite;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_WEBSITE);
     }
@@ -1271,9 +1274,9 @@ contract GenArt721CoreV3_Engine_Flex is
         uint256 _projectId,
         string memory _projectLicense
     ) external {
-        onlyNonEmptyString(_projectLicense);
-        onlyUnlocked(_projectId);
-        onlyArtistOrAdminACL(_projectId, this.updateProjectLicense.selector);
+        _onlyNonEmptyString(_projectLicense);
+        _onlyUnlocked(_projectId);
+        _onlyArtistOrAdminACL(_projectId, this.updateProjectLicense.selector);
         projects[_projectId].license = _projectLicense;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_LICENSE);
     }
@@ -1291,7 +1294,7 @@ contract GenArt721CoreV3_Engine_Flex is
         uint256 _projectId,
         uint24 _maxInvocations
     ) external {
-        onlyArtist(_projectId);
+        _onlyArtist(_projectId);
         // CHECKS
         Project storage project = projects[_projectId];
         uint256 _invocations = project.invocations;
@@ -1320,9 +1323,9 @@ contract GenArt721CoreV3_Engine_Flex is
         uint256 _projectId,
         string memory _script
     ) external {
-        onlyNonEmptyString(_script);
-        onlyUnlocked(_projectId);
-        onlyArtistOrAdminACL(_projectId, this.addProjectScript.selector);
+        _onlyNonEmptyString(_script);
+        _onlyUnlocked(_projectId);
+        _onlyArtistOrAdminACL(_projectId, this.addProjectScript.selector);
         Project storage project = projects[_projectId];
         // store script in contract bytecode
         project.scriptBytecodeAddresses[project.scriptCount] = _script
@@ -1343,9 +1346,9 @@ contract GenArt721CoreV3_Engine_Flex is
         uint256 _scriptId,
         string memory _script
     ) external {
-        onlyNonEmptyString(_script);
-        onlyUnlocked(_projectId);
-        onlyArtistOrAdminACL(_projectId, this.updateProjectScript.selector);
+        _onlyNonEmptyString(_script);
+        _onlyUnlocked(_projectId);
+        _onlyArtistOrAdminACL(_projectId, this.updateProjectScript.selector);
         Project storage project = projects[_projectId];
         require(_scriptId < project.scriptCount, "scriptId out of range");
 
@@ -1360,8 +1363,11 @@ contract GenArt721CoreV3_Engine_Flex is
      * @param _projectId Project to be updated.
      */
     function removeProjectLastScript(uint256 _projectId) external {
-        onlyUnlocked(_projectId);
-        onlyArtistOrAdminACL(_projectId, this.removeProjectLastScript.selector);
+        _onlyUnlocked(_projectId);
+        _onlyArtistOrAdminACL(
+            _projectId,
+            this.removeProjectLastScript.selector
+        );
         Project storage project = projects[_projectId];
         require(project.scriptCount > 0, "No scripts to remove");
 
@@ -1383,8 +1389,11 @@ contract GenArt721CoreV3_Engine_Flex is
         uint256 _projectId,
         bytes32 _scriptTypeAndVersion
     ) external {
-        onlyUnlocked(_projectId);
-        onlyArtistOrAdminACL(_projectId, this.updateProjectScriptType.selector);
+        _onlyUnlocked(_projectId);
+        _onlyArtistOrAdminACL(
+            _projectId,
+            this.updateProjectScriptType.selector
+        );
         Project storage project = projects[_projectId];
         // require exactly one @ symbol in _scriptTypeAndVersion
         require(
@@ -1409,9 +1418,9 @@ contract GenArt721CoreV3_Engine_Flex is
         uint256 _projectId,
         string memory _aspectRatio
     ) external {
-        onlyNonEmptyString(_aspectRatio);
-        onlyUnlocked(_projectId);
-        onlyArtistOrAdminACL(
+        _onlyNonEmptyString(_aspectRatio);
+        _onlyUnlocked(_projectId);
+        _onlyArtistOrAdminACL(
             _projectId,
             this.updateProjectAspectRatio.selector
         );
@@ -1458,8 +1467,8 @@ contract GenArt721CoreV3_Engine_Flex is
         uint256 _projectId,
         string memory _newBaseURI
     ) external {
-        onlyNonEmptyString(_newBaseURI);
-        onlyArtist(_projectId);
+        _onlyNonEmptyString(_newBaseURI);
+        _onlyArtist(_projectId);
         projects[_projectId].projectBaseURI = _newBaseURI;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_BASE_URI);
     }
@@ -1471,8 +1480,8 @@ contract GenArt721CoreV3_Engine_Flex is
      * @param _defaultBaseURI New default base URI.
      */
     function updateDefaultBaseURI(string memory _defaultBaseURI) external {
-        onlyNonEmptyString(_defaultBaseURI);
-        onlyAdminACL(this.updateDefaultBaseURI.selector);
+        _onlyNonEmptyString(_defaultBaseURI);
+        _onlyAdminACL(this.updateDefaultBaseURI.selector);
         _updateDefaultBaseURI(_defaultBaseURI);
     }
 
@@ -1857,7 +1866,7 @@ contract GenArt721CoreV3_Engine_Flex is
         view
         returns (address payable[] memory recipients, uint256[] memory bps)
     {
-        onlyValidTokenId(_tokenId);
+        _onlyValidTokenId(_tokenId);
         // initialize arrays with maximum potential length
         recipients = new address payable[](4);
         bps = new uint256[](4);
@@ -2070,7 +2079,7 @@ contract GenArt721CoreV3_Engine_Flex is
     function tokenURI(
         uint256 _tokenId
     ) public view override returns (string memory) {
-        onlyValidTokenId(_tokenId);
+        _onlyValidTokenId(_tokenId);
         string memory _projectBaseURI = projects[tokenIdToProjectId(_tokenId)]
             .projectBaseURI;
         return string.concat(_projectBaseURI, toString(_tokenId));
@@ -2195,7 +2204,7 @@ contract GenArt721CoreV3_Engine_Flex is
      * @dev This also enforces that the `_projectId` passed in is valid.
      */
     function _projectUnlocked(uint256 _projectId) internal view returns (bool) {
-        onlyValidProjectId(_projectId);
+        _onlyValidProjectId(_projectId);
         uint256 projectCompletedTimestamp = projects[_projectId]
             .completedTimestamp;
         bool projectOpen = projectCompletedTimestamp == 0;

--- a/contracts/GenArt721CoreV3_Engine_Flex.sol
+++ b/contracts/GenArt721CoreV3_Engine_Flex.sol
@@ -10,7 +10,6 @@ import "./interfaces/0.8.x/IGenArt721CoreContractV3_Engine_Flex.sol";
 import "./interfaces/0.8.x/IDependencyRegistryCompatibleV0.sol";
 import "./interfaces/0.8.x/IManifold.sol";
 
-import "@openzeppelin-4.7/contracts/utils/Strings.sol";
 import "@openzeppelin-4.7/contracts/access/Ownable.sol";
 import "./libs/0.8.x/ERC721_PackedHashSeed.sol";
 import "./libs/0.8.x/BytecodeStorage.sol";
@@ -101,17 +100,15 @@ contract GenArt721CoreV3_Engine_Flex is
     using BytecodeStorage for string;
     using BytecodeStorage for address;
     using Bytes32Strings for bytes32;
-    using Strings for uint256;
-    using Strings for address;
-    uint256 constant ONE_HUNDRED = 100;
+    uint256 ONE_HUNDRED = 100;
     uint256 constant ONE_MILLION = 1_000_000;
-    uint24 constant ONE_MILLION_UINT24 = 1_000_000;
-    uint256 constant FOUR_WEEKS_IN_SECONDS = 2_419_200;
-    uint8 constant AT_CHARACTER_CODE = uint8(bytes1("@")); // 0x40
+    uint24 ONE_MILLION_UINT24 = 1_000_000;
+    uint256 FOUR_WEEKS_IN_SECONDS = 2_419_200;
+    uint8 AT_CHARACTER_CODE = uint8(bytes1("@")); // 0x40
 
     // numeric constants
-    uint256 constant MAX_PROVIDER_SECONDARY_SALES_BPS = 10000; // 10_000 BPS = 100%
-    uint256 constant ARTIST_MAX_SECONDARY_ROYALTY_PERCENTAGE = 95; // 95%
+    uint256 MAX_PROVIDER_SECONDARY_SALES_BPS = 10000; // 10_000 BPS = 100%
+    uint256 ARTIST_MAX_SECONDARY_ROYALTY_PERCENTAGE = 95; // 95%
 
     // This contract emits generic events that contain fields that indicate
     // which parameter has been updated. This is sufficient for application
@@ -123,36 +120,35 @@ contract GenArt721CoreV3_Engine_Flex is
     //
     // The following fields are used to indicate which contract-level parameter
     // has been updated in the `PlatformUpdated` event:
-    bytes32 constant FIELD_NEXT_PROJECT_ID = "nextProjectId";
-    bytes32 constant FIELD_NEW_PROJECTS_FORBIDDEN = "newProjectsForbidden";
-    bytes32 constant FIELD_DEFAULT_BASE_URI = "defaultBaseURI";
-    bytes32 constant FIELD_RANDOMIZER_ADDRESS = "randomizerAddress";
-    bytes32 constant FIELD_ARTBLOCKS_DEPENDENCY_REGISTRY_ADDRESS =
+    bytes32 FIELD_NEXT_PROJECT_ID = "nextProjectId";
+    bytes32 FIELD_NEW_PROJECTS_FORBIDDEN = "newProjectsForbidden";
+    bytes32 FIELD_DEFAULT_BASE_URI = "defaultBaseURI";
+    bytes32 FIELD_RANDOMIZER_ADDRESS = "randomizerAddress";
+    bytes32 FIELD_ARTBLOCKS_DEPENDENCY_REGISTRY_ADDRESS =
         "dependencyRegistryAddress";
-    bytes32 constant FIELD_PROVIDER_SALES_ADDRESSES = "providerSalesAddresses";
-    bytes32 constant FIELD_PROVIDER_PRIMARY_SALES_PERCENTAGES =
+    bytes32 FIELD_PROVIDER_SALES_ADDRESSES = "providerSalesAddresses";
+    bytes32 FIELD_PROVIDER_PRIMARY_SALES_PERCENTAGES =
         "providerPrimaryPercentages";
-    bytes32 constant FIELD_PROVIDER_SECONDARY_SALES_BPS =
-        "providerSecondaryBPS";
+    bytes32 FIELD_PROVIDER_SECONDARY_SALES_BPS = "providerSecondaryBPS";
     // The following fields are used to indicate which project-level parameter
     // has been updated in the `ProjectUpdated` event:
-    bytes32 constant FIELD_PROJECT_COMPLETED = "completed";
-    bytes32 constant FIELD_PROJECT_ACTIVE = "active";
-    bytes32 constant FIELD_PROJECT_ARTIST_ADDRESS = "artistAddress";
-    bytes32 constant FIELD_PROJECT_PAUSED = "paused";
-    bytes32 constant FIELD_PROJECT_CREATED = "created";
-    bytes32 constant FIELD_PROJECT_NAME = "name";
-    bytes32 constant FIELD_PROJECT_ARTIST_NAME = "artistName";
-    bytes32 constant FIELD_PROJECT_SECONDARY_MARKET_ROYALTY_PERCENTAGE =
+    bytes32 FIELD_PROJECT_COMPLETED = "completed";
+    bytes32 FIELD_PROJECT_ACTIVE = "active";
+    bytes32 FIELD_PROJECT_ARTIST_ADDRESS = "artistAddress";
+    bytes32 FIELD_PROJECT_PAUSED = "paused";
+    bytes32 FIELD_PROJECT_CREATED = "created";
+    bytes32 FIELD_PROJECT_NAME = "name";
+    bytes32 FIELD_PROJECT_ARTIST_NAME = "artistName";
+    bytes32 FIELD_PROJECT_SECONDARY_MARKET_ROYALTY_PERCENTAGE =
         "royaltyPercentage";
-    bytes32 constant FIELD_PROJECT_DESCRIPTION = "description";
-    bytes32 constant FIELD_PROJECT_WEBSITE = "website";
-    bytes32 constant FIELD_PROJECT_LICENSE = "license";
-    bytes32 constant FIELD_PROJECT_MAX_INVOCATIONS = "maxInvocations";
-    bytes32 constant FIELD_PROJECT_SCRIPT = "script";
-    bytes32 constant FIELD_PROJECT_SCRIPT_TYPE = "scriptType";
-    bytes32 constant FIELD_PROJECT_ASPECT_RATIO = "aspectRatio";
-    bytes32 constant FIELD_PROJECT_BASE_URI = "baseURI";
+    bytes32 FIELD_PROJECT_DESCRIPTION = "description";
+    bytes32 FIELD_PROJECT_WEBSITE = "website";
+    bytes32 FIELD_PROJECT_LICENSE = "license";
+    bytes32 FIELD_PROJECT_MAX_INVOCATIONS = "maxInvocations";
+    bytes32 FIELD_PROJECT_SCRIPT = "script";
+    bytes32 FIELD_PROJECT_SCRIPT_TYPE = "scriptType";
+    bytes32 FIELD_PROJECT_ASPECT_RATIO = "aspectRatio";
+    bytes32 FIELD_PROJECT_BASE_URI = "baseURI";
 
     /// Dependency registry managed by Art Blocks
     address public artblocksDependencyRegistryAddress;
@@ -266,82 +262,78 @@ contract GenArt721CoreV3_Engine_Flex is
     bool public immutable autoApproveArtistSplitProposals;
 
     /// version & type of this core contract
-    bytes32 constant CORE_VERSION = "v3.1.1";
+    bytes32 CORE_VERSION = "v3.1.1";
 
-    function coreVersion() external pure returns (string memory) {
+    function coreVersion() external view returns (string memory) {
         return CORE_VERSION.toString();
     }
 
-    bytes32 constant CORE_TYPE = "GenArt721CoreV3_Engine_Flex";
+    bytes32 CORE_TYPE = "GenArt721CoreV3_Engine_Flex";
 
-    function coreType() external pure returns (string memory) {
+    function coreType() external view returns (string memory) {
         return CORE_TYPE.toString();
     }
 
     /// default base URI to initialize all new project projectBaseURI values to
     string public defaultBaseURI;
 
-    modifier onlyUnlockedProjectExternalAssetDependencies(uint256 _projectId) {
+    function onlyUnlockedProjectExternalAssetDependencies(
+        uint256 _projectId
+    ) internal view {
         require(
             !projects[_projectId].externalAssetDependenciesLocked,
-            "Project external asset dependencies are locked"
+            "External dependencies locked"
         );
-        _;
     }
 
-    modifier onlyNonZeroAddress(address _address) {
+    function onlyNonZeroAddress(address _address) internal pure {
         require(_address != address(0), "Must input non-zero address");
-        _;
     }
 
-    modifier onlyNonEmptyString(string memory _string) {
+    function onlyNonEmptyString(string memory _string) internal pure {
         require(bytes(_string).length != 0, "Must input non-empty string");
-        _;
     }
 
-    modifier onlyValidTokenId(uint256 _tokenId) {
+    function onlyValidTokenId(uint256 _tokenId) internal view {
         require(_exists(_tokenId), "Token ID does not exist");
-        _;
     }
 
-    modifier onlyValidProjectId(uint256 _projectId) {
+    function onlyValidProjectId(uint256 _projectId) internal view {
         require(
             (_projectId >= startingProjectId) && (_projectId < _nextProjectId),
             "Project ID does not exist"
         );
-        _;
     }
 
-    modifier onlyUnlocked(uint256 _projectId) {
+    function onlyUnlocked(uint256 _projectId) internal view {
         // Note: calling `_projectUnlocked` enforces that the `_projectId`
         //       passed in is valid.`
         require(_projectUnlocked(_projectId), "Only if unlocked");
-        _;
     }
 
-    modifier onlyAdminACL(bytes4 _selector) {
+    function onlyAdminACL(bytes4 _selector) internal {
         require(
             adminACLAllowed(msg.sender, address(this), _selector),
             "Only Admin ACL allowed"
         );
-        _;
     }
 
-    modifier onlyArtist(uint256 _projectId) {
+    function onlyArtist(uint256 _projectId) internal view {
         require(
             msg.sender == projectIdToFinancials[_projectId].artistAddress,
             "Only artist"
         );
-        _;
     }
 
-    modifier onlyArtistOrAdminACL(uint256 _projectId, bytes4 _selector) {
+    function onlyArtistOrAdminACL(
+        uint256 _projectId,
+        bytes4 _selector
+    ) internal {
         require(
             msg.sender == projectIdToFinancials[_projectId].artistAddress ||
                 adminACLAllowed(msg.sender, address(this), _selector),
             "Only artist or Admin ACL allowed"
         );
-        _;
     }
 
     /**
@@ -350,10 +342,10 @@ contract GenArt721CoreV3_Engine_Flex is
      * contract to continue to function if the owner decides to renounce
      * ownership.
      */
-    modifier onlyAdminACLOrRenouncedArtist(
+    function onlyAdminACLOrRenouncedArtist(
         uint256 _projectId,
         bytes4 _selector
-    ) {
+    ) internal {
         require(
             adminACLAllowed(msg.sender, address(this), _selector) ||
                 (owner() == address(0) &&
@@ -361,7 +353,6 @@ contract GenArt721CoreV3_Engine_Flex is
                     projectIdToFinancials[_projectId].artistAddress),
             "Only Admin ACL allowed, or artist if owner has renounced"
         );
-        _;
     }
 
     /**
@@ -389,13 +380,11 @@ contract GenArt721CoreV3_Engine_Flex is
         uint248 _startingProjectId,
         bool _autoApproveArtistSplitProposals,
         address _engineRegistryContract
-    )
-        ERC721_PackedHashSeed(_tokenName, _tokenSymbol)
-        onlyNonZeroAddress(_renderProviderAddress)
-        onlyNonZeroAddress(_platformProviderAddress)
-        onlyNonZeroAddress(_randomizerContract)
-        onlyNonZeroAddress(_adminACLContract)
-    {
+    ) ERC721_PackedHashSeed(_tokenName, _tokenSymbol) {
+        onlyNonZeroAddress(_renderProviderAddress);
+        onlyNonZeroAddress(_platformProviderAddress);
+        onlyNonZeroAddress(_randomizerContract);
+        onlyNonZeroAddress(_adminACLContract);
         // setup immutable `autoApproveArtistSplitProposals` config
         autoApproveArtistSplitProposals = _autoApproveArtistSplitProposals;
         // record contracts starting project ID
@@ -414,7 +403,7 @@ contract GenArt721CoreV3_Engine_Flex is
         _updateDefaultBaseURI(
             string.concat(
                 "https://token.artblocks.io/",
-                address(this).toHexString(),
+                toHexString(address(this)),
                 "/"
             )
         );
@@ -432,10 +421,8 @@ contract GenArt721CoreV3_Engine_Flex is
     /**
      * @notice Updates preferredIPFSGateway to `_gateway`.
      */
-    function updateIPFSGateway(string calldata _gateway)
-        public
-        onlyAdminACL(this.updateIPFSGateway.selector)
-    {
+    function updateIPFSGateway(string calldata _gateway) public {
+        onlyAdminACL(this.updateIPFSGateway.selector);
         preferredIPFSGateway = _gateway;
         emit GatewayUpdated(ExternalAssetDependencyType.IPFS, _gateway);
     }
@@ -443,10 +430,8 @@ contract GenArt721CoreV3_Engine_Flex is
     /**
      * @notice Updates preferredArweaveGateway to `_gateway`.
      */
-    function updateArweaveGateway(string calldata _gateway)
-        public
-        onlyAdminACL(this.updateArweaveGateway.selector)
-    {
+    function updateArweaveGateway(string calldata _gateway) public {
+        onlyAdminACL(this.updateArweaveGateway.selector);
         preferredArweaveGateway = _gateway;
         emit GatewayUpdated(ExternalAssetDependencyType.ARWEAVE, _gateway);
     }
@@ -454,14 +439,12 @@ contract GenArt721CoreV3_Engine_Flex is
     /**
      * @notice Locks external asset dependencies for project `_projectId`.
      */
-    function lockProjectExternalAssetDependencies(uint256 _projectId)
-        external
+    function lockProjectExternalAssetDependencies(uint256 _projectId) external {
+        onlyUnlockedProjectExternalAssetDependencies(_projectId);
         onlyArtistOrAdminACL(
             _projectId,
             this.lockProjectExternalAssetDependencies.selector
-        )
-        onlyUnlockedProjectExternalAssetDependencies(_projectId)
-    {
+        );
         projects[_projectId].externalAssetDependenciesLocked = true;
         emit ProjectExternalAssetDependenciesLocked(_projectId);
     }
@@ -479,11 +462,9 @@ contract GenArt721CoreV3_Engine_Flex is
     /**
      * @notice Returns external asset dependency count for project `_projectId` at index `_index`.
      */
-    function projectExternalAssetDependencyCount(uint256 _projectId)
-        public
-        view
-        returns (uint256)
-    {
+    function projectExternalAssetDependencyCount(
+        uint256 _projectId
+    ) public view returns (uint256) {
         return uint256(projects[_projectId].externalAssetDependencyCount);
     }
 
@@ -502,14 +483,12 @@ contract GenArt721CoreV3_Engine_Flex is
         uint256 _index,
         string memory _cidOrData,
         ExternalAssetDependencyType _dependencyType
-    )
-        external
-        onlyUnlockedProjectExternalAssetDependencies(_projectId)
+    ) external {
+        onlyUnlockedProjectExternalAssetDependencies(_projectId);
         onlyArtistOrAdminACL(
             _projectId,
             this.updateProjectExternalAssetDependency.selector
-        )
-    {
+        );
         uint24 assetCount = projects[_projectId].externalAssetDependencyCount;
         require(_index < assetCount, "Asset index out of range");
         ExternalAssetDependencyType oldDependencyType = projects[_projectId]
@@ -522,9 +501,7 @@ contract GenArt721CoreV3_Engine_Flex is
         if (_dependencyType == ExternalAssetDependencyType.ONCHAIN) {
             // purge bytecode if we are replacing an existing onchain asset
             if (oldDependencyType == ExternalAssetDependencyType.ONCHAIN) {
-                projects[_projectId]
-                    .externalAssetDependencyBytecodeAddresses[_index]
-                    .purgeBytecode();
+                // do not purge bytecode due to deprecated self-destruct
             } else {
                 // we only need to set the cid to an empty string if we are replacing an offchain asset
                 // an onchain asset will already have an empty cid
@@ -532,8 +509,8 @@ contract GenArt721CoreV3_Engine_Flex is
             }
 
             projects[_projectId].externalAssetDependencyBytecodeAddresses[
-                    _index
-                ] = _cidOrData.writeToBytecode();
+                _index
+            ] = _cidOrData.writeToBytecode();
             // we don't want to emit data, so we emit the cid as an empty string
             _cidOrData = "";
         } else {
@@ -560,14 +537,12 @@ contract GenArt721CoreV3_Engine_Flex is
     function removeProjectExternalAssetDependency(
         uint256 _projectId,
         uint256 _index
-    )
-        external
-        onlyUnlockedProjectExternalAssetDependencies(_projectId)
+    ) external {
+        onlyUnlockedProjectExternalAssetDependencies(_projectId);
         onlyArtistOrAdminACL(
             _projectId,
             this.updateProjectExternalAssetDependency.selector
-        )
-    {
+        );
         uint24 assetCount = projects[_projectId].externalAssetDependencyCount;
         require(_index < assetCount, "Asset index out of range");
 
@@ -578,10 +553,7 @@ contract GenArt721CoreV3_Engine_Flex is
                 .externalAssetDependencies[_index]
                 .dependencyType == ExternalAssetDependencyType.ONCHAIN
         ) {
-            //purging bytecode of deleted asset
-            projects[_projectId]
-                .externalAssetDependencyBytecodeAddresses[_index]
-                .purgeBytecode();
+            // do not purge bytecode due to deprecated self-destruct
             delete projects[_projectId]
                 .externalAssetDependencyBytecodeAddresses[_index];
         }
@@ -598,9 +570,10 @@ contract GenArt721CoreV3_Engine_Flex is
         ) {
             // copy last element bytecode address to index of element to be removed
             projects[_projectId].externalAssetDependencyBytecodeAddresses[
-                    _index
-                ] = projects[_projectId]
-                .externalAssetDependencyBytecodeAddresses[lastElementIndex];
+                _index
+            ] = projects[_projectId].externalAssetDependencyBytecodeAddresses[
+                lastElementIndex
+            ];
             // delete last element bytecode address
             delete projects[_projectId]
                 .externalAssetDependencyBytecodeAddresses[lastElementIndex];
@@ -626,20 +599,18 @@ contract GenArt721CoreV3_Engine_Flex is
         uint256 _projectId,
         string memory _cidOrData,
         ExternalAssetDependencyType _dependencyType
-    )
-        external
-        onlyUnlockedProjectExternalAssetDependencies(_projectId)
+    ) external {
+        onlyUnlockedProjectExternalAssetDependencies(_projectId);
         onlyArtistOrAdminACL(
             _projectId,
             this.updateProjectExternalAssetDependency.selector
-        )
-    {
+        );
         uint24 assetCount = projects[_projectId].externalAssetDependencyCount;
         // if the incoming dependency type is onchain, we need to write the data to bytecode
         if (_dependencyType == ExternalAssetDependencyType.ONCHAIN) {
             projects[_projectId].externalAssetDependencyBytecodeAddresses[
-                    assetCount
-                ] = _cidOrData.writeToBytecode();
+                assetCount
+            ] = _cidOrData.writeToBytecode();
             _cidOrData = "";
         }
         ExternalAssetDependency memory asset = ExternalAssetDependency({
@@ -746,10 +717,8 @@ contract GenArt721CoreV3_Engine_Flex is
      * for indexing purposes, it must be emitted by the randomizer. This is to
      * minimize gas when minting.
      */
-    function setTokenHash_8PT(uint256 _tokenId, bytes32 _hashSeed)
-        external
-        onlyValidTokenId(_tokenId)
-    {
+    function setTokenHash_8PT(uint256 _tokenId, bytes32 _hashSeed) external {
+        onlyValidTokenId(_tokenId);
         OwnerAndHashSeed storage ownerAndHashSeed = _ownersAndHashSeeds[
             _tokenId
         ];
@@ -799,11 +768,9 @@ contract GenArt721CoreV3_Engine_Flex is
      */
     function updateArtblocksDependencyRegistryAddress(
         address _artblocksDependencyRegistryAddress
-    )
-        external
-        onlyAdminACL(this.updateArtblocksDependencyRegistryAddress.selector)
-        onlyNonZeroAddress(_artblocksDependencyRegistryAddress)
-    {
+    ) external {
+        onlyNonZeroAddress(_artblocksDependencyRegistryAddress);
+        onlyAdminACL(this.updateArtblocksDependencyRegistryAddress.selector);
         artblocksDependencyRegistryAddress = _artblocksDependencyRegistryAddress;
         emit PlatformUpdated(FIELD_ARTBLOCKS_DEPENDENCY_REGISTRY_ADDRESS);
     }
@@ -825,14 +792,12 @@ contract GenArt721CoreV3_Engine_Flex is
         address payable _renderProviderSecondarySalesAddress,
         address payable _platformProviderPrimarySalesAddress,
         address payable _platformProviderSecondarySalesAddress
-    )
-        external
-        onlyAdminACL(this.updateProviderSalesAddresses.selector)
-        onlyNonZeroAddress(_renderProviderPrimarySalesAddress)
-        onlyNonZeroAddress(_renderProviderSecondarySalesAddress)
-        onlyNonZeroAddress(_platformProviderPrimarySalesAddress)
-        onlyNonZeroAddress(_platformProviderSecondarySalesAddress)
-    {
+    ) external {
+        onlyNonZeroAddress(_renderProviderPrimarySalesAddress);
+        onlyNonZeroAddress(_renderProviderSecondarySalesAddress);
+        onlyNonZeroAddress(_platformProviderPrimarySalesAddress);
+        onlyNonZeroAddress(_platformProviderSecondarySalesAddress);
+        onlyAdminACL(this.updateProviderSalesAddresses.selector);
         _updateProviderSalesAddresses(
             _renderProviderPrimarySalesAddress,
             _renderProviderSecondarySalesAddress,
@@ -851,10 +816,8 @@ contract GenArt721CoreV3_Engine_Flex is
     function updateProviderPrimarySalesPercentages(
         uint256 renderProviderPrimarySalesPercentage_,
         uint256 platformProviderPrimarySalesPercentage_
-    )
-        external
-        onlyAdminACL(this.updateProviderPrimarySalesPercentages.selector)
-    {
+    ) external {
+        onlyAdminACL(this.updateProviderPrimarySalesPercentages.selector);
         // Validate that the sum of the proposed %s, does not exceed 100%.
         require(
             (renderProviderPrimarySalesPercentage_ +
@@ -888,7 +851,8 @@ contract GenArt721CoreV3_Engine_Flex is
     function updateProviderSecondarySalesBPS(
         uint256 _renderProviderSecondarySalesBPS,
         uint256 _platformProviderSecondarySalesBPS
-    ) external onlyAdminACL(this.updateProviderSecondarySalesBPS.selector) {
+    ) external {
+        onlyAdminACL(this.updateProviderSecondarySalesBPS.selector);
         // Validate that the sum of the proposed provider BPS, does not exceed 10_000 BPS.
         require(
             (_renderProviderSecondarySalesBPS +
@@ -905,11 +869,9 @@ contract GenArt721CoreV3_Engine_Flex is
      * @notice Updates minter to `_address`.
      * @param _address Address of new minter.
      */
-    function updateMinterContract(address _address)
-        external
-        onlyAdminACL(this.updateMinterContract.selector)
-        onlyNonZeroAddress(_address)
-    {
+    function updateMinterContract(address _address) external {
+        onlyNonZeroAddress(_address);
+        onlyAdminACL(this.updateMinterContract.selector);
         minterContract = _address;
         emit MinterUpdated(_address);
     }
@@ -918,11 +880,9 @@ contract GenArt721CoreV3_Engine_Flex is
      * @notice Updates randomizer to `_randomizerAddress`.
      * @param _randomizerAddress Address of new randomizer.
      */
-    function updateRandomizerAddress(address _randomizerAddress)
-        external
-        onlyAdminACL(this.updateRandomizerAddress.selector)
-        onlyNonZeroAddress(_randomizerAddress)
-    {
+    function updateRandomizerAddress(address _randomizerAddress) external {
+        onlyNonZeroAddress(_randomizerAddress);
+        onlyAdminACL(this.updateRandomizerAddress.selector);
         _updateRandomizerAddress(_randomizerAddress);
     }
 
@@ -930,11 +890,9 @@ contract GenArt721CoreV3_Engine_Flex is
      * @notice Toggles project `_projectId` as active/inactive.
      * @param _projectId Project ID to be toggled.
      */
-    function toggleProjectIsActive(uint256 _projectId)
-        external
-        onlyAdminACL(this.toggleProjectIsActive.selector)
-        onlyValidProjectId(_projectId)
-    {
+    function toggleProjectIsActive(uint256 _projectId) external {
+        onlyValidProjectId(_projectId);
+        onlyAdminACL(this.toggleProjectIsActive.selector);
         projects[_projectId].active = !projects[_projectId].active;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_ACTIVE);
     }
@@ -977,12 +935,10 @@ contract GenArt721CoreV3_Engine_Flex is
         uint256 _additionalPayeePrimarySalesPercentage,
         address payable _additionalPayeeSecondarySales,
         uint256 _additionalPayeeSecondarySalesPercentage
-    )
-        external
-        onlyValidProjectId(_projectId)
-        onlyArtist(_projectId)
-        onlyNonZeroAddress(_artistAddress)
-    {
+    ) external {
+        onlyNonZeroAddress(_artistAddress);
+        onlyValidProjectId(_projectId);
+        onlyArtist(_projectId);
         ProjectFinance storage projectFinance = projectIdToFinancials[
             _projectId
         ];
@@ -1100,15 +1056,13 @@ contract GenArt721CoreV3_Engine_Flex is
         uint256 _additionalPayeePrimarySalesPercentage,
         address payable _additionalPayeeSecondarySales,
         uint256 _additionalPayeeSecondarySalesPercentage
-    )
-        external
-        onlyValidProjectId(_projectId)
+    ) external {
+        onlyNonZeroAddress(_artistAddress);
+        onlyValidProjectId(_projectId);
         onlyAdminACLOrRenouncedArtist(
             _projectId,
             this.adminAcceptArtistAddressesAndSplits.selector
-        )
-        onlyNonZeroAddress(_artistAddress)
-    {
+        );
         // checks
         require(
             proposedArtistAddressesAndSplitsHash[_projectId] ==
@@ -1154,15 +1108,13 @@ contract GenArt721CoreV3_Engine_Flex is
     function updateProjectArtistAddress(
         uint256 _projectId,
         address payable _artistAddress
-    )
-        external
-        onlyValidProjectId(_projectId)
+    ) external {
+        onlyNonZeroAddress(_artistAddress);
+        onlyValidProjectId(_projectId);
         onlyAdminACLOrRenouncedArtist(
             _projectId,
             this.updateProjectArtistAddress.selector
-        )
-        onlyNonZeroAddress(_artistAddress)
-    {
+        );
         projectIdToFinancials[_projectId].artistAddress = _artistAddress;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_ARTIST_ADDRESS);
     }
@@ -1171,10 +1123,8 @@ contract GenArt721CoreV3_Engine_Flex is
      * @notice Toggles paused state of project `_projectId`.
      * @param _projectId Project ID to be toggled.
      */
-    function toggleProjectIsPaused(uint256 _projectId)
-        external
-        onlyArtist(_projectId)
-    {
+    function toggleProjectIsPaused(uint256 _projectId) external {
+        onlyArtist(_projectId);
         projects[_projectId].paused = !projects[_projectId].paused;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_PAUSED);
     }
@@ -1188,12 +1138,10 @@ contract GenArt721CoreV3_Engine_Flex is
     function addProject(
         string memory _projectName,
         address payable _artistAddress
-    )
-        external
-        onlyAdminACL(this.addProject.selector)
-        onlyNonEmptyString(_projectName)
-        onlyNonZeroAddress(_artistAddress)
-    {
+    ) external {
+        onlyNonZeroAddress(_artistAddress);
+        onlyNonEmptyString(_projectName);
+        onlyAdminACL(this.addProject.selector);
         require(!newProjectsForbidden, "New projects forbidden");
         uint256 projectId = _nextProjectId;
         projectIdToFinancials[projectId].artistAddress = _artistAddress;
@@ -1209,10 +1157,8 @@ contract GenArt721CoreV3_Engine_Flex is
     /**
      * @notice Forever forbids new projects from being added to this contract.
      */
-    function forbidNewProjects()
-        external
-        onlyAdminACL(this.forbidNewProjects.selector)
-    {
+    function forbidNewProjects() external {
+        onlyAdminACL(this.forbidNewProjects.selector);
         require(!newProjectsForbidden, "Already forbidden");
         _forbidNewProjects();
     }
@@ -1222,12 +1168,13 @@ contract GenArt721CoreV3_Engine_Flex is
      * @param _projectId Project ID.
      * @param _projectName New project name.
      */
-    function updateProjectName(uint256 _projectId, string memory _projectName)
-        external
-        onlyUnlocked(_projectId)
-        onlyArtistOrAdminACL(_projectId, this.updateProjectName.selector)
-        onlyNonEmptyString(_projectName)
-    {
+    function updateProjectName(
+        uint256 _projectId,
+        string memory _projectName
+    ) external {
+        onlyNonEmptyString(_projectName);
+        onlyUnlocked(_projectId);
+        onlyArtistOrAdminACL(_projectId, this.updateProjectName.selector);
         projects[_projectId].name = _projectName;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_NAME);
     }
@@ -1241,12 +1188,10 @@ contract GenArt721CoreV3_Engine_Flex is
     function updateProjectArtistName(
         uint256 _projectId,
         string memory _projectArtistName
-    )
-        external
-        onlyUnlocked(_projectId)
-        onlyArtistOrAdminACL(_projectId, this.updateProjectArtistName.selector)
-        onlyNonEmptyString(_projectArtistName)
-    {
+    ) external {
+        onlyNonEmptyString(_projectArtistName);
+        onlyUnlocked(_projectId);
+        onlyArtistOrAdminACL(_projectId, this.updateProjectArtistName.selector);
         projects[_projectId].artist = _projectArtistName;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_ARTIST_NAME);
     }
@@ -1265,7 +1210,8 @@ contract GenArt721CoreV3_Engine_Flex is
     function updateProjectSecondaryMarketRoyaltyPercentage(
         uint256 _projectId,
         uint256 _secondMarketRoyalty
-    ) external onlyArtist(_projectId) {
+    ) external {
+        onlyArtist(_projectId);
         require(
             _secondMarketRoyalty <= ARTIST_MAX_SECONDARY_ROYALTY_PERCENTAGE,
             "Max of ARTIST_MAX_SECONDARY_ROYALTY_PERCENTAGE percent"
@@ -1313,7 +1259,8 @@ contract GenArt721CoreV3_Engine_Flex is
     function updateProjectWebsite(
         uint256 _projectId,
         string memory _projectWebsite
-    ) external onlyArtist(_projectId) {
+    ) external {
+        onlyArtist(_projectId);
         projects[_projectId].website = _projectWebsite;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_WEBSITE);
     }
@@ -1326,12 +1273,10 @@ contract GenArt721CoreV3_Engine_Flex is
     function updateProjectLicense(
         uint256 _projectId,
         string memory _projectLicense
-    )
-        external
-        onlyUnlocked(_projectId)
-        onlyArtistOrAdminACL(_projectId, this.updateProjectLicense.selector)
-        onlyNonEmptyString(_projectLicense)
-    {
+    ) external {
+        onlyNonEmptyString(_projectLicense);
+        onlyUnlocked(_projectId);
+        onlyArtistOrAdminACL(_projectId, this.updateProjectLicense.selector);
         projects[_projectId].license = _projectLicense;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_LICENSE);
     }
@@ -1348,7 +1293,8 @@ contract GenArt721CoreV3_Engine_Flex is
     function updateProjectMaxInvocations(
         uint256 _projectId,
         uint24 _maxInvocations
-    ) external onlyArtist(_projectId) {
+    ) external {
+        onlyArtist(_projectId);
         // CHECKS
         Project storage project = projects[_projectId];
         uint256 _invocations = project.invocations;
@@ -1376,12 +1322,13 @@ contract GenArt721CoreV3_Engine_Flex is
      * @param _script Script to be added. Required to be a non-empty string,
      * but no further validation is performed.
      */
-    function addProjectScript(uint256 _projectId, string memory _script)
-        external
-        onlyUnlocked(_projectId)
-        onlyArtistOrAdminACL(_projectId, this.addProjectScript.selector)
-        onlyNonEmptyString(_script)
-    {
+    function addProjectScript(
+        uint256 _projectId,
+        string memory _script
+    ) external {
+        onlyNonEmptyString(_script);
+        onlyUnlocked(_projectId);
+        onlyArtistOrAdminACL(_projectId, this.addProjectScript.selector);
         Project storage project = projects[_projectId];
         // store script in contract bytecode
         project.scriptBytecodeAddresses[project.scriptCount] = _script
@@ -1401,24 +1348,13 @@ contract GenArt721CoreV3_Engine_Flex is
         uint256 _projectId,
         uint256 _scriptId,
         string memory _script
-    )
-        external
-        onlyUnlocked(_projectId)
-        onlyArtistOrAdminACL(_projectId, this.updateProjectScript.selector)
-        onlyNonEmptyString(_script)
-    {
+    ) external {
+        onlyNonEmptyString(_script);
+        onlyUnlocked(_projectId);
+        onlyArtistOrAdminACL(_projectId, this.updateProjectScript.selector);
         Project storage project = projects[_projectId];
         require(_scriptId < project.scriptCount, "scriptId out of range");
-        // purge old contract bytecode contract from the blockchain state
-        // note: Although this does reduce usage of Ethereum state, it does not
-        // reduce the gas costs of removal transactions. We believe this is the
-        // best behavior at the time of writing, and do not expect this to
-        // result in any breaking changes in the future. All current proposals
-        // to change the self-destruct opcode are backwards compatible, but may
-        // result in not removing the bytecode from the blockchain state. This
-        // implementation is compatible with that architecture, as it does not
-        // rely on the bytecode being removed from the blockchain state.
-        project.scriptBytecodeAddresses[_scriptId].purgeBytecode();
+        // do not purge bytecode due to deprecated self-destruct
         // store script in contract bytecode, replacing reference address from
         // the contract that no longer exists with the newly created one
         project.scriptBytecodeAddresses[_scriptId] = _script.writeToBytecode();
@@ -1429,23 +1365,12 @@ contract GenArt721CoreV3_Engine_Flex is
      * @notice Removes last script from project `_projectId`.
      * @param _projectId Project to be updated.
      */
-    function removeProjectLastScript(uint256 _projectId)
-        external
-        onlyUnlocked(_projectId)
-        onlyArtistOrAdminACL(_projectId, this.removeProjectLastScript.selector)
-    {
+    function removeProjectLastScript(uint256 _projectId) external {
+        onlyUnlocked(_projectId);
+        onlyArtistOrAdminACL(_projectId, this.removeProjectLastScript.selector);
         Project storage project = projects[_projectId];
         require(project.scriptCount > 0, "there are no scripts to remove");
-        // purge old contract bytecode contract from the blockchain state
-        // note: Although this does reduce usage of Ethereum state, it does not
-        // reduce the gas costs of removal transactions. We believe this is the
-        // best behavior at the time of writing, and do not expect this to
-        // result in any breaking changes in the future. All current proposals
-        // to change the self-destruct opcode are backwards compatible, but may
-        // result in not removing the bytecode from the blockchain state. This
-        // implementation is compatible with that architecture, as it does not
-        // rely on the bytecode being removed from the blockchain state.
-        project.scriptBytecodeAddresses[project.scriptCount - 1].purgeBytecode();
+        // do not purge bytecode due to deprecated self-destruct
         // delete reference to contract address that no longer exists
         delete project.scriptBytecodeAddresses[project.scriptCount - 1];
         unchecked {
@@ -1463,11 +1388,9 @@ contract GenArt721CoreV3_Engine_Flex is
     function updateProjectScriptType(
         uint256 _projectId,
         bytes32 _scriptTypeAndVersion
-    )
-        external
-        onlyUnlocked(_projectId)
-        onlyArtistOrAdminACL(_projectId, this.updateProjectScriptType.selector)
-    {
+    ) external {
+        onlyUnlocked(_projectId);
+        onlyArtistOrAdminACL(_projectId, this.updateProjectScriptType.selector);
         Project storage project = projects[_projectId];
         // require exactly one @ symbol in _scriptTypeAndVersion
         require(
@@ -1491,12 +1414,13 @@ contract GenArt721CoreV3_Engine_Flex is
     function updateProjectAspectRatio(
         uint256 _projectId,
         string memory _aspectRatio
-    )
-        external
-        onlyUnlocked(_projectId)
-        onlyArtistOrAdminACL(_projectId, this.updateProjectAspectRatio.selector)
-        onlyNonEmptyString(_aspectRatio)
-    {
+    ) external {
+        onlyNonEmptyString(_aspectRatio);
+        onlyUnlocked(_projectId);
+        onlyArtistOrAdminACL(
+            _projectId,
+            this.updateProjectAspectRatio.selector
+        );
         // Perform more detailed input validation for aspect ratio.
         bytes memory aspectRatioBytes = bytes(_aspectRatio);
         uint256 bytesLength = aspectRatioBytes.length;
@@ -1536,11 +1460,12 @@ contract GenArt721CoreV3_Engine_Flex is
      * @param _projectId Project to be updated.
      * @param _newBaseURI New base URI.
      */
-    function updateProjectBaseURI(uint256 _projectId, string memory _newBaseURI)
-        external
-        onlyArtist(_projectId)
-        onlyNonEmptyString(_newBaseURI)
-    {
+    function updateProjectBaseURI(
+        uint256 _projectId,
+        string memory _newBaseURI
+    ) external {
+        onlyNonEmptyString(_newBaseURI);
+        onlyArtist(_projectId);
         projects[_projectId].projectBaseURI = _newBaseURI;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_BASE_URI);
     }
@@ -1551,11 +1476,9 @@ contract GenArt721CoreV3_Engine_Flex is
      * projects. Token URIs are determined by their project's `projectBaseURI`.
      * @param _defaultBaseURI New default base URI.
      */
-    function updateDefaultBaseURI(string memory _defaultBaseURI)
-        external
-        onlyAdminACL(this.updateDefaultBaseURI.selector)
-        onlyNonEmptyString(_defaultBaseURI)
-    {
+    function updateDefaultBaseURI(string memory _defaultBaseURI) external {
+        onlyNonEmptyString(_defaultBaseURI);
+        onlyAdminACL(this.updateDefaultBaseURI.selector);
         _updateDefaultBaseURI(_defaultBaseURI);
     }
 
@@ -1590,11 +1513,9 @@ contract GenArt721CoreV3_Engine_Flex is
      * @return bytes12 Token hash seed.
      * @dev token hash seed is keccak256 hashed to give the token hash
      */
-    function tokenIdToHashSeed(uint256 _tokenId)
-        external
-        view
-        returns (bytes12)
-    {
+    function tokenIdToHashSeed(
+        uint256 _tokenId
+    ) external view returns (bytes12) {
         return _ownersAndHashSeeds[_tokenId].hashSeed;
     }
 
@@ -1632,11 +1553,9 @@ contract GenArt721CoreV3_Engine_Flex is
      * @param _projectId Project ID to be queried.
      * @return address Artist's address.
      */
-    function projectIdToArtistAddress(uint256 _projectId)
-        external
-        view
-        returns (address payable)
-    {
+    function projectIdToArtistAddress(
+        uint256 _projectId
+    ) external view returns (address payable) {
         return projectIdToFinancials[_projectId].artistAddress;
     }
 
@@ -1648,11 +1567,9 @@ contract GenArt721CoreV3_Engine_Flex is
      * @param _projectId Project ID to be queried.
      * @return uint256 Artist's secondary market royalty percentage.
      */
-    function projectIdToSecondaryMarketRoyaltyPercentage(uint256 _projectId)
-        external
-        view
-        returns (uint256)
-    {
+    function projectIdToSecondaryMarketRoyaltyPercentage(
+        uint256 _projectId
+    ) external view returns (uint256) {
         return
             projectIdToFinancials[_projectId].secondaryMarketRoyaltyPercentage;
     }
@@ -1663,11 +1580,9 @@ contract GenArt721CoreV3_Engine_Flex is
      * @param _projectId Project ID to be queried.
      * @return address Artist's additional payee address for primary sales.
      */
-    function projectIdToAdditionalPayeePrimarySales(uint256 _projectId)
-        external
-        view
-        returns (address payable)
-    {
+    function projectIdToAdditionalPayeePrimarySales(
+        uint256 _projectId
+    ) external view returns (address payable) {
         return projectIdToFinancials[_projectId].additionalPayeePrimarySales;
     }
 
@@ -1692,11 +1607,9 @@ contract GenArt721CoreV3_Engine_Flex is
      * @return address payable Artist's additional payee address for secondary
      * sales.
      */
-    function projectIdToAdditionalPayeeSecondarySales(uint256 _projectId)
-        external
-        view
-        returns (address payable)
-    {
+    function projectIdToAdditionalPayeeSecondarySales(
+        uint256 _projectId
+    ) external view returns (address payable) {
         return projectIdToFinancials[_projectId].additionalPayeeSecondarySales;
     }
 
@@ -1724,7 +1637,9 @@ contract GenArt721CoreV3_Engine_Flex is
      * @return license Project license
      * @dev this function was named projectDetails prior to V3 core contract.
      */
-    function projectDetails(uint256 _projectId)
+    function projectDetails(
+        uint256 _projectId
+    )
         external
         view
         returns (
@@ -1755,7 +1670,9 @@ contract GenArt721CoreV3_Engine_Flex is
      * @return locked Boolean representing if project is locked
      * @dev price and currency info are located on minter contracts
      */
-    function projectStateData(uint256 _projectId)
+    function projectStateData(
+        uint256 _projectId
+    )
         external
         view
         returns (
@@ -1794,7 +1711,9 @@ contract GenArt721CoreV3_Engine_Flex is
      * the sum of `renderProviderSecondarySalesBPS`
      * and `platformProviderSecondarySalesBPS`.
      */
-    function projectArtistPaymentInfo(uint256 _projectId)
+    function projectArtistPaymentInfo(
+        uint256 _projectId
+    )
         external
         view
         returns (
@@ -1831,7 +1750,9 @@ contract GenArt721CoreV3_Engine_Flex is
      * "1.77777778" for 16:9, etc.)
      * @return scriptCount Count of scripts for project
      */
-    function projectScriptDetails(uint256 _projectId)
+    function projectScriptDetails(
+        uint256 _projectId
+    )
         external
         view
         returns (
@@ -1862,11 +1783,10 @@ contract GenArt721CoreV3_Engine_Flex is
      * @param _projectId Project to be queried.
      * @param _index Index of script to be queried.
      */
-    function projectScriptByIndex(uint256 _projectId, uint256 _index)
-        external
-        view
-        returns (string memory)
-    {
+    function projectScriptByIndex(
+        uint256 _projectId,
+        uint256 _index
+    ) external view returns (string memory) {
         Project storage project = projects[_projectId];
         // If trying to access an out-of-index script, return the empty string.
         if (_index >= project.scriptCount) {
@@ -1880,11 +1800,9 @@ contract GenArt721CoreV3_Engine_Flex is
      * @param _projectId Project to be queried.
      * @return projectBaseURI Base URI for project
      */
-    function projectURIInfo(uint256 _projectId)
-        external
-        view
-        returns (string memory projectBaseURI)
-    {
+    function projectURIInfo(
+        uint256 _projectId
+    ) external view returns (string memory projectBaseURI) {
         projectBaseURI = projects[_projectId].projectBaseURI;
     }
 
@@ -1916,11 +1834,9 @@ contract GenArt721CoreV3_Engine_Flex is
      * @dev If a randomizer is switched away from and then switched back to, it
      * will show up in the history twice.
      */
-    function getHistoricalRandomizerAt(uint256 _index)
-        external
-        view
-        returns (address)
-    {
+    function getHistoricalRandomizerAt(
+        uint256 _index
+    ) external view returns (address) {
         require(
             _index < _historicalRandomizerAddresses.length,
             "Index out of bounds"
@@ -1940,12 +1856,14 @@ contract GenArt721CoreV3_Engine_Flex is
      * @dev reverts if invalid _tokenId
      * @dev only returns recipients that have a non-zero BPS allocation
      */
-    function getRoyalties(uint256 _tokenId)
+    function getRoyalties(
+        uint256 _tokenId
+    )
         external
         view
-        onlyValidTokenId(_tokenId)
         returns (address payable[] memory recipients, uint256[] memory bps)
     {
+        onlyValidTokenId(_tokenId);
         // initialize arrays with maximum potential length
         recipients = new address payable[](4);
         bps = new uint256[](4);
@@ -2030,7 +1948,10 @@ contract GenArt721CoreV3_Engine_Flex is
      * to the contract performing the revenue split to handle this
      * appropriately.
      */
-    function getPrimaryRevenueSplits(uint256 _projectId, uint256 _price)
+    function getPrimaryRevenueSplits(
+        uint256 _projectId,
+        uint256 _price
+    )
         external
         view
         returns (
@@ -2094,11 +2015,9 @@ contract GenArt721CoreV3_Engine_Flex is
      * @param _tokenId Token ID to be queried.
      * @return _projectId Project ID for given `_tokenId`.
      */
-    function tokenIdToProjectId(uint256 _tokenId)
-        public
-        pure
-        returns (uint256 _projectId)
-    {
+    function tokenIdToProjectId(
+        uint256 _tokenId
+    ) public pure returns (uint256 _projectId) {
         return _tokenId / ONE_MILLION;
     }
 
@@ -2154,28 +2073,21 @@ contract GenArt721CoreV3_Engine_Flex is
      * @dev token URIs are the concatenation of the project base URI and the
      * token ID.
      */
-    function tokenURI(uint256 _tokenId)
-        public
-        view
-        override
-        onlyValidTokenId(_tokenId)
-        returns (string memory)
-    {
+    function tokenURI(
+        uint256 _tokenId
+    ) public view override returns (string memory) {
+        onlyValidTokenId(_tokenId);
         string memory _projectBaseURI = projects[tokenIdToProjectId(_tokenId)]
             .projectBaseURI;
-        return string.concat(_projectBaseURI, _tokenId.toString());
+        return string.concat(_projectBaseURI, toString(_tokenId));
     }
 
     /**
      * @dev See {IERC165-supportsInterface}.
      */
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        virtual
-        override
-        returns (bool)
-    {
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override returns (bool) {
         return
             interfaceId == type(IManifold).interfaceId ||
             super.supportsInterface(interfaceId);
@@ -2288,12 +2200,8 @@ contract GenArt721CoreV3_Engine_Flex is
      * @return bool true if project is unlocked, false otherwise.
      * @dev This also enforces that the `_projectId` passed in is valid.
      */
-    function _projectUnlocked(uint256 _projectId)
-        internal
-        view
-        onlyValidProjectId(_projectId)
-        returns (bool)
-    {
+    function _projectUnlocked(uint256 _projectId) internal view returns (bool) {
+        onlyValidProjectId(_projectId);
         uint256 projectCompletedTimestamp = projects[_projectId]
             .completedTimestamp;
         bool projectOpen = projectCompletedTimestamp == 0;
@@ -2301,5 +2209,60 @@ contract GenArt721CoreV3_Engine_Flex is
             projectOpen ||
             (block.timestamp - projectCompletedTimestamp <
                 FOUR_WEEKS_IN_SECONDS);
+    }
+
+    // strings library from OpenZeppelin, modified for no constants
+
+    bytes16 private _HEX_SYMBOLS = "0123456789abcdef";
+    uint8 private _ADDRESS_LENGTH = 20;
+
+    /**
+     * @dev Converts a `uint256` to its ASCII `string` decimal representation.
+     */
+    function toString(uint256 value) internal pure returns (string memory) {
+        // Inspired by OraclizeAPI's implementation - MIT licence
+        // https://github.com/oraclize/ethereum-api/blob/b42146b063c7d6ee1358846c198246239e9360e8/oraclizeAPI_0.4.25.sol
+
+        if (value == 0) {
+            return "0";
+        }
+        uint256 temp = value;
+        uint256 digits;
+        while (temp != 0) {
+            digits++;
+            temp /= 10;
+        }
+        bytes memory buffer = new bytes(digits);
+        while (value != 0) {
+            digits -= 1;
+            buffer[digits] = bytes1(uint8(48 + uint256(value % 10)));
+            value /= 10;
+        }
+        return string(buffer);
+    }
+
+    /**
+     * @dev Converts a `uint256` to its ASCII `string` hexadecimal representation with fixed length.
+     */
+    function toHexString(
+        uint256 value,
+        uint256 length
+    ) internal view returns (string memory) {
+        bytes memory buffer = new bytes(2 * length + 2);
+        buffer[0] = "0";
+        buffer[1] = "x";
+        for (uint256 i = 2 * length + 1; i > 1; --i) {
+            buffer[i] = _HEX_SYMBOLS[value & 0xf];
+            value >>= 4;
+        }
+        require(value == 0, "Strings: hex length insufficient");
+        return string(buffer);
+    }
+
+    /**
+     * @dev Converts an `address` with fixed length of 20 bytes to its not checksummed ASCII `string` hexadecimal representation.
+     */
+    function toHexString(address addr) internal view returns (string memory) {
+        return toHexString(uint256(uint160(addr)), _ADDRESS_LENGTH);
     }
 }

--- a/contracts/GenArt721CoreV3_Engine_Flex.sol
+++ b/contracts/GenArt721CoreV3_Engine_Flex.sol
@@ -100,15 +100,15 @@ contract GenArt721CoreV3_Engine_Flex is
     using BytecodeStorage for string;
     using BytecodeStorage for address;
     using Bytes32Strings for bytes32;
-    uint256 ONE_HUNDRED = 100;
+    uint256 constant ONE_HUNDRED = 100;
     uint256 constant ONE_MILLION = 1_000_000;
-    uint24 ONE_MILLION_UINT24 = 1_000_000;
-    uint256 FOUR_WEEKS_IN_SECONDS = 2_419_200;
-    uint8 AT_CHARACTER_CODE = uint8(bytes1("@")); // 0x40
+    uint24 constant ONE_MILLION_UINT24 = 1_000_000;
+    uint256 constant FOUR_WEEKS_IN_SECONDS = 2_419_200;
+    uint8 constant AT_CHARACTER_CODE = uint8(bytes1("@")); // 0x40
 
     // numeric constants
-    uint256 MAX_PROVIDER_SECONDARY_SALES_BPS = 10000; // 10_000 BPS = 100%
-    uint256 ARTIST_MAX_SECONDARY_ROYALTY_PERCENTAGE = 95; // 95%
+    uint256 constant MAX_PROVIDER_SECONDARY_SALES_BPS = 10000; // 10_000 BPS = 100%
+    uint256 constant ARTIST_MAX_SECONDARY_ROYALTY_PERCENTAGE = 95; // 95%
 
     // This contract emits generic events that contain fields that indicate
     // which parameter has been updated. This is sufficient for application
@@ -120,35 +120,36 @@ contract GenArt721CoreV3_Engine_Flex is
     //
     // The following fields are used to indicate which contract-level parameter
     // has been updated in the `PlatformUpdated` event:
-    bytes32 FIELD_NEXT_PROJECT_ID = "nextProjectId";
-    bytes32 FIELD_NEW_PROJECTS_FORBIDDEN = "newProjectsForbidden";
-    bytes32 FIELD_DEFAULT_BASE_URI = "defaultBaseURI";
-    bytes32 FIELD_RANDOMIZER_ADDRESS = "randomizerAddress";
-    bytes32 FIELD_ARTBLOCKS_DEPENDENCY_REGISTRY_ADDRESS =
+    bytes32 constant FIELD_NEXT_PROJECT_ID = "nextProjectId";
+    bytes32 constant FIELD_NEW_PROJECTS_FORBIDDEN = "newProjectsForbidden";
+    bytes32 constant FIELD_DEFAULT_BASE_URI = "defaultBaseURI";
+    bytes32 constant FIELD_RANDOMIZER_ADDRESS = "randomizerAddress";
+    bytes32 constant FIELD_ARTBLOCKS_DEPENDENCY_REGISTRY_ADDRESS =
         "dependencyRegistryAddress";
-    bytes32 FIELD_PROVIDER_SALES_ADDRESSES = "providerSalesAddresses";
-    bytes32 FIELD_PROVIDER_PRIMARY_SALES_PERCENTAGES =
+    bytes32 constant FIELD_PROVIDER_SALES_ADDRESSES = "providerSalesAddresses";
+    bytes32 constant FIELD_PROVIDER_PRIMARY_SALES_PERCENTAGES =
         "providerPrimaryPercentages";
-    bytes32 FIELD_PROVIDER_SECONDARY_SALES_BPS = "providerSecondaryBPS";
+    bytes32 constant FIELD_PROVIDER_SECONDARY_SALES_BPS =
+        "providerSecondaryBPS";
     // The following fields are used to indicate which project-level parameter
     // has been updated in the `ProjectUpdated` event:
-    bytes32 FIELD_PROJECT_COMPLETED = "completed";
-    bytes32 FIELD_PROJECT_ACTIVE = "active";
-    bytes32 FIELD_PROJECT_ARTIST_ADDRESS = "artistAddress";
-    bytes32 FIELD_PROJECT_PAUSED = "paused";
-    bytes32 FIELD_PROJECT_CREATED = "created";
-    bytes32 FIELD_PROJECT_NAME = "name";
-    bytes32 FIELD_PROJECT_ARTIST_NAME = "artistName";
-    bytes32 FIELD_PROJECT_SECONDARY_MARKET_ROYALTY_PERCENTAGE =
+    bytes32 constant FIELD_PROJECT_COMPLETED = "completed";
+    bytes32 constant FIELD_PROJECT_ACTIVE = "active";
+    bytes32 constant FIELD_PROJECT_ARTIST_ADDRESS = "artistAddress";
+    bytes32 constant FIELD_PROJECT_PAUSED = "paused";
+    bytes32 constant FIELD_PROJECT_CREATED = "created";
+    bytes32 constant FIELD_PROJECT_NAME = "name";
+    bytes32 constant FIELD_PROJECT_ARTIST_NAME = "artistName";
+    bytes32 constant FIELD_PROJECT_SECONDARY_MARKET_ROYALTY_PERCENTAGE =
         "royaltyPercentage";
-    bytes32 FIELD_PROJECT_DESCRIPTION = "description";
-    bytes32 FIELD_PROJECT_WEBSITE = "website";
-    bytes32 FIELD_PROJECT_LICENSE = "license";
-    bytes32 FIELD_PROJECT_MAX_INVOCATIONS = "maxInvocations";
-    bytes32 FIELD_PROJECT_SCRIPT = "script";
-    bytes32 FIELD_PROJECT_SCRIPT_TYPE = "scriptType";
-    bytes32 FIELD_PROJECT_ASPECT_RATIO = "aspectRatio";
-    bytes32 FIELD_PROJECT_BASE_URI = "baseURI";
+    bytes32 constant FIELD_PROJECT_DESCRIPTION = "description";
+    bytes32 constant FIELD_PROJECT_WEBSITE = "website";
+    bytes32 constant FIELD_PROJECT_LICENSE = "license";
+    bytes32 constant FIELD_PROJECT_MAX_INVOCATIONS = "maxInvocations";
+    bytes32 constant FIELD_PROJECT_SCRIPT = "script";
+    bytes32 constant FIELD_PROJECT_SCRIPT_TYPE = "scriptType";
+    bytes32 constant FIELD_PROJECT_ASPECT_RATIO = "aspectRatio";
+    bytes32 constant FIELD_PROJECT_BASE_URI = "baseURI";
 
     /// Dependency registry managed by Art Blocks
     address public artblocksDependencyRegistryAddress;
@@ -262,15 +263,15 @@ contract GenArt721CoreV3_Engine_Flex is
     bool public immutable autoApproveArtistSplitProposals;
 
     /// version & type of this core contract
-    bytes32 CORE_VERSION = "v3.1.1";
+    bytes32 constant CORE_VERSION = "v3.1.1";
 
-    function coreVersion() external view returns (string memory) {
+    function coreVersion() external pure returns (string memory) {
         return CORE_VERSION.toString();
     }
 
-    bytes32 CORE_TYPE = "GenArt721CoreV3_Engine_Flex";
+    bytes32 constant CORE_TYPE = "GenArt721CoreV3_Engine_Flex";
 
-    function coreType() external view returns (string memory) {
+    function coreType() external pure returns (string memory) {
         return CORE_TYPE.toString();
     }
 
@@ -499,12 +500,7 @@ contract GenArt721CoreV3_Engine_Flex is
             .dependencyType = _dependencyType;
         // if the incoming dependency type is onchain, we need to write the data to bytecode
         if (_dependencyType == ExternalAssetDependencyType.ONCHAIN) {
-            // purge bytecode if we are replacing an existing onchain asset
-            if (oldDependencyType == ExternalAssetDependencyType.ONCHAIN) {
-                projects[_projectId]
-                    .externalAssetDependencyBytecodeAddresses[_index]
-                    .purgeBytecode();
-            } else {
+            if (oldDependencyType != ExternalAssetDependencyType.ONCHAIN) {
                 // we only need to set the cid to an empty string if we are replacing an offchain asset
                 // an onchain asset will already have an empty cid
                 projects[_projectId].externalAssetDependencies[_index].cid = "";
@@ -555,10 +551,6 @@ contract GenArt721CoreV3_Engine_Flex is
                 .externalAssetDependencies[_index]
                 .dependencyType == ExternalAssetDependencyType.ONCHAIN
         ) {
-            //purging bytecode of deleted asset
-            projects[_projectId]
-                .externalAssetDependencyBytecodeAddresses[_index]
-                .purgeBytecode();
             delete projects[_projectId]
                 .externalAssetDependencyBytecodeAddresses[_index];
         }
@@ -1356,16 +1348,7 @@ contract GenArt721CoreV3_Engine_Flex is
         onlyArtistOrAdminACL(_projectId, this.updateProjectScript.selector);
         Project storage project = projects[_projectId];
         require(_scriptId < project.scriptCount, "scriptId out of range");
-        // purge old contract bytecode contract from the blockchain state
-        // note: Although this does reduce usage of Ethereum state, it does not
-        // reduce the gas costs of removal transactions. We believe this is the
-        // best behavior at the time of writing, and do not expect this to
-        // result in any breaking changes in the future. All current proposals
-        // to change the self-destruct opcode are backwards compatible, but may
-        // result in not removing the bytecode from the blockchain state. This
-        // implementation is compatible with that architecture, as it does not
-        // rely on the bytecode being removed from the blockchain state.
-        project.scriptBytecodeAddresses[_scriptId].purgeBytecode();
+
         // store script in contract bytecode, replacing reference address from
         // the contract that no longer exists with the newly created one
         project.scriptBytecodeAddresses[_scriptId] = _script.writeToBytecode();
@@ -1381,18 +1364,7 @@ contract GenArt721CoreV3_Engine_Flex is
         onlyArtistOrAdminACL(_projectId, this.removeProjectLastScript.selector);
         Project storage project = projects[_projectId];
         require(project.scriptCount > 0, "No scripts to remove");
-        // purge old contract bytecode contract from the blockchain state
-        // note: Although this does reduce usage of Ethereum state, it does not
-        // reduce the gas costs of removal transactions. We believe this is the
-        // best behavior at the time of writing, and do not expect this to
-        // result in any breaking changes in the future. All current proposals
-        // to change the self-destruct opcode are backwards compatible, but may
-        // result in not removing the bytecode from the blockchain state. This
-        // implementation is compatible with that architecture, as it does not
-        // rely on the bytecode being removed from the blockchain state.
-        project
-            .scriptBytecodeAddresses[project.scriptCount - 1]
-            .purgeBytecode();
+
         // delete reference to contract address that no longer exists
         delete project.scriptBytecodeAddresses[project.scriptCount - 1];
         unchecked {

--- a/contracts/V3_ENGINE_CHANGELOG.md
+++ b/contracts/V3_ENGINE_CHANGELOG.md
@@ -21,3 +21,9 @@ V3 performance metrics are available in [V3_Performance.md](V3_Performance.md)
 
 - Bug fix a bug to update new artist address in storage when the contract-level state variable `autoApproveArtistSplitProposals` is set to `true`. This bug was introduced in the 3.1.0 release, but all 3.1.0 contracts were deployed with `autoApproveArtistSplitProposals` set to `false`, so this bug was not exposed on mainnet.
 - Minor refactoring and code cleanup.
+
+## The following changes were made in the Core V3 Engine (3.1.2) contract:
+
+- Change modifiers to internal functions, preventing duplication of the logic throughout the bytecode
+- Change overly long revert strings (>31 characters) to be <= 31 characters where necessary
+- Removing the "purge bytecode" logic and calls, since selfdestruct is deprecated

--- a/contracts/engine/GenArt721CoreV2_ENGINE_FLEX.sol
+++ b/contracts/engine/GenArt721CoreV2_ENGINE_FLEX.sol
@@ -205,10 +205,10 @@ contract GenArt721CoreV2_ENGINE_FLEX is ERC721, IGenArt721CoreV2_PBAB {
         return tokenId;
     }
 
-    function _mintToken(address _to, uint256 _projectId)
-        internal
-        returns (uint256 _tokenId)
-    {
+    function _mintToken(
+        address _to,
+        uint256 _projectId
+    ) internal returns (uint256 _tokenId) {
         uint256 tokenIdToBe = (_projectId * ONE_MILLION) +
             projects[_projectId].invocations;
 
@@ -237,10 +237,9 @@ contract GenArt721CoreV2_ENGINE_FLEX is ERC721, IGenArt721CoreV2_PBAB {
     /**
      * @notice Updates preferredIPFSGateway to `_gateway`.
      */
-    function updateIPFSGateway(string calldata _gateway)
-        public
-        onlyWhitelisted
-    {
+    function updateIPFSGateway(
+        string calldata _gateway
+    ) public onlyWhitelisted {
         preferredIPFSGateway = _gateway;
         emit GatewayUpdated(ExternalAssetDependencyType.IPFS, _gateway);
     }
@@ -248,10 +247,9 @@ contract GenArt721CoreV2_ENGINE_FLEX is ERC721, IGenArt721CoreV2_PBAB {
     /**
      * @notice Updates preferredArweaveGateway to `_gateway`.
      */
-    function updateArweaveGateway(string calldata _gateway)
-        public
-        onlyWhitelisted
-    {
+    function updateArweaveGateway(
+        string calldata _gateway
+    ) public onlyWhitelisted {
         preferredArweaveGateway = _gateway;
         emit GatewayUpdated(ExternalAssetDependencyType.ARWEAVE, _gateway);
     }
@@ -266,10 +264,9 @@ contract GenArt721CoreV2_ENGINE_FLEX is ERC721, IGenArt721CoreV2_PBAB {
     /**
      * @notice Updates render provider address to `_renderProviderAddress`.
      */
-    function updateRenderProviderAddress(address payable _renderProviderAddress)
-        public
-        onlyAdmin
-    {
+    function updateRenderProviderAddress(
+        address payable _renderProviderAddress
+    ) public onlyAdmin {
         renderProviderAddress = _renderProviderAddress;
     }
 
@@ -277,10 +274,9 @@ contract GenArt721CoreV2_ENGINE_FLEX is ERC721, IGenArt721CoreV2_PBAB {
      * @notice Updates render provider mint revenue percentage to
      * `_renderProviderPercentage`.
      */
-    function updateRenderProviderPercentage(uint256 _renderProviderPercentage)
-        public
-        onlyAdmin
-    {
+    function updateRenderProviderPercentage(
+        uint256 _renderProviderPercentage
+    ) public onlyAdmin {
         require(_renderProviderPercentage <= 25, "Max of 25%");
         renderProviderPercentage = _renderProviderPercentage;
     }
@@ -316,28 +312,27 @@ contract GenArt721CoreV2_ENGINE_FLEX is ERC721, IGenArt721CoreV2_PBAB {
     /**
      * @notice Updates randomizer to `_randomizerAddress`.
      */
-    function updateRandomizerAddress(address _randomizerAddress)
-        public
-        onlyWhitelisted
-    {
+    function updateRandomizerAddress(
+        address _randomizerAddress
+    ) public onlyWhitelisted {
         randomizerContract = IRandomizer(_randomizerAddress);
     }
 
     /**
      * @notice Locks project `_projectId`.
      */
-    function toggleProjectIsLocked(uint256 _projectId)
-        public
-        onlyWhitelisted
-        onlyUnlocked(_projectId)
-    {
+    function toggleProjectIsLocked(
+        uint256 _projectId
+    ) public onlyWhitelisted onlyUnlocked(_projectId) {
         projects[_projectId].locked = true;
     }
 
     /**
      * @notice Locks external asset dependencies for project `_projectId`.
      */
-    function lockProjectExternalAssetDependencies(uint256 _projectId)
+    function lockProjectExternalAssetDependencies(
+        uint256 _projectId
+    )
         external
         onlyArtistOrWhitelisted(_projectId)
         onlyUnlockedProjectExternalAssetDependencies(_projectId)
@@ -366,10 +361,9 @@ contract GenArt721CoreV2_ENGINE_FLEX is ERC721, IGenArt721CoreV2_PBAB {
     /**
      * @notice Toggles paused state of project `_projectId`.
      */
-    function toggleProjectIsPaused(uint256 _projectId)
-        public
-        onlyArtist(_projectId)
-    {
+    function toggleProjectIsPaused(
+        uint256 _projectId
+    ) public onlyArtist(_projectId) {
         projects[_projectId].paused = !projects[_projectId].paused;
     }
 
@@ -424,11 +418,10 @@ contract GenArt721CoreV2_ENGINE_FLEX is ERC721, IGenArt721CoreV2_PBAB {
     /**
      * @notice Updates name of project `_projectId` to be `_projectName`.
      */
-    function updateProjectName(uint256 _projectId, string memory _projectName)
-        public
-        onlyUnlocked(_projectId)
-        onlyArtistOrWhitelisted(_projectId)
-    {
+    function updateProjectName(
+        uint256 _projectId,
+        string memory _projectName
+    ) public onlyUnlocked(_projectId) onlyArtistOrWhitelisted(_projectId) {
         projects[_projectId].name = _projectName;
     }
 
@@ -530,11 +523,10 @@ contract GenArt721CoreV2_ENGINE_FLEX is ERC721, IGenArt721CoreV2_PBAB {
      * @param _projectId Project to be updated.
      * @param _script Script to be added.
      */
-    function addProjectScript(uint256 _projectId, string memory _script)
-        public
-        onlyUnlocked(_projectId)
-        onlyArtistOrWhitelisted(_projectId)
-    {
+    function addProjectScript(
+        uint256 _projectId,
+        string memory _script
+    ) public onlyUnlocked(_projectId) onlyArtistOrWhitelisted(_projectId) {
         projects[_projectId].scripts[
             projects[_projectId].scriptCount
         ] = _script;
@@ -660,11 +652,9 @@ contract GenArt721CoreV2_ENGINE_FLEX is ERC721, IGenArt721CoreV2_PBAB {
     /**
      * @notice Removes last script from project `_projectId`.
      */
-    function removeProjectLastScript(uint256 _projectId)
-        public
-        onlyUnlocked(_projectId)
-        onlyArtistOrWhitelisted(_projectId)
-    {
+    function removeProjectLastScript(
+        uint256 _projectId
+    ) public onlyUnlocked(_projectId) onlyArtistOrWhitelisted(_projectId) {
         require(
             projects[_projectId].scriptCount > 0,
             "there are no scripts to remove"
@@ -688,21 +678,20 @@ contract GenArt721CoreV2_ENGINE_FLEX is ERC721, IGenArt721CoreV2_PBAB {
     /**
      * @notice Updates ipfs hash for project `_projectId`.
      */
-    function updateProjectIpfsHash(uint256 _projectId, string memory _ipfsHash)
-        public
-        onlyUnlocked(_projectId)
-        onlyArtistOrWhitelisted(_projectId)
-    {
+    function updateProjectIpfsHash(
+        uint256 _projectId,
+        string memory _ipfsHash
+    ) public onlyUnlocked(_projectId) onlyArtistOrWhitelisted(_projectId) {
         projects[_projectId].ipfsHash = _ipfsHash;
     }
 
     /**
      * @notice Updates base URI for project `_projectId` to `_newBaseURI`.
      */
-    function updateProjectBaseURI(uint256 _projectId, string memory _newBaseURI)
-        public
-        onlyArtist(_projectId)
-    {
+    function updateProjectBaseURI(
+        uint256 _projectId,
+        string memory _newBaseURI
+    ) public onlyArtist(_projectId) {
         projects[_projectId].projectBaseURI = _newBaseURI;
     }
 
@@ -715,7 +704,9 @@ contract GenArt721CoreV2_ENGINE_FLEX is ERC721, IGenArt721CoreV2_PBAB {
      * @return website Project website
      * @return license Project license
      */
-    function projectDetails(uint256 _projectId)
+    function projectDetails(
+        uint256 _projectId
+    )
         public
         view
         returns (
@@ -747,7 +738,9 @@ contract GenArt721CoreV2_ENGINE_FLEX is ERC721, IGenArt721CoreV2_PBAB {
      * @return currency Symbol of project's currency
      * @return currencyAddress Address of project's currency
      */
-    function projectTokenInfo(uint256 _projectId)
+    function projectTokenInfo(
+        uint256 _projectId
+    )
         public
         view
         returns (
@@ -784,7 +777,9 @@ contract GenArt721CoreV2_ENGINE_FLEX is ERC721, IGenArt721CoreV2_PBAB {
      * @return locked Boolean representing if project is locked
      * @return paused Boolean representing if project is paused
      */
-    function projectScriptInfo(uint256 _projectId)
+    function projectScriptInfo(
+        uint256 _projectId
+    )
         public
         view
         returns (
@@ -806,11 +801,10 @@ contract GenArt721CoreV2_ENGINE_FLEX is ERC721, IGenArt721CoreV2_PBAB {
      * @notice Returns script for project `_projectId` at script index `_index`
 
      */
-    function projectScriptByIndex(uint256 _projectId, uint256 _index)
-        public
-        view
-        returns (string memory)
-    {
+    function projectScriptByIndex(
+        uint256 _projectId,
+        uint256 _index
+    ) public view returns (string memory) {
         return projects[_projectId].scripts[_index];
     }
 
@@ -827,22 +821,18 @@ contract GenArt721CoreV2_ENGINE_FLEX is ERC721, IGenArt721CoreV2_PBAB {
     /**
      * @notice Returns external asset dependency count for project `_projectId` at index `_index`.
      */
-    function projectExternalAssetDependencyCount(uint256 _projectId)
-        public
-        view
-        returns (uint256)
-    {
+    function projectExternalAssetDependencyCount(
+        uint256 _projectId
+    ) public view returns (uint256) {
         return uint256(projects[_projectId].externalAssetDependencyCount);
     }
 
     /**
      * @notice Returns base URI for project `_projectId`.
      */
-    function projectURIInfo(uint256 _projectId)
-        public
-        view
-        returns (string memory projectBaseURI)
-    {
+    function projectURIInfo(
+        uint256 _projectId
+    ) public view returns (string memory projectBaseURI) {
         projectBaseURI = projects[_projectId].projectBaseURI;
     }
 
@@ -856,7 +846,9 @@ contract GenArt721CoreV2_ENGINE_FLEX is ERC721, IGenArt721CoreV2_PBAB {
      * @return royaltyFeeByID Total royalty percentage to be sent to
      * combination of artist and additional payee
      */
-    function getRoyaltyData(uint256 _tokenId)
+    function getRoyaltyData(
+        uint256 _tokenId
+    )
         public
         view
         returns (
@@ -881,13 +873,9 @@ contract GenArt721CoreV2_ENGINE_FLEX is ERC721, IGenArt721CoreV2_PBAB {
     /**
      * @notice Gets token URI for token ID `_tokenId`.
      */
-    function tokenURI(uint256 _tokenId)
-        public
-        view
-        override
-        onlyValidTokenId(_tokenId)
-        returns (string memory)
-    {
+    function tokenURI(
+        uint256 _tokenId
+    ) public view override onlyValidTokenId(_tokenId) returns (string memory) {
         return
             string(
                 abi.encodePacked(

--- a/contracts/interfaces/0.8.x/IGenArt721CoreContractV3_Engine.sol
+++ b/contracts/interfaces/0.8.x/IGenArt721CoreContractV3_Engine.sol
@@ -8,7 +8,10 @@ import "./IGenArt721CoreContractV3_Base.sol";
 
 interface IGenArt721CoreContractV3_Engine is IGenArt721CoreContractV3_Base {
     // @dev new function in V3
-    function getPrimaryRevenueSplits(uint256 _projectId, uint256 _price)
+    function getPrimaryRevenueSplits(
+        uint256 _projectId,
+        uint256 _price
+    )
         external
         view
         returns (
@@ -71,8 +74,7 @@ interface IGenArt721CoreContractV3_Engine is IGenArt721CoreContractV3_Base {
     function tokenIdToHash(uint256 _tokenId) external view returns (bytes32);
 
     // function to read the hash-seed for a given tokenId
-    function tokenIdToHashSeed(uint256 _tokenId)
-        external
-        view
-        returns (bytes12);
+    function tokenIdToHashSeed(
+        uint256 _tokenId
+    ) external view returns (bytes12);
 }

--- a/contracts/interfaces/0.8.x/IGenArt721CoreContractV3_Engine_Flex.sol
+++ b/contracts/interfaces/0.8.x/IGenArt721CoreContractV3_Engine_Flex.sol
@@ -76,8 +76,7 @@ interface IGenArt721CoreContractV3_Engine_Flex is
     ) external view returns (ExternalAssetDependency memory);
 
     // getter function of public mapping length
-    function projectExternalAssetDependencyCount(uint256 _projectId)
-        external
-        view
-        returns (uint256);
+    function projectExternalAssetDependencyCount(
+        uint256 _projectId
+    ) external view returns (uint256);
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -69,7 +69,7 @@ module.exports = {
   },
   contractSizer: {
     alphaSort: true,
-    runOnCompile: false,
+    runOnCompile: true,
     disambiguatePaths: false,
   },
   docgen: {


### PR DESCRIPTION
Reduce contract bytecode size to <24 kb by doing the following:
- change modifiers to internal functions, preventing duplication of the logic throughout the bytecode
- change constants to non-constants, preventing duplication throughout bytecode
- move OpenZeppelin Strings lib into our contract and minimize bytecode of the portions of the library that are used
- change overly long revert strings (>31 characters) to be <= 31 characters where necessary

In addition to the changes above, we could further reduce this contract's bytecode size by:
- removing the "purge bytecode" logic and calls, since selfdestruct is deprecated (maybe 1 kb?)
- eliminating custom errors (that could use error codes) instead of using revert messages (maybe 1-2 kb?)

(the estimates on potential for further kb reduction above are just guesses, so we should study if we want/need to pursue further reductions.

Note that without shortening some of the error messages, which is the only change that isn't a refactor, the contract is only 0.1 kb over the 24 kb limit. Instead of changing error messages (which adds complexity to our testing suite), we could do something else like remove the purge bytecode logic.

============================================================================================

(BEN L UPDATE, SOW @ 2/7/23 5:30PM PST)

After further discussion async with concerned parties, the optimizations for V3_Engine & V3_Engine_FLEX are now as follows:

- Change modifiers to internal functions, preventing duplication of the logic throughout the bytecode
- Change overly long revert strings (>31 characters) to be <= 31 characters where necessary
- Removing the "purge bytecode" logic and calls, since selfdestruct is deprecated

V3_ENGINE_FLEX contract is now ~23.9KB.
Moving forward we are also planning to add the rule of preferring internal functions over modifiers to our contract's styleguide
