### PR TITLE
Add polyptych minter and randomizer deployment reference scripts

### DIFF
--- a/scripts/minter-deployments/1_reference_goerli-dev_minter-polyptych_deployer.ts
+++ b/scripts/minter-deployments/1_reference_goerli-dev_minter-polyptych_deployer.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Created By: Art Blocks Inc.
+
+import { ethers } from "hardhat";
+import { tryVerify } from "../util/verification";
+
+// hide nuisance logs about event overloading
+import { Logger } from "@ethersproject/logger";
+Logger.setLogLevel(Logger.levels.ERROR);
+
+// delay to avoid issues with reorgs and tx failures
+import { delay } from "../util/utils";
+const EXTRA_DELAY_BETWEEN_TX = 5000; // ms
+
+/**
+ * This script was created to deploy the MinterPolyptychV0 contract to the Ethereum
+ * Goerli testnet, for the Art Blocks dev environment.
+ * It is intended to document the deployment process and provide a reference
+ * for the steps required to deploy the MinterPolyptychV0 contract.
+ */
+//////////////////////////////////////////////////////////////////////////////
+// CONFIG BEGINS HERE
+//////////////////////////////////////////////////////////////////////////////
+const genArt721V3CoreAddress = "0x5702797Ff45FCb0a70eB6AE1E4563299dCFa9Dd6";
+const minterFilterAddress = "0x72AE7160A580893Fb1049D17Fbd736Ad39Ea7FbD";
+const delegationRegistryAddress = "0x00000000000076A84feF008CDAbe6409d2FE638B";
+const minterName = "MinterPolyptychV0";
+//////////////////////////////////////////////////////////////////////////////
+// CONFIG ENDS HERE
+//////////////////////////////////////////////////////////////////////////////
+
+async function main() {
+  const [deployer] = await ethers.getSigners();
+  const network = await ethers.provider.getNetwork();
+  const networkName = network.name == "homestead" ? "mainnet" : network.name;
+  if (networkName != "goerli") {
+    throw new Error("This script is intended to be run on mainnet only");
+  }
+  //////////////////////////////////////////////////////////////////////////////
+  // DEPLOYMENT BEGINS HERE
+  //////////////////////////////////////////////////////////////////////////////
+
+  // Deploy Minter contract(s)
+  const minterPolyptychFactory = await ethers.getContractFactory(minterName);
+  const minterPolyptych = await minterPolyptychFactory.deploy(
+    genArt721V3CoreAddress,
+    minterFilterAddress,
+    delegationRegistryAddress
+  );
+  await minterPolyptych.deployed();
+  const minterPolyptychAddress = minterPolyptych.address;
+  console.log(`${minterName} deployed at ${minterPolyptychAddress}`);
+  await delay(EXTRA_DELAY_BETWEEN_TX);
+
+  //////////////////////////////////////////////////////////////////////////////
+  // DEPLOYMENT ENDS HERE
+  //////////////////////////////////////////////////////////////////////////////
+
+  //////////////////////////////////////////////////////////////////////////////
+  // SETUP BEGINS HERE
+  //////////////////////////////////////////////////////////////////////////////
+
+  // allowlist the new minter on the minter filter
+  const minterFilterContract = await ethers.getContractAt(
+    "MinterFilterV1",
+    minterFilterAddress
+  );
+  await minterFilterContract.addApprovedMinter(minterPolyptychAddress);
+
+  // Output instructions for manual Etherscan verification.
+  await tryVerify(
+    minterName,
+    minterPolyptychAddress,
+    [genArt721V3CoreAddress, minterFilterAddress, delegationRegistryAddress],
+    networkName
+  );
+
+  //////////////////////////////////////////////////////////////////////////////
+  // SETUP ENDS HERE
+  //////////////////////////////////////////////////////////////////////////////
+
+  console.log(
+    `Done! MinterPolyptychV0 deployed to ${minterPolyptychAddress}, and allowlisted on the minter filter at ${minterFilterAddress}`
+  );
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/randomizer-deployments/dev/1_reference_goerli-dev_randomizerPolyptych_deployer.ts
+++ b/scripts/randomizer-deployments/dev/1_reference_goerli-dev_randomizerPolyptych_deployer.ts
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Created By: Art Blocks Inc.
+
+import { ethers } from "hardhat";
+import { tryVerify } from "../../util/verification";
+
+// hide nuisance logs about event overloading
+import { Logger } from "@ethersproject/logger";
+Logger.setLogLevel(Logger.levels.ERROR);
+
+// delay to avoid issues with reorgs and tx failures
+import { delay } from "../../util/utils";
+const EXTRA_DELAY_BETWEEN_TX = 5000; // ms
+
+/**
+ * This script was created to deploy polyptych randomizer as required for the MinterPolyptychV0 contract to the Ethereum
+ * Goerli testnet, for the Art Blocks dev environment.
+ * It is intended to document the deployment process and provide a reference
+ * for the steps required to deploy the polyptych randomizer contract.
+ * NOTE: this script makes calls as both the deployer, and then as the superAdmin of the
+ * associated core contract. If the deployer is not the superAdmin, then the script will
+ * need to be modified to make the calls as the superAdmin (or calls must be made manually).
+ */
+//////////////////////////////////////////////////////////////////////////////
+// CONFIG BEGINS HERE
+//////////////////////////////////////////////////////////////////////////////
+const genArt721V3CoreAddress = "0x5702797Ff45FCb0a70eB6AE1E4563299dCFa9Dd6";
+const coreContractType = "GenArt721CoreV3_Engine";
+const polyptychMinterAddress = "0xAA72E10Eec168D66847048b8FceB1aCf25db8115";
+const randomizerName = "BasicPolyptychRandomizerV0";
+//////////////////////////////////////////////////////////////////////////////
+// CONFIG ENDS HERE
+//////////////////////////////////////////////////////////////////////////////
+
+async function main() {
+  const [deployer] = await ethers.getSigners();
+  const network = await ethers.provider.getNetwork();
+  const networkName = network.name == "homestead" ? "mainnet" : network.name;
+  if (networkName != "goerli") {
+    throw new Error("This script is intended to be run on mainnet only");
+  }
+  //////////////////////////////////////////////////////////////////////////////
+  // DEPLOYMENT BEGINS HERE
+  //////////////////////////////////////////////////////////////////////////////
+
+  // Deploy new randomizer contract(s)
+  const randomizerFactory = await ethers.getContractFactory(randomizerName);
+  const randomizer = await randomizerFactory.deploy();
+  await randomizer.deployed();
+  const randomizerAddress = randomizer.address;
+  console.log(`[INFO] ${randomizerName} deployed at ${randomizerAddress}`);
+  await delay(EXTRA_DELAY_BETWEEN_TX);
+
+  //////////////////////////////////////////////////////////////////////////////
+  // DEPLOYMENT ENDS HERE
+  //////////////////////////////////////////////////////////////////////////////
+
+  //////////////////////////////////////////////////////////////////////////////
+  // SETUP BEGINS HERE
+  //////////////////////////////////////////////////////////////////////////////
+
+  // assign core and renounce ownership
+  await randomizer.assignCoreAndRenounce(genArt721V3CoreAddress, {
+    gasLimit: 1000000,
+  });
+  console.log(
+    `[INFO] ${randomizerName} updated it's reference to the core contract ${genArt721V3CoreAddress}, and ownership was renounced`
+  );
+  await delay(EXTRA_DELAY_BETWEEN_TX);
+
+  // THE FOLLOWING CALLS MUST BE MADE AS THE SUPERADMIN OF THE CORE CONTRACT
+  // IF THE DEPLOYER IS NOT THE SUPERADMIN, THEN THE CALLS MUST BE MADE MANUALLY
+  // add polyptych minter to the randomizer
+  await randomizer.setHashSeedSetterContract(polyptychMinterAddress);
+  console.log(
+    `[INFO] Set hash seed setter contract to be the Polyptych minter at ${polyptychMinterAddress} on the randomizer at ${randomizerAddress}`
+  );
+  await delay(EXTRA_DELAY_BETWEEN_TX);
+
+  const coreContract = await ethers.getContractAt(
+    coreContractType,
+    genArt721V3CoreAddress
+  );
+  await coreContract.updateRandomizerAddress(randomizerAddress);
+  console.log(
+    `[INFO] Updated randomizer for core at ${genArt721V3CoreAddress} to the Polyptych Randomizer at at ${randomizerAddress}`
+  );
+  await delay(EXTRA_DELAY_BETWEEN_TX);
+
+  // verify contract on Etherscan if not on mainnet
+  if (networkName == "goerli") {
+    await tryVerify(randomizerName, randomizerAddress, [], networkName);
+  } else {
+    console.log(
+      `[INFO] Skipping Etherscan verification for ${randomizerName} on ${networkName}`
+    );
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  // SETUP ENDS HERE
+  //////////////////////////////////////////////////////////////////////////////
+
+  console.log(`Done!`);
+  console.log(`Reminder that before a project switches to polyptych randomization mode \
+(sometimes after initial frame  mints if polyptych tokens are all in same project), \
+an artist will need to call \`toggleProjectIsPolyptych\` on this randomizer contract.`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Description of the change

This adds polyptych minter and polyptych basic randomizer deployment scripts as references for future deployments.

Ideally, we will create a generic minter deployment script for minters and randomizers, similar to what we recently did for V3 Engine in #484. In the short term, wanted to document these deployments that were made on dev to support end-to-end testing.

## Deployment logs

**Minter deployment:**
```
%  yarn hardhat run --network goerli scripts/minter-deployments/1_reference_goerli-dev_minter-polyptych_deployer.ts 
MinterPolyptychV0 deployed at 0xAA72E10Eec168D66847048b8FceB1aCf25db8115
[INFO] Verifying MinterPolyptychV0 contract deployment...
Nothing to compile
Successfully submitted source code for contract
contracts/minter-suite/Minters/MinterPolyptychV0.sol:MinterPolyptychV0 at 0xAA72E10Eec168D66847048b8FceB1aCf25db8115
for verification on the block explorer. Waiting for verification result...

Successfully verified contract MinterPolyptychV0 on Etherscan.
https://goerli.etherscan.io/address/0xAA72E10Eec168D66847048b8FceB1aCf25db8115#code
[INFO] MinterPolyptychV0 contract verified on Etherscan at 0xAA72E10Eec168D66847048b8FceB1aCf25db8115}
Done! MinterPolyptychV0 deployed to 0xAA72E10Eec168D66847048b8FceB1aCf25db8115, and allowlisted on the minter filter at 0x72AE7160A580893Fb1049D17Fbd736Ad39Ea7FbD
```

**Basic Polyptych Randomizer:**
```
% yarn hardhat run --network goerli scripts/randomizer-deployments/dev/1_reference_goerli-dev_randomizerPolyptych_deployer.ts
yarn run v1.22.19
$ /Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/node_modules/.bin/hardhat run --network goerli scripts/randomizer-deployments/dev/1_reference_goerli-dev_randomizerPolyptych_deployer.ts
[INFO] BasicPolyptychRandomizerV0 deployed at 0xc7Db60697d4aA1925D43E0E950A42b09795211f6
[INFO] BasicPolyptychRandomizerV0 updated it's reference to the core contract 0x5702797Ff45FCb0a70eB6AE1E4563299dCFa9Dd6, and ownership was renounced
[INFO] Set hash seed setter contract to be the Polyptych minter at 0xAA72E10Eec168D66847048b8FceB1aCf25db8115 on the randomizer at 0xc7Db60697d4aA1925D43E0E950A42b09795211f6
[INFO] Updated randomizer for core at 0x5702797Ff45FCb0a70eB6AE1E4563299dCFa9Dd6 to the Polyptych Randomizer at at 0xc7Db60697d4aA1925D43E0E950A42b09795211f6
[INFO] Verifying BasicPolyptychRandomizerV0 contract deployment...
Nothing to compile
Successfully submitted source code for contract
contracts/BasicPolyptychRandomizerV0.sol:BasicPolyptychRandomizerV0 at 0xc7Db60697d4aA1925D43E0E950A42b09795211f6
for verification on the block explorer. Waiting for verification result...

Successfully verified contract BasicPolyptychRandomizerV0 on Etherscan.
https://goerli.etherscan.io/address/0xc7Db60697d4aA1925D43E0E950A42b09795211f6#code
[INFO] BasicPolyptychRandomizerV0 contract verified on Etherscan at 0xc7Db60697d4aA1925D43E0E950A42b09795211f6}
Done!
Reminder that before a project switches to polyptych randomization   (sometimes after initial frame  mints if polyptych tokens are all in same project),  an artist will need to call `toggleProjectIsPolyptych` on this randomizer contract.
```
