### PR TITLE
Capability to generically deploy V3_Engine_Flex

### DIFF
--- a/deployments/engine/V3/partners/dev-example-flex/DEPLOYMENTS.md
+++ b/deployments/engine/V3/partners/dev-example-flex/DEPLOYMENTS.md
@@ -1,0 +1,42 @@
+
+# Deployment
+
+Date: 2023-02-22T20:50:43.959Z
+
+## **Network:** goerli
+
+## **Environment:** dev
+
+**Deployment Input File:** `deployments/engine/V3/partners/dev-example-flex/deployment-config.dev.ts`
+
+**GenArt721CoreV3_Engine_Flex:** https://etherscan.io/address/0xd2363Acbf8CdF01A5FdfcB8f0295e0a5dF94518D#code
+
+**AdminACLV1:** https://etherscan.io/address/0x2e84869f024c90445A35DB81cD7940A206520848#code
+
+**Engine Registry:** https://etherscan.io/address/0x263113c07CB69eE047E6572E135E8C3C6302feFE#code
+
+**MinterFilterV1:** https://etherscan.io/address/0x2c321e8306E9F8843562313c32F39833a1C2966b#code
+
+**Minters:**
+
+**MinterSetPriceV4:** https://etherscan.io/address/0xB2670C23F6dFce72c913B9f039162d9470CE4d06#code
+
+
+
+**Metadata**
+
+- **Starting Project Id:** 5
+- **Token Name:** Engine Partner Flex
+- **Token Ticker:** FLX_PRTNR
+- **Auto Approve Artist Split Proposals:** true
+- **Render Provider Address, Primary Sales:** deployer
+- **Platform Provider Address, Primary Sales:** deployer
+
+**Other**
+
+- **Add initial project?:** true
+- **Add initial token?:** true
+- **Image Bucket:** engine-partner-flex-goerli
+
+---
+

--- a/deployments/engine/V3/partners/dev-example-flex/DEPLOYMENT_LOGS.log
+++ b/deployments/engine/V3/partners/dev-example-flex/DEPLOYMENT_LOGS.log
@@ -1,0 +1,68 @@
+----------------------------------------
+[INFO] Datetime of deployment: 2023-02-22T20:45:33.548Z
+[INFO] Deployment configuration file: /Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/deployments/engine/V3/partners/dev-example-flex/deployment-config.dev.ts
+[INFO] Deploying to network: goerli
+[INFO] Deploying to environment: dev
+[INFO] New Admin ACL AdminACLV1 deployed at address: 0x2e84869f024c90445A35DB81cD7940A206520848
+[INFO] Randomizer BasicRandomizerV2 deployed at 0xc21A7f8804C2196b77754269054E58A2b2BE84e5
+[INFO] Core GenArt721CoreV3_Engine_Flex deployed at 0xd2363Acbf8CdF01A5FdfcB8f0295e0a5dF94518D
+[INFO] Minter Filter MinterFilterV1 deployed at 0x2c321e8306E9F8843562313c32F39833a1C2966b
+[INFO] MinterSetPriceV4 deployed at 0xB2670C23F6dFce72c913B9f039162d9470CE4d06
+[INFO] Assigned randomizer to core and renounced ownership of randomizer
+[INFO] Updated the Minter Filter on the Core contract to 0x2c321e8306E9F8843562313c32F39833a1C2966b.
+[INFO] Allowlisted minter MinterSetPriceV4 at 0xB2670C23F6dFce72c913B9f039162d9470CE4d06 on minter filter.
+[INFO] Added Engine Partner Flex project 5 placeholder on Engine Partner Flex contract, artist is 0x2246475beddf9333b6a6D9217194576E7617Afd1.
+[INFO] Configured set price minter (0xB2670C23F6dFce72c913B9f039162d9470CE4d06) for project 5.
+[INFO] Configured minter price project 5.
+[INFO] Minted token 0 for project 5.
+[INFO] Verifying core contract contract deployment...
+
+Successfully submitted source code for contract
+contracts/GenArt721CoreV3_Engine_Flex.sol:GenArt721CoreV3_Engine_Flex at 0xd2363Acbf8CdF01A5FdfcB8f0295e0a5dF94518D
+for verification on the block explorer. Waiting for verification result...
+
+Successfully verified contract GenArt721CoreV3_Engine_Flex on Etherscan.
+https://goerli.etherscan.io/address/0xd2363Acbf8CdF01A5FdfcB8f0295e0a5dF94518D#code
+[INFO] Core contract verified on Etherscan at 0xd2363Acbf8CdF01A5FdfcB8f0295e0a5dF94518D}
+[INFO] Verifying MinterFilter contract deployment...
+
+Successfully submitted source code for contract
+contracts/minter-suite/MinterFilter/MinterFilterV1.sol:MinterFilterV1 at 0x2c321e8306E9F8843562313c32F39833a1C2966b
+for verification on the block explorer. Waiting for verification result...
+
+Successfully verified contract MinterFilterV1 on Etherscan.
+https://goerli.etherscan.io/address/0x2c321e8306E9F8843562313c32F39833a1C2966b#code
+[INFO] MinterFilter contract verified on Etherscan at 0x2c321e8306E9F8843562313c32F39833a1C2966b}
+[INFO] Verifying MinterSetPriceV4 contract deployment...
+
+Successfully submitted source code for contract
+contracts/minter-suite/Minters/MinterSetPriceV4.sol:MinterSetPriceV4 at 0xB2670C23F6dFce72c913B9f039162d9470CE4d06
+for verification on the block explorer. Waiting for verification result...
+
+Successfully verified contract MinterSetPriceV4 on Etherscan.
+https://goerli.etherscan.io/address/0xB2670C23F6dFce72c913B9f039162d9470CE4d06#code
+[INFO] MinterSetPriceV4 contract verified on Etherscan at 0xB2670C23F6dFce72c913B9f039162d9470CE4d06}
+Created s3 bucket for https://engine-partner-flex-goerli.s3.amazonaws.com
+[INFO] Created image bucket engine-partner-flex-goerli
+[INFO] Deployment details written to /Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/deployments/engine/V3/partners/dev-example-flex/DEPLOYMENTS.md
+Upserting 1 contract...
+Contracts metadata upsert input:
+{
+  "address": "0xd2363acbf8cdf01a5fdfcb8f0295e0a5df94518d",
+  "name": "Engine Partner Flex",
+  "bucket_name": "engine-partner-flex-goerli",
+  "default_vertical_name": "flex"
+}
+Successfully upserted 1 contract
+Upserting 1 project...
+Projects metadata upsert input:
+{
+  "id": "0xd2363acbf8cdf01a5fdfcb8f0295e0a5df94518d-5",
+  "contract_address": "0xd2363acbf8cdf01a5fdfcb8f0295e0a5df94518d",
+  "project_id": "5",
+  "artist_address": "0x2246475beddf9333b6a6d9217194576e7617afd1",
+  "vertical_name": "flex"
+}
+Successfully upserted 1 project
+[ACTION] provider primary and secondary sales payment addresses remain as deployer addresses: 0x2246475beddf9333b6a6D9217194576E7617Afd1. Update later as needed.
+[ACTION] AdminACL's superAdmin address is 0x2246475beddf9333b6a6D9217194576E7617Afd1, don't forget to update if requred.

--- a/deployments/engine/V3/partners/dev-example-flex/deployment-config.dev.ts
+++ b/deployments/engine/V3/partners/dev-example-flex/deployment-config.dev.ts
@@ -1,0 +1,45 @@
+// This file is used to configure the deployment of the Engine Partner contracts
+// It is intended to be imported by the generic deployer in `/scripts/engine/V3/generic-v3-engine-deployer.ts`
+export const deployDetailsArray = [
+  {
+    network: "goerli",
+    // environment is only used for metadata purposes, and is not used in the deployment process
+    // Please set to "dev", "staging", or "mainnet", as appropriate
+    environment: "dev",
+    // if you want to use an existing admin ACL, set the address here (otherwise set as undefined to deploy a new one)
+    existingAdminACL: undefined,
+    // the following can be undefined if you are using an existing admin ACL, otherwise define the Admin ACL contract name
+    // if deploying a new AdminACL
+    adminACLContractName: "AdminACLV1",
+    // See the `KNOWN_ENGINE_REGISTRIES` object in `/scripts/engine/V3/constants.ts` for the correct registry address for
+    // the intended network and the corresponding deployer wallet addresses
+    // @dev if you neeed a new engine registry, use the `/scripts/engine/V3/engine-registry-deployer.ts` script
+    engineRegistryAddress: "0x263113c07CB69eE047E6572E135E8C3C6302feFE",
+    randomizerContractName: "BasicRandomizerV2",
+    genArt721CoreContractName: "GenArt721CoreV3_Engine_Flex",
+    tokenName: "Engine Partner Flex",
+    tokenTicker: "FLX_PRTNR",
+    startingProjectId: 5,
+    autoApproveArtistSplitProposals: true,
+    renderProviderAddress: "deployer", // use either "0x..." or special "deployer" which sets the render provider to the deployer
+    platformProviderAddress: "deployer", // use either "0x..." or special "deployer" which sets the render provider to the deployer
+    // minter suite
+    minterFilterContractName: "MinterFilterV1",
+    minters: [
+      // include any of the most recent minter contracts the engine partner wishes to use
+      // @dev ensure the minter contracts here are the latest versions
+      "MinterSetPriceV4",
+    ],
+    // set to true if you want to add an initial project to the core contract
+    addInitialProject: true,
+    // set to true if you want to add an initial token to the initial project
+    // (this will only work if you have set addInitialProject to true, and requires a MinterSetPriceV[4-9])
+    addInitialToken: true,
+    // optionally define this to set default vertical name for the contract after deployment.
+    // if not defined, the default vertical name will be "unassigned".
+    // common values include `fullyonchain`, `flex`, or partnerships like `artblocksxpace`.
+    // also note that if you desire to create a new veritcal, you will need to add the vertical name to the
+    // `project_verticals` table in the database before running this deploy script.
+    defaultVerticalName: "flex",
+  },
+];

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -69,7 +69,7 @@ module.exports = {
   },
   contractSizer: {
     alphaSort: true,
-    runOnCompile: true,
+    runOnCompile: false,
     disambiguatePaths: false,
   },
   docgen: {

--- a/scripts/engine/V3/generic-engine-deployer.ts
+++ b/scripts/engine/V3/generic-engine-deployer.ts
@@ -30,7 +30,10 @@ const MANUAL_GAS_LIMIT = 500000; // gas
 var log_stdout = process.stdout;
 
 // These are the core contracts that may be deployed by this script.
-const SUPPORTED_CORE_CONTRACTS = ["GenArt721CoreV3_Engine"];
+const SUPPORTED_CORE_CONTRACTS = [
+  "GenArt721CoreV3_Engine",
+  "GenArt721CoreV3_Engine_Flex",
+];
 
 /**
  * This script was created to deploy the V3 core Engine contracts,
@@ -132,6 +135,25 @@ async function main() {
         `[ERROR] This script only supports deployment of the following core contracts: ${SUPPORTED_CORE_CONTRACTS.join(
           ", "
         )}`
+      );
+    }
+
+    // verify that default vertical is not fullyonchain if using the flex engine
+    if (
+      deployDetails.defaultVerticalName == "fullyonchain" &&
+      deployDetails.genArt721CoreContractName.includes("Flex")
+    ) {
+      throw new Error(
+        `[ERROR] The default vertical cannot be fullyonchain if using the flex engine`
+      );
+    }
+    // verify that the default vertical is not flex if not using a flex engine
+    if (
+      deployDetails.defaultVerticalName == "flex" &&
+      !deployDetails.genArt721CoreContractName.includes("Flex")
+    ) {
+      throw new Error(
+        `[ERROR] The default vertical cannot be flex if not using a flex engine`
       );
     }
     //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description of the change

Add capability to deploy V3_Engine_Flex with generic engine deployer script.

As part of this PR, I'm also including a dev example flex deployment that was ran successfully ran on goerli.

This is follow-on from #450 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204024755133705