### PR TITLE
Add Deployed event on MinterFilterV1

### DIFF
--- a/contracts/interfaces/0.8.x/IMinterFilterV0.sol
+++ b/contracts/interfaces/0.8.x/IMinterFilterV0.sol
@@ -5,6 +5,12 @@ pragma solidity ^0.8.0;
 
 interface IMinterFilterV0 {
     /**
+     * @notice Emitted when contract is deployed to notify indexing services
+     * of the new contract deployment.
+     */
+    event Deployed();
+
+    /**
      * @notice Approved minter `_minterAddress`.
      */
     event MinterApproved(address indexed _minterAddress, string _minterType);

--- a/contracts/minter-suite/MinterFilter/MinterFilterV1.sol
+++ b/contracts/minter-suite/MinterFilter/MinterFilterV1.sol
@@ -106,6 +106,7 @@ contract MinterFilterV1 is IMinterFilterV0 {
     ) onlyNonZeroAddress(_genArt721Address) {
         genArt721CoreAddress = _genArt721Address;
         genArtCoreContract = IGenArt721CoreContractV3(_genArt721Address);
+        emit Deployed();
     }
 
     /**

--- a/contracts/minter-suite/MinterFilter/MinterFilterV1.sol
+++ b/contracts/minter-suite/MinterFilter/MinterFilterV1.sol
@@ -6,6 +6,8 @@ import "../../interfaces/0.8.x/IFilteredMinterV0.sol";
 import "../../interfaces/0.8.x/IAdminACLV0.sol";
 import "../../interfaces/0.8.x/IGenArt721CoreContractV3.sol";
 
+import "../../libs/0.8.x/Bytes32Strings.sol";
+
 import "@openzeppelin-4.5/contracts/utils/structs/EnumerableMap.sol";
 
 pragma solidity 0.8.17;
@@ -39,6 +41,21 @@ pragma solidity 0.8.17;
 contract MinterFilterV1 is IMinterFilterV0 {
     // add Enumerable Map methods
     using EnumerableMap for EnumerableMap.UintToAddressMap;
+    // add Bytes32Strings methods
+    using Bytes32Strings for bytes32;
+
+    /// version & type of this core contract
+    bytes32 constant MINTER_FILTER_VERSION = "v1.0.1";
+
+    function minterFilterVersion() external pure returns (string memory) {
+        return MINTER_FILTER_VERSION.toString();
+    }
+
+    bytes32 constant MINTER_FILTER_TYPE = "MinterFilterV1";
+
+    function minterFilterType() external pure returns (string memory) {
+        return MINTER_FILTER_TYPE.toString();
+    }
 
     /// Core contract address this minter interacts with
     address public immutable genArt721CoreAddress;

--- a/test/minter-filter/events/MinterFilterV1Events.test.ts
+++ b/test/minter-filter/events/MinterFilterV1Events.test.ts
@@ -73,5 +73,23 @@ runForEach.forEach((params) => {
     describe("common tests", async function () {
       await MinterFilterEvents_Common();
     });
+
+    describe("Deployed", async function () {
+      it("should emit Deployed during deployment", async function () {
+        const minterFilterFactory = await ethers.getContractFactory(
+          "MinterFilterV1"
+        );
+
+        const tx = await minterFilterFactory
+          .connect(this.accounts.deployer)
+          .deploy(this.genArt721Core.address);
+        const receipt = await tx.deployTransaction.wait();
+        const deployed = receipt.logs[0];
+        // expect "Deployed" event as log 0
+        await expect(deployed.topics[0]).to.be.equal(
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Deployed()"))
+        );
+      });
+    });
   });
 });

--- a/test/minter-filter/views/MinterFilterV1Views.test.ts
+++ b/test/minter-filter/views/MinterFilterV1Views.test.ts
@@ -71,5 +71,22 @@ runForEach.forEach((params) => {
         );
       });
     });
+
+    describe("minterFilterVersion", async function () {
+      it("returns expected value", async function () {
+        // addProject
+        const minterFilterVersion =
+          await this.minterFilter.minterFilterVersion();
+        expect(minterFilterVersion).to.equal("v1.0.1");
+      });
+    });
+
+    describe("minterFilterType", async function () {
+      it("returns expected value", async function () {
+        // addProject
+        const minterFilterType = await this.minterFilter.minterFilterType();
+        expect(minterFilterType).to.equal("MinterFilterV1");
+      });
+    });
   });
 });


### PR DESCRIPTION
## Description of the change

Add a `Deployed` event to IMinterFilterV0 to improve indexing logic available for V3 Engine contracts

We currently have an issue in our subgraph where we would like to determine if we should index an Engine partner's MinterSuite based on if their MinterFilter contract is in the subgraph store or not. This new event, along with a follow-on handler to add the MinterFilter to the store when the `Deployed` event is observed, will enable that process.

Assuming this is implemented, a follow-on PR will be on subgraph, and we will implement block-number based logic to index all MinterFilters before this change is implemented (our current patched behavior), and will only index MinterFilters in a subgraph's config if on a block after this change is implemented.

## Design Alternatives Considered

We could index all Engine contract minters as MinterFilters (which is our current patched behavior), but we could experience subgraph failures if we index all Engine minter systems by default.
We could change our deployment strategy to require a specific ordering such as a minter must be allowlisted on a MinterFilter before we set the MinterFilter to be the minter on a core contract (which adds the minter to the store due to the emitted event), but that system is not very robust.
This seemed like the cleanest system with minimal effort, especially since it will also work with our future plans of a consolidated minter suite.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203931419658369