### PR TITLE
Remove modifiers from all active contracts

### DIFF
--- a/contracts/BasicPolyptychRandomizerV0.sol
+++ b/contracts/BasicPolyptychRandomizerV0.sol
@@ -46,26 +46,23 @@ contract BasicPolyptychRandomizerV0 is IRandomizerPolyptychV0, Ownable {
 
     // modifier to restrict access to only AdminACL allowed calls
     // @dev defers which ACL contract is used to the core contract
-    modifier onlyCoreAdminACL(bytes4 _selector) {
+    function _onlyCoreAdminACL(bytes4 _selector) internal {
         require(
             genArt721Core.adminACLAllowed(msg.sender, address(this), _selector),
             "Only Core AdminACL allowed"
         );
-        _;
     }
 
-    modifier onlyArtist(uint256 _projectId) {
+    function _onlyArtist(uint256 _projectId) internal view {
         require(
             msg.sender == genArt721Core.projectIdToArtistAddress(_projectId),
             "Only Artist"
         );
-        _;
     }
 
     // Allows the owner of the core contract to set the minter that is allowed to assign hash seeds
-    function setHashSeedSetterContract(
-        address _contractAddress
-    ) external onlyCoreAdminACL(this.setHashSeedSetterContract.selector) {
+    function setHashSeedSetterContract(address _contractAddress) external {
+        _onlyCoreAdminACL(this.setHashSeedSetterContract.selector);
         hashSeedSetterContract = _contractAddress;
         emit HashSeedSetterUpdated(_contractAddress);
     }
@@ -74,9 +71,8 @@ contract BasicPolyptychRandomizerV0 is IRandomizerPolyptychV0, Ownable {
      * @notice Allows the owner of the core contract to configure a project as a polyptych
      * @param _projectId - The ID of the project that has a polyptych panel (second, third, etc.)
      */
-    function toggleProjectIsPolyptych(
-        uint256 _projectId
-    ) external onlyArtist(_projectId) {
+    function toggleProjectIsPolyptych(uint256 _projectId) external {
+        _onlyArtist(_projectId);
         projectIsPolyptych[_projectId] = !projectIsPolyptych[_projectId];
         emit ProjectIsPolyptychUpdated(
             _projectId,

--- a/contracts/DependencyRegistryV0.sol
+++ b/contracts/DependencyRegistryV0.sol
@@ -65,38 +65,37 @@ contract DependencyRegistryV0 is
     EnumerableSet.AddressSet private _supportedCoreContracts;
     mapping(address => mapping(uint256 => bytes32)) projectDependencyTypeOverrides;
 
-    modifier onlyNonZeroAddress(address _address) {
+    function _onlyNonZeroAddress(address _address) internal pure {
         require(_address != address(0), "Must input non-zero address");
-        _;
     }
 
-    modifier onlyNonEmptyString(string memory _string) {
+    function _onlyNonEmptyString(string memory _string) internal pure {
         require(bytes(_string).length != 0, "Must input non-empty string");
-        _;
     }
 
-    modifier onlyAdminACL(bytes4 _selector) {
+    function _onlyAdminACL(bytes4 _selector) internal {
         require(
             adminACLAllowed(msg.sender, address(this), _selector),
             "Only Admin ACL allowed"
         );
-        _;
     }
 
-    modifier onlySupportedCoreContract(address _coreContractAddress) {
+    function _onlySupportedCoreContract(
+        address _coreContractAddress
+    ) internal view {
         require(
             _supportedCoreContracts.contains(_coreContractAddress),
             "Core contract not supported"
         );
-        _;
     }
 
-    modifier onlyExistingDependencyType(bytes32 _dependencyType) {
+    function _onlyExistingDependencyType(
+        bytes32 _dependencyType
+    ) internal view {
         require(
             _dependencyTypes.contains(_dependencyType),
             "Dependency type does not exist"
         );
-        _;
     }
 
     /**
@@ -121,7 +120,8 @@ contract DependencyRegistryV0 is
         string memory _preferredCDN,
         string memory _preferredRepository,
         string memory _referenceWebsite
-    ) external onlyAdminACL(this.addDependency.selector) {
+    ) external {
+        _onlyAdminACL(this.addDependency.selector);
         require(
             !_dependencyTypes.contains(_dependencyType),
             "Dependency type already exists"
@@ -152,13 +152,9 @@ contract DependencyRegistryV0 is
      * @notice Removes a dependency.
      * @param _dependencyType Name of dependency type (i.e. "type@version")
      */
-    function removeDependency(
-        bytes32 _dependencyType
-    )
-        external
-        onlyAdminACL(this.removeDependency.selector)
-        onlyExistingDependencyType(_dependencyType)
-    {
+    function removeDependency(bytes32 _dependencyType) external {
+        _onlyAdminACL(this.removeDependency.selector);
+        _onlyExistingDependencyType(_dependencyType);
         Dependency storage dependency = dependencyDetails[_dependencyType];
         require(
             dependency.additionalCDNCount == 0 &&
@@ -182,12 +178,10 @@ contract DependencyRegistryV0 is
     function addDependencyScript(
         bytes32 _dependencyType,
         string memory _script
-    )
-        external
-        onlyAdminACL(this.addDependencyScript.selector)
-        onlyNonEmptyString(_script)
-        onlyExistingDependencyType(_dependencyType)
-    {
+    ) external {
+        _onlyAdminACL(this.addDependencyScript.selector);
+        _onlyNonEmptyString(_script);
+        _onlyExistingDependencyType(_dependencyType);
         Dependency storage dependency = dependencyDetails[_dependencyType];
         // store script in contract bytecode
         dependency.scriptBytecodeAddresses[dependency.scriptCount] = _script
@@ -208,12 +202,10 @@ contract DependencyRegistryV0 is
         bytes32 _dependencyType,
         uint256 _scriptId,
         string memory _script
-    )
-        external
-        onlyAdminACL(this.updateDependencyScript.selector)
-        onlyNonEmptyString(_script)
-        onlyExistingDependencyType(_dependencyType)
-    {
+    ) external {
+        _onlyAdminACL(this.updateDependencyScript.selector);
+        _onlyNonEmptyString(_script);
+        _onlyExistingDependencyType(_dependencyType);
         Dependency storage dependencyType = dependencyDetails[_dependencyType];
         require(
             _scriptId < dependencyType.scriptCount,
@@ -241,13 +233,9 @@ contract DependencyRegistryV0 is
      * @notice Removes last script from dependency `_dependencyType`.
      * @param _dependencyType dependency to be updated.
      */
-    function removeDependencyLastScript(
-        bytes32 _dependencyType
-    )
-        external
-        onlyAdminACL(this.removeDependencyLastScript.selector)
-        onlyExistingDependencyType(_dependencyType)
-    {
+    function removeDependencyLastScript(bytes32 _dependencyType) external {
+        _onlyAdminACL(this.removeDependencyLastScript.selector);
+        _onlyExistingDependencyType(_dependencyType);
         Dependency storage dependency = dependencyDetails[_dependencyType];
         require(dependency.scriptCount > 0, "there are no scripts to remove");
         // purge old contract bytecode contract from the blockchain state
@@ -279,11 +267,9 @@ contract DependencyRegistryV0 is
     function updateDependencyPreferredCDN(
         bytes32 _dependencyType,
         string memory _preferredCDN
-    )
-        external
-        onlyAdminACL(this.updateDependencyPreferredCDN.selector)
-        onlyExistingDependencyType(_dependencyType)
-    {
+    ) external {
+        _onlyAdminACL(this.updateDependencyPreferredCDN.selector);
+        _onlyExistingDependencyType(_dependencyType);
         dependencyDetails[_dependencyType].preferredCDN = _preferredCDN;
 
         emit DependencyPreferredCDNUpdated(_dependencyType, _preferredCDN);
@@ -297,11 +283,9 @@ contract DependencyRegistryV0 is
     function updateDependencyPreferredRepository(
         bytes32 _dependencyType,
         string memory _preferredRepository
-    )
-        external
-        onlyAdminACL(this.updateDependencyPreferredRepository.selector)
-        onlyExistingDependencyType(_dependencyType)
-    {
+    ) external {
+        _onlyAdminACL(this.updateDependencyPreferredRepository.selector);
+        _onlyExistingDependencyType(_dependencyType);
         dependencyDetails[_dependencyType]
             .preferredRepository = _preferredRepository;
 
@@ -319,11 +303,9 @@ contract DependencyRegistryV0 is
     function updateDependencyReferenceWebsite(
         bytes32 _dependencyType,
         string memory _referenceWebsite
-    )
-        external
-        onlyAdminACL(this.updateDependencyReferenceWebsite.selector)
-        onlyExistingDependencyType(_dependencyType)
-    {
+    ) external {
+        _onlyAdminACL(this.updateDependencyReferenceWebsite.selector);
+        _onlyExistingDependencyType(_dependencyType);
         dependencyDetails[_dependencyType].referenceWebsite = _referenceWebsite;
 
         emit DependencyReferenceWebsiteUpdated(
@@ -341,12 +323,10 @@ contract DependencyRegistryV0 is
     function addDependencyAdditionalCDN(
         bytes32 _dependencyType,
         string memory _additionalCDN
-    )
-        external
-        onlyAdminACL(this.addDependencyAdditionalCDN.selector)
-        onlyNonEmptyString(_additionalCDN)
-        onlyExistingDependencyType(_dependencyType)
-    {
+    ) external {
+        _onlyAdminACL(this.addDependencyAdditionalCDN.selector);
+        _onlyNonEmptyString(_additionalCDN);
+        _onlyExistingDependencyType(_dependencyType);
         Dependency storage dependency = dependencyDetails[_dependencyType];
 
         uint256 additionalCDNCount = uint256(dependency.additionalCDNCount);
@@ -370,11 +350,9 @@ contract DependencyRegistryV0 is
     function removeDependencyAdditionalCDNAtIndex(
         bytes32 _dependencyType,
         uint256 _index
-    )
-        external
-        onlyAdminACL(this.removeDependencyAdditionalCDNAtIndex.selector)
-        onlyExistingDependencyType(_dependencyType)
-    {
+    ) external {
+        _onlyAdminACL(this.removeDependencyAdditionalCDNAtIndex.selector);
+        _onlyExistingDependencyType(_dependencyType);
         Dependency storage dependency = dependencyDetails[_dependencyType];
 
         uint256 additionalCDNCount = dependency.additionalCDNCount;
@@ -402,12 +380,10 @@ contract DependencyRegistryV0 is
         bytes32 _dependencyType,
         uint256 _index,
         string memory _additionalCDN
-    )
-        external
-        onlyAdminACL(this.updateDependencyAdditionalCDNAtIndex.selector)
-        onlyNonEmptyString(_additionalCDN)
-        onlyExistingDependencyType(_dependencyType)
-    {
+    ) external {
+        _onlyAdminACL(this.updateDependencyAdditionalCDNAtIndex.selector);
+        _onlyNonEmptyString(_additionalCDN);
+        _onlyExistingDependencyType(_dependencyType);
         Dependency storage dependency = dependencyDetails[_dependencyType];
         uint24 additionalCDNCount = dependency.additionalCDNCount;
         require(_index < additionalCDNCount, "Asset index out of range");
@@ -430,12 +406,10 @@ contract DependencyRegistryV0 is
     function addDependencyAdditionalRepository(
         bytes32 _dependencyType,
         string memory _additionalRepository
-    )
-        external
-        onlyAdminACL(this.addDependencyAdditionalRepository.selector)
-        onlyNonEmptyString(_additionalRepository)
-        onlyExistingDependencyType(_dependencyType)
-    {
+    ) external {
+        _onlyAdminACL(this.addDependencyAdditionalRepository.selector);
+        _onlyNonEmptyString(_additionalRepository);
+        _onlyExistingDependencyType(_dependencyType);
         Dependency storage dependency = dependencyDetails[_dependencyType];
         uint256 additionalRepositoryCount = uint256(
             dependency.additionalRepositoryCount
@@ -464,11 +438,11 @@ contract DependencyRegistryV0 is
     function removeDependencyAdditionalRepositoryAtIndex(
         bytes32 _dependencyType,
         uint256 _index
-    )
-        external
-        onlyAdminACL(this.removeDependencyAdditionalRepositoryAtIndex.selector)
-        onlyExistingDependencyType(_dependencyType)
-    {
+    ) external {
+        _onlyAdminACL(
+            this.removeDependencyAdditionalRepositoryAtIndex.selector
+        );
+        _onlyExistingDependencyType(_dependencyType);
         Dependency storage dependency = dependencyDetails[_dependencyType];
         uint256 additionalRepositoryCount = uint256(
             dependency.additionalRepositoryCount
@@ -497,12 +471,12 @@ contract DependencyRegistryV0 is
         bytes32 _dependencyType,
         uint256 _index,
         string memory _additionalRepository
-    )
-        external
-        onlyAdminACL(this.updateDependencyAdditionalRepositoryAtIndex.selector)
-        onlyNonEmptyString(_additionalRepository)
-        onlyExistingDependencyType(_dependencyType)
-    {
+    ) external {
+        _onlyAdminACL(
+            this.updateDependencyAdditionalRepositoryAtIndex.selector
+        );
+        _onlyNonEmptyString(_additionalRepository);
+        _onlyExistingDependencyType(_dependencyType);
         Dependency storage dependency = dependencyDetails[_dependencyType];
         uint24 additionalRepositoryCount = dependency.additionalRepositoryCount;
         require(_index < additionalRepositoryCount, "Asset index out of range");
@@ -520,13 +494,9 @@ contract DependencyRegistryV0 is
      * @notice Adds a new core contract to the list of supported core contracts.
      * @param _contractAddress Address of the core contract to be added.
      */
-    function addSupportedCoreContract(
-        address _contractAddress
-    )
-        external
-        onlyAdminACL(this.addSupportedCoreContract.selector)
-        onlyNonZeroAddress(_contractAddress)
-    {
+    function addSupportedCoreContract(address _contractAddress) external {
+        _onlyAdminACL(this.addSupportedCoreContract.selector);
+        _onlyNonZeroAddress(_contractAddress);
         require(
             !_supportedCoreContracts.contains(_contractAddress),
             "Contract already supported"
@@ -541,13 +511,9 @@ contract DependencyRegistryV0 is
      * @notice Removes a core contract from the list of supported core contracts.
      * @param _contractAddress Address of the core contract to be removed.
      */
-    function removeSupportedCoreContract(
-        address _contractAddress
-    )
-        external
-        onlyAdminACL(this.removeSupportedCoreContract.selector)
-        onlySupportedCoreContract(_contractAddress)
-    {
+    function removeSupportedCoreContract(address _contractAddress) external {
+        _onlyAdminACL(this.removeSupportedCoreContract.selector);
+        _onlySupportedCoreContract(_contractAddress);
         _supportedCoreContracts.remove(_contractAddress);
 
         emit SupportedCoreContractRemoved(_contractAddress);
@@ -566,12 +532,10 @@ contract DependencyRegistryV0 is
         address _contractAddress,
         uint256 _projectId,
         bytes32 _dependencyType
-    )
-        external
-        onlyAdminACL(this.addProjectDependencyTypeOverride.selector)
-        onlyExistingDependencyType(_dependencyType)
-        onlySupportedCoreContract(_contractAddress)
-    {
+    ) external {
+        _onlyAdminACL(this.addProjectDependencyTypeOverride.selector);
+        _onlyExistingDependencyType(_dependencyType);
+        _onlySupportedCoreContract(_contractAddress);
         projectDependencyTypeOverrides[_contractAddress][
             _projectId
         ] = _dependencyType;
@@ -592,7 +556,8 @@ contract DependencyRegistryV0 is
     function removeProjectDependencyTypeOverride(
         address _contractAddress,
         uint256 _projectId
-    ) external onlyAdminACL(this.removeProjectDependencyTypeOverride.selector) {
+    ) external {
+        _onlyAdminACL(this.removeProjectDependencyTypeOverride.selector);
         require(
             projectDependencyTypeOverrides[_contractAddress][_projectId] !=
                 bytes32(""),
@@ -808,12 +773,8 @@ contract DependencyRegistryV0 is
     function getDependencyTypeForProject(
         address _contractAddress,
         uint256 _projectId
-    )
-        external
-        view
-        onlySupportedCoreContract(_contractAddress)
-        returns (string memory)
-    {
+    ) external view returns (string memory) {
+        _onlySupportedCoreContract(_contractAddress);
         bytes32 dependencyType = projectDependencyTypeOverrides[
             _contractAddress
         ][_projectId];

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -240,65 +240,60 @@ contract GenArt721CoreV3 is
     bool public newProjectsForbidden;
 
     /// version & type of this core contract
-    string public constant coreVersion = "v3.0.0";
+    string public constant coreVersion = "v3.0.2";
     string public constant coreType = "GenArt721CoreV3";
 
     /// default base URI to initialize all new project projectBaseURI values to
     string public defaultBaseURI;
 
-    modifier onlyNonZeroAddress(address _address) {
+    function _onlyNonZeroAddress(address _address) internal pure {
         require(_address != address(0), "Must input non-zero address");
-        _;
     }
 
-    modifier onlyNonEmptyString(string memory _string) {
+    function _onlyNonEmptyString(string memory _string) internal pure {
         require(bytes(_string).length != 0, "Must input non-empty string");
-        _;
     }
 
-    modifier onlyValidTokenId(uint256 _tokenId) {
+    function _onlyValidTokenId(uint256 _tokenId) internal view {
         require(_exists(_tokenId), "Token ID does not exist");
-        _;
     }
 
-    modifier onlyValidProjectId(uint256 _projectId) {
+    function _onlyValidProjectId(uint256 _projectId) internal view {
         require(
             (_projectId >= startingProjectId) && (_projectId < _nextProjectId),
             "Project ID does not exist"
         );
-        _;
     }
 
-    modifier onlyUnlocked(uint256 _projectId) {
+    function _onlyUnlocked(uint256 _projectId) internal view {
         // Note: calling `_projectUnlocked` enforces that the `_projectId`
         //       passed in is valid.`
         require(_projectUnlocked(_projectId), "Only if unlocked");
-        _;
     }
 
-    modifier onlyAdminACL(bytes4 _selector) {
+    function _onlyAdminACL(bytes4 _selector) internal {
         require(
             adminACLAllowed(msg.sender, address(this), _selector),
             "Only Admin ACL allowed"
         );
-        _;
     }
 
-    modifier onlyArtist(uint256 _projectId) {
+    function _onlyArtist(uint256 _projectId) internal view {
         require(
             msg.sender == projectIdToFinancials[_projectId].artistAddress,
             "Only artist"
         );
-        _;
     }
 
-    modifier onlyArtistOrAdminACL(uint256 _projectId, bytes4 _selector) {
+    function _onlyArtistOrAdminACL(
+        uint256 _projectId,
+        bytes4 _selector
+    ) internal {
         require(
             msg.sender == projectIdToFinancials[_projectId].artistAddress ||
                 adminACLAllowed(msg.sender, address(this), _selector),
             "Only artist or Admin ACL allowed"
         );
-        _;
     }
 
     /**
@@ -307,10 +302,10 @@ contract GenArt721CoreV3 is
      * contract to continue to function if the owner decides to renounce
      * ownership.
      */
-    modifier onlyAdminACLOrRenouncedArtist(
+    function _onlyAdminACLOrRenouncedArtist(
         uint256 _projectId,
         bytes4 _selector
-    ) {
+    ) internal {
         require(
             adminACLAllowed(msg.sender, address(this), _selector) ||
                 (owner() == address(0) &&
@@ -318,7 +313,6 @@ contract GenArt721CoreV3 is
                     projectIdToFinancials[_projectId].artistAddress),
             "Only Admin ACL allowed, or artist if owner has renounced"
         );
-        _;
     }
 
     /**
@@ -340,10 +334,8 @@ contract GenArt721CoreV3 is
         address _randomizerContract,
         address _adminACLContract,
         uint248 _startingProjectId
-    )
-        ERC721_PackedHashSeed(_tokenName, _tokenSymbol)
-        onlyNonZeroAddress(_randomizerContract)
-    {
+    ) ERC721_PackedHashSeed(_tokenName, _tokenSymbol) {
+        _onlyNonZeroAddress(_randomizerContract);
         // record contracts starting project ID
         // casting-up is safe
         startingProjectId = uint256(_startingProjectId);
@@ -447,10 +439,8 @@ contract GenArt721CoreV3 is
      * for indexing purposes, it must be emitted by the randomizer. This is to
      * minimize gas when minting.
      */
-    function setTokenHash_8PT(
-        uint256 _tokenId,
-        bytes32 _hashSeed
-    ) external onlyValidTokenId(_tokenId) {
+    function setTokenHash_8PT(uint256 _tokenId, bytes32 _hashSeed) external {
+        _onlyValidTokenId(_tokenId);
         OwnerAndHashSeed storage ownerAndHashSeed = _ownersAndHashSeeds[
             _tokenId
         ];
@@ -500,11 +490,9 @@ contract GenArt721CoreV3 is
      */
     function updateArtblocksCurationRegistryAddress(
         address _artblocksCurationRegistryAddress
-    )
-        external
-        onlyAdminACL(this.updateArtblocksCurationRegistryAddress.selector)
-        onlyNonZeroAddress(_artblocksCurationRegistryAddress)
-    {
+    ) external {
+        _onlyAdminACL(this.updateArtblocksCurationRegistryAddress.selector);
+        _onlyNonZeroAddress(_artblocksCurationRegistryAddress);
         artblocksCurationRegistryAddress = _artblocksCurationRegistryAddress;
         emit PlatformUpdated(FIELD_ARTBLOCKS_CURATION_REGISTRY_ADDRESS);
     }
@@ -516,11 +504,9 @@ contract GenArt721CoreV3 is
      */
     function updateArtblocksDependencyRegistryAddress(
         address _artblocksDependencyRegistryAddress
-    )
-        external
-        onlyAdminACL(this.updateArtblocksDependencyRegistryAddress.selector)
-        onlyNonZeroAddress(_artblocksDependencyRegistryAddress)
-    {
+    ) external {
+        _onlyAdminACL(this.updateArtblocksDependencyRegistryAddress.selector);
+        _onlyNonZeroAddress(_artblocksDependencyRegistryAddress);
         artblocksDependencyRegistryAddress = _artblocksDependencyRegistryAddress;
         emit PlatformUpdated(FIELD_ARTBLOCKS_DEPENDENCY_REGISTRY_ADDRESS);
     }
@@ -533,11 +519,9 @@ contract GenArt721CoreV3 is
      */
     function updateArtblocksPrimarySalesAddress(
         address payable _artblocksPrimarySalesAddress
-    )
-        external
-        onlyAdminACL(this.updateArtblocksPrimarySalesAddress.selector)
-        onlyNonZeroAddress(_artblocksPrimarySalesAddress)
-    {
+    ) external {
+        _onlyAdminACL(this.updateArtblocksPrimarySalesAddress.selector);
+        _onlyNonZeroAddress(_artblocksPrimarySalesAddress);
         _updateArtblocksPrimarySalesAddress(_artblocksPrimarySalesAddress);
     }
 
@@ -549,11 +533,9 @@ contract GenArt721CoreV3 is
      */
     function updateArtblocksSecondarySalesAddress(
         address payable _artblocksSecondarySalesAddress
-    )
-        external
-        onlyAdminACL(this.updateArtblocksSecondarySalesAddress.selector)
-        onlyNonZeroAddress(_artblocksSecondarySalesAddress)
-    {
+    ) external {
+        _onlyAdminACL(this.updateArtblocksSecondarySalesAddress.selector);
+        _onlyNonZeroAddress(_artblocksSecondarySalesAddress);
         _updateArtblocksSecondarySalesAddress(_artblocksSecondarySalesAddress);
     }
 
@@ -565,10 +547,8 @@ contract GenArt721CoreV3 is
      */
     function updateArtblocksPrimarySalesPercentage(
         uint256 artblocksPrimarySalesPercentage_
-    )
-        external
-        onlyAdminACL(this.updateArtblocksPrimarySalesPercentage.selector)
-    {
+    ) external {
+        _onlyAdminACL(this.updateArtblocksPrimarySalesPercentage.selector);
         require(
             artblocksPrimarySalesPercentage_ <=
                 ART_BLOCKS_MAX_PRIMARY_SALES_PERCENTAGE,
@@ -593,7 +573,8 @@ contract GenArt721CoreV3 is
      */
     function updateArtblocksSecondarySalesBPS(
         uint256 _artblocksSecondarySalesBPS
-    ) external onlyAdminACL(this.updateArtblocksSecondarySalesBPS.selector) {
+    ) external {
+        _onlyAdminACL(this.updateArtblocksSecondarySalesBPS.selector);
         require(
             _artblocksSecondarySalesBPS <= ART_BLOCKS_MAX_SECONDARY_SALES_BPS,
             "Max of ART_BLOCKS_MAX_SECONDARY_SALES_BPS BPS"
@@ -606,13 +587,9 @@ contract GenArt721CoreV3 is
      * @notice Updates minter to `_address`.
      * @param _address Address of new minter.
      */
-    function updateMinterContract(
-        address _address
-    )
-        external
-        onlyAdminACL(this.updateMinterContract.selector)
-        onlyNonZeroAddress(_address)
-    {
+    function updateMinterContract(address _address) external {
+        _onlyAdminACL(this.updateMinterContract.selector);
+        _onlyNonZeroAddress(_address);
         minterContract = _address;
         emit MinterUpdated(_address);
     }
@@ -621,13 +598,9 @@ contract GenArt721CoreV3 is
      * @notice Updates randomizer to `_randomizerAddress`.
      * @param _randomizerAddress Address of new randomizer.
      */
-    function updateRandomizerAddress(
-        address _randomizerAddress
-    )
-        external
-        onlyAdminACL(this.updateRandomizerAddress.selector)
-        onlyNonZeroAddress(_randomizerAddress)
-    {
+    function updateRandomizerAddress(address _randomizerAddress) external {
+        _onlyAdminACL(this.updateRandomizerAddress.selector);
+        _onlyNonZeroAddress(_randomizerAddress);
         _updateRandomizerAddress(_randomizerAddress);
     }
 
@@ -635,13 +608,9 @@ contract GenArt721CoreV3 is
      * @notice Toggles project `_projectId` as active/inactive.
      * @param _projectId Project ID to be toggled.
      */
-    function toggleProjectIsActive(
-        uint256 _projectId
-    )
-        external
-        onlyAdminACL(this.toggleProjectIsActive.selector)
-        onlyValidProjectId(_projectId)
-    {
+    function toggleProjectIsActive(uint256 _projectId) external {
+        _onlyAdminACL(this.toggleProjectIsActive.selector);
+        _onlyValidProjectId(_projectId);
         projects[_projectId].active = !projects[_projectId].active;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_ACTIVE);
     }
@@ -682,12 +651,10 @@ contract GenArt721CoreV3 is
         uint256 _additionalPayeePrimarySalesPercentage,
         address payable _additionalPayeeSecondarySales,
         uint256 _additionalPayeeSecondarySalesPercentage
-    )
-        external
-        onlyValidProjectId(_projectId)
-        onlyArtist(_projectId)
-        onlyNonZeroAddress(_artistAddress)
-    {
+    ) external {
+        _onlyValidProjectId(_projectId);
+        _onlyArtist(_projectId);
+        _onlyNonZeroAddress(_artistAddress);
         ProjectFinance storage projectFinance = projectIdToFinancials[
             _projectId
         ];
@@ -802,15 +769,13 @@ contract GenArt721CoreV3 is
         uint256 _additionalPayeePrimarySalesPercentage,
         address payable _additionalPayeeSecondarySales,
         uint256 _additionalPayeeSecondarySalesPercentage
-    )
-        external
-        onlyValidProjectId(_projectId)
-        onlyAdminACLOrRenouncedArtist(
+    ) external {
+        _onlyValidProjectId(_projectId);
+        _onlyAdminACLOrRenouncedArtist(
             _projectId,
             this.adminAcceptArtistAddressesAndSplits.selector
-        )
-        onlyNonZeroAddress(_artistAddress)
-    {
+        );
+        _onlyNonZeroAddress(_artistAddress);
         // checks
         require(
             proposedArtistAddressesAndSplitsHash[_projectId] ==
@@ -856,15 +821,13 @@ contract GenArt721CoreV3 is
     function updateProjectArtistAddress(
         uint256 _projectId,
         address payable _artistAddress
-    )
-        external
-        onlyValidProjectId(_projectId)
-        onlyAdminACLOrRenouncedArtist(
+    ) external {
+        _onlyValidProjectId(_projectId);
+        _onlyAdminACLOrRenouncedArtist(
             _projectId,
             this.updateProjectArtistAddress.selector
-        )
-        onlyNonZeroAddress(_artistAddress)
-    {
+        );
+        _onlyNonZeroAddress(_artistAddress);
         projectIdToFinancials[_projectId].artistAddress = _artistAddress;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_ARTIST_ADDRESS);
     }
@@ -873,9 +836,8 @@ contract GenArt721CoreV3 is
      * @notice Toggles paused state of project `_projectId`.
      * @param _projectId Project ID to be toggled.
      */
-    function toggleProjectIsPaused(
-        uint256 _projectId
-    ) external onlyArtist(_projectId) {
+    function toggleProjectIsPaused(uint256 _projectId) external {
+        _onlyArtist(_projectId);
         projects[_projectId].paused = !projects[_projectId].paused;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_PAUSED);
     }
@@ -889,12 +851,10 @@ contract GenArt721CoreV3 is
     function addProject(
         string memory _projectName,
         address payable _artistAddress
-    )
-        external
-        onlyAdminACL(this.addProject.selector)
-        onlyNonEmptyString(_projectName)
-        onlyNonZeroAddress(_artistAddress)
-    {
+    ) external {
+        _onlyAdminACL(this.addProject.selector);
+        _onlyNonEmptyString(_projectName);
+        _onlyNonZeroAddress(_artistAddress);
         require(!newProjectsForbidden, "New projects forbidden");
         uint256 projectId = _nextProjectId;
         projectIdToFinancials[projectId].artistAddress = _artistAddress;
@@ -910,10 +870,8 @@ contract GenArt721CoreV3 is
     /**
      * @notice Forever forbids new projects from being added to this contract.
      */
-    function forbidNewProjects()
-        external
-        onlyAdminACL(this.forbidNewProjects.selector)
-    {
+    function forbidNewProjects() external {
+        _onlyAdminACL(this.forbidNewProjects.selector);
         require(!newProjectsForbidden, "Already forbidden");
         _forbidNewProjects();
     }
@@ -926,12 +884,10 @@ contract GenArt721CoreV3 is
     function updateProjectName(
         uint256 _projectId,
         string memory _projectName
-    )
-        external
-        onlyUnlocked(_projectId)
-        onlyArtistOrAdminACL(_projectId, this.updateProjectName.selector)
-        onlyNonEmptyString(_projectName)
-    {
+    ) external {
+        _onlyUnlocked(_projectId);
+        _onlyArtistOrAdminACL(_projectId, this.updateProjectName.selector);
+        _onlyNonEmptyString(_projectName);
         projects[_projectId].name = _projectName;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_NAME);
     }
@@ -945,12 +901,13 @@ contract GenArt721CoreV3 is
     function updateProjectArtistName(
         uint256 _projectId,
         string memory _projectArtistName
-    )
-        external
-        onlyUnlocked(_projectId)
-        onlyArtistOrAdminACL(_projectId, this.updateProjectArtistName.selector)
-        onlyNonEmptyString(_projectArtistName)
-    {
+    ) external {
+        _onlyUnlocked(_projectId);
+        _onlyArtistOrAdminACL(
+            _projectId,
+            this.updateProjectArtistName.selector
+        );
+        _onlyNonEmptyString(_projectArtistName);
         projects[_projectId].artist = _projectArtistName;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_ARTIST_NAME);
     }
@@ -969,7 +926,8 @@ contract GenArt721CoreV3 is
     function updateProjectSecondaryMarketRoyaltyPercentage(
         uint256 _projectId,
         uint256 _secondMarketRoyalty
-    ) external onlyArtist(_projectId) {
+    ) external {
+        _onlyArtist(_projectId);
         require(
             _secondMarketRoyalty <= ARTIST_MAX_SECONDARY_ROYALTY_PERCENTAGE,
             "Max of ARTIST_MAX_SECONDARY_ROYALTY_PERCENTAGE percent"
@@ -1017,7 +975,8 @@ contract GenArt721CoreV3 is
     function updateProjectWebsite(
         uint256 _projectId,
         string memory _projectWebsite
-    ) external onlyArtist(_projectId) {
+    ) external {
+        _onlyArtist(_projectId);
         projects[_projectId].website = _projectWebsite;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_WEBSITE);
     }
@@ -1030,12 +989,10 @@ contract GenArt721CoreV3 is
     function updateProjectLicense(
         uint256 _projectId,
         string memory _projectLicense
-    )
-        external
-        onlyUnlocked(_projectId)
-        onlyArtistOrAdminACL(_projectId, this.updateProjectLicense.selector)
-        onlyNonEmptyString(_projectLicense)
-    {
+    ) external {
+        _onlyUnlocked(_projectId);
+        _onlyArtistOrAdminACL(_projectId, this.updateProjectLicense.selector);
+        _onlyNonEmptyString(_projectLicense);
         projects[_projectId].license = _projectLicense;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_LICENSE);
     }
@@ -1052,7 +1009,8 @@ contract GenArt721CoreV3 is
     function updateProjectMaxInvocations(
         uint256 _projectId,
         uint24 _maxInvocations
-    ) external onlyArtist(_projectId) {
+    ) external {
+        _onlyArtist(_projectId);
         // CHECKS
         Project storage project = projects[_projectId];
         uint256 _invocations = project.invocations;
@@ -1083,12 +1041,10 @@ contract GenArt721CoreV3 is
     function addProjectScript(
         uint256 _projectId,
         string memory _script
-    )
-        external
-        onlyUnlocked(_projectId)
-        onlyArtistOrAdminACL(_projectId, this.addProjectScript.selector)
-        onlyNonEmptyString(_script)
-    {
+    ) external {
+        _onlyUnlocked(_projectId);
+        _onlyArtistOrAdminACL(_projectId, this.addProjectScript.selector);
+        _onlyNonEmptyString(_script);
         Project storage project = projects[_projectId];
         // store script in contract bytecode
         project.scriptBytecodeAddresses[project.scriptCount] = _script
@@ -1108,12 +1064,10 @@ contract GenArt721CoreV3 is
         uint256 _projectId,
         uint256 _scriptId,
         string memory _script
-    )
-        external
-        onlyUnlocked(_projectId)
-        onlyArtistOrAdminACL(_projectId, this.updateProjectScript.selector)
-        onlyNonEmptyString(_script)
-    {
+    ) external {
+        _onlyUnlocked(_projectId);
+        _onlyArtistOrAdminACL(_projectId, this.updateProjectScript.selector);
+        _onlyNonEmptyString(_script);
         Project storage project = projects[_projectId];
         require(_scriptId < project.scriptCount, "scriptId out of range");
         // purge old contract bytecode contract from the blockchain state
@@ -1136,13 +1090,12 @@ contract GenArt721CoreV3 is
      * @notice Removes last script from project `_projectId`.
      * @param _projectId Project to be updated.
      */
-    function removeProjectLastScript(
-        uint256 _projectId
-    )
-        external
-        onlyUnlocked(_projectId)
-        onlyArtistOrAdminACL(_projectId, this.removeProjectLastScript.selector)
-    {
+    function removeProjectLastScript(uint256 _projectId) external {
+        _onlyUnlocked(_projectId);
+        _onlyArtistOrAdminACL(
+            _projectId,
+            this.removeProjectLastScript.selector
+        );
         Project storage project = projects[_projectId];
         require(project.scriptCount > 0, "there are no scripts to remove");
         // purge old contract bytecode contract from the blockchain state
@@ -1174,11 +1127,12 @@ contract GenArt721CoreV3 is
     function updateProjectScriptType(
         uint256 _projectId,
         bytes32 _scriptTypeAndVersion
-    )
-        external
-        onlyUnlocked(_projectId)
-        onlyArtistOrAdminACL(_projectId, this.updateProjectScriptType.selector)
-    {
+    ) external {
+        _onlyUnlocked(_projectId);
+        _onlyArtistOrAdminACL(
+            _projectId,
+            this.updateProjectScriptType.selector
+        );
         Project storage project = projects[_projectId];
         // require exactly one @ symbol in _scriptTypeAndVersion
         require(
@@ -1202,12 +1156,13 @@ contract GenArt721CoreV3 is
     function updateProjectAspectRatio(
         uint256 _projectId,
         string memory _aspectRatio
-    )
-        external
-        onlyUnlocked(_projectId)
-        onlyArtistOrAdminACL(_projectId, this.updateProjectAspectRatio.selector)
-        onlyNonEmptyString(_aspectRatio)
-    {
+    ) external {
+        _onlyUnlocked(_projectId);
+        _onlyArtistOrAdminACL(
+            _projectId,
+            this.updateProjectAspectRatio.selector
+        );
+        _onlyNonEmptyString(_aspectRatio);
         // Perform more detailed input validation for aspect ratio.
         bytes memory aspectRatioBytes = bytes(_aspectRatio);
         uint256 bytesLength = aspectRatioBytes.length;
@@ -1250,7 +1205,9 @@ contract GenArt721CoreV3 is
     function updateProjectBaseURI(
         uint256 _projectId,
         string memory _newBaseURI
-    ) external onlyArtist(_projectId) onlyNonEmptyString(_newBaseURI) {
+    ) external {
+        _onlyArtist(_projectId);
+        _onlyNonEmptyString(_newBaseURI);
         projects[_projectId].projectBaseURI = _newBaseURI;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_BASE_URI);
     }
@@ -1261,13 +1218,9 @@ contract GenArt721CoreV3 is
      * projects. Token URIs are determined by their project's `projectBaseURI`.
      * @param _defaultBaseURI New default base URI.
      */
-    function updateDefaultBaseURI(
-        string memory _defaultBaseURI
-    )
-        external
-        onlyAdminACL(this.updateDefaultBaseURI.selector)
-        onlyNonEmptyString(_defaultBaseURI)
-    {
+    function updateDefaultBaseURI(string memory _defaultBaseURI) external {
+        _onlyAdminACL(this.updateDefaultBaseURI.selector);
+        _onlyNonEmptyString(_defaultBaseURI);
         _updateDefaultBaseURI(_defaultBaseURI);
     }
 
@@ -1670,9 +1623,9 @@ contract GenArt721CoreV3 is
     )
         external
         view
-        onlyValidTokenId(_tokenId)
         returns (address payable[] memory recipients, uint256[] memory bps)
     {
+        _onlyValidTokenId(_tokenId);
         // initialize arrays with maximum potential length
         recipients = new address payable[](3);
         bps = new uint256[](3);
@@ -1867,7 +1820,8 @@ contract GenArt721CoreV3 is
      */
     function tokenURI(
         uint256 _tokenId
-    ) public view override onlyValidTokenId(_tokenId) returns (string memory) {
+    ) public view override returns (string memory) {
+        _onlyValidTokenId(_tokenId);
         string memory _projectBaseURI = projects[tokenIdToProjectId(_tokenId)]
             .projectBaseURI;
         return string.concat(_projectBaseURI, _tokenId.toString());
@@ -1987,9 +1941,8 @@ contract GenArt721CoreV3 is
      * @return bool true if project is unlocked, false otherwise.
      * @dev This also enforces that the `_projectId` passed in is valid.
      */
-    function _projectUnlocked(
-        uint256 _projectId
-    ) internal view onlyValidProjectId(_projectId) returns (bool) {
+    function _projectUnlocked(uint256 _projectId) internal view returns (bool) {
+        _onlyValidProjectId(_projectId);
         uint256 projectCompletedTimestamp = projects[_projectId]
             .completedTimestamp;
         bool projectOpen = projectCompletedTimestamp == 0;

--- a/contracts/V3_CHANGELOG.md
+++ b/contracts/V3_CHANGELOG.md
@@ -84,3 +84,7 @@ V3 performance metrics are available in [V3_Performance.md](V3_Performance.md)
   - This is to help ensure that the data stored on-chain is valid and is not accidentally invalid (e.g. an artist additional payee being set to the zero address, while also sending funds to the additional payee).
 - Improve natspec documentation, especially around privileged roles and functions
 - Achieve 100% test coverage of V3 core contract
+
+## The following changes were made in the Core V3 (3.0.2) contract:
+
+- Change modifiers to internal functions, preventing duplication of the logic throughout the bytecode

--- a/contracts/explorations/GenArt721CoreV3_Explorations.sol
+++ b/contracts/explorations/GenArt721CoreV3_Explorations.sol
@@ -245,71 +245,66 @@ contract GenArt721CoreV3_Explorations is
     /// default base URI to initialize all new project projectBaseURI values to
     string public defaultBaseURI;
 
-    modifier onlyNonZeroAddress(address _address) {
+    function _onlyNonZeroAddress(address _address) internal pure {
         require(_address != address(0), "Must input non-zero address");
-        _;
     }
 
-    modifier onlyNonEmptyString(string memory _string) {
+    function _onlyNonEmptyString(string memory _string) internal pure {
         require(bytes(_string).length != 0, "Must input non-empty string");
-        _;
     }
 
-    modifier onlyValidTokenId(uint256 _tokenId) {
+    function _onlyValidTokenId(uint256 _tokenId) internal view {
         require(_exists(_tokenId), "Token ID does not exist");
-        _;
     }
 
-    modifier onlyValidProjectId(uint256 _projectId) {
+    function _onlyValidProjectId(uint256 _projectId) internal view {
         require(
             (_projectId >= startingProjectId) && (_projectId < _nextProjectId),
             "Project ID does not exist"
         );
-        _;
     }
 
-    modifier onlyUnlocked(uint256 _projectId) {
+    function _onlyUnlocked(uint256 _projectId) internal view {
         // Note: calling `_projectUnlocked` enforces that the `_projectId`
         //       passed in is valid.`
         require(_projectUnlocked(_projectId), "Only if unlocked");
-        _;
     }
 
-    modifier onlyAdminACL(bytes4 _selector) {
+    function onlyAdminACL(bytes4 _selector) internal {
         require(
             adminACLAllowed(msg.sender, address(this), _selector),
             "Only Admin ACL allowed"
         );
-        _;
     }
 
-    modifier onlyArtist(uint256 _projectId) {
+    function _onlyArtist(uint256 _projectId) internal view {
         require(
             msg.sender == projectIdToFinancials[_projectId].artistAddress,
             "Only artist"
         );
-        _;
     }
 
-    modifier onlyArtistOrAdminACL(uint256 _projectId, bytes4 _selector) {
+    function _onlyArtistOrAdminACL(
+        uint256 _projectId,
+        bytes4 _selector
+    ) internal {
         require(
             msg.sender == projectIdToFinancials[_projectId].artistAddress ||
                 adminACLAllowed(msg.sender, address(this), _selector),
             "Only artist or Admin ACL allowed"
         );
-        _;
     }
 
     /**
-     * This modifier allows the artist of a project to call a function if the
+     * This function allows the artist of a project to call a function if the
      * owner of the contract has renounced ownership. This is to allow the
      * contract to continue to function if the owner decides to renounce
      * ownership.
      */
-    modifier onlyAdminACLOrRenouncedArtist(
+    function _onlyAdminACLOrRenouncedArtist(
         uint256 _projectId,
         bytes4 _selector
-    ) {
+    ) internal {
         require(
             adminACLAllowed(msg.sender, address(this), _selector) ||
                 (owner() == address(0) &&
@@ -317,7 +312,6 @@ contract GenArt721CoreV3_Explorations is
                     projectIdToFinancials[_projectId].artistAddress),
             "Only Admin ACL allowed, or artist if owner has renounced"
         );
-        _;
     }
 
     /**
@@ -339,10 +333,8 @@ contract GenArt721CoreV3_Explorations is
         address _randomizerContract,
         address _adminACLContract,
         uint248 _startingProjectId
-    )
-        ERC721_PackedHashSeed(_tokenName, _tokenSymbol)
-        onlyNonZeroAddress(_randomizerContract)
-    {
+    ) ERC721_PackedHashSeed(_tokenName, _tokenSymbol) {
+        _onlyNonZeroAddress(_randomizerContract);
         // record contracts starting project ID
         // casting-up is safe
         startingProjectId = uint256(_startingProjectId);
@@ -452,10 +444,8 @@ contract GenArt721CoreV3_Explorations is
      * for indexing purposes, it must be emitted by the randomizer. This is to
      * minimize gas when minting.
      */
-    function setTokenHash_8PT(
-        uint256 _tokenId,
-        bytes32 _hashSeed
-    ) external onlyValidTokenId(_tokenId) {
+    function setTokenHash_8PT(uint256 _tokenId, bytes32 _hashSeed) external {
+        _onlyValidTokenId(_tokenId);
         OwnerAndHashSeed storage ownerAndHashSeed = _ownersAndHashSeeds[
             _tokenId
         ];
@@ -481,8 +471,8 @@ contract GenArt721CoreV3_Explorations is
      * that also integrate with the owner/AdminACL contract (e.g. potentially
      * minter suite contracts, registry contracts, etc.).
      * After renouncing ownership, artists will be in control of updates to
-     * their payment addresses and splits (see modifier
-     * onlyAdminACLOrRenouncedArtist`).
+     * their payment addresses and splits (see function
+     * _onlyAdminACLOrRenouncedArtist`).
      * While there is no currently intended reason to call this method based on
      * defined Art Blocks business practices, this method exists to allow
      * artists to continue to maintain the limited set of contract
@@ -507,11 +497,9 @@ contract GenArt721CoreV3_Explorations is
      */
     function updateArtblocksCurationRegistryAddress(
         address _artblocksCurationRegistryAddress
-    )
-        external
-        onlyAdminACL(this.updateArtblocksCurationRegistryAddress.selector)
-        onlyNonZeroAddress(_artblocksCurationRegistryAddress)
-    {
+    ) external {
+        onlyAdminACL(this.updateArtblocksCurationRegistryAddress.selector);
+        _onlyNonZeroAddress(_artblocksCurationRegistryAddress);
         revert("Action not supported");
     }
 
@@ -522,11 +510,9 @@ contract GenArt721CoreV3_Explorations is
      */
     function updateArtblocksDependencyRegistryAddress(
         address _artblocksDependencyRegistryAddress
-    )
-        external
-        onlyAdminACL(this.updateArtblocksDependencyRegistryAddress.selector)
-        onlyNonZeroAddress(_artblocksDependencyRegistryAddress)
-    {
+    ) external {
+        onlyAdminACL(this.updateArtblocksDependencyRegistryAddress.selector);
+        _onlyNonZeroAddress(_artblocksDependencyRegistryAddress);
         artblocksDependencyRegistryAddress = _artblocksDependencyRegistryAddress;
         emit PlatformUpdated(FIELD_ARTBLOCKS_DEPENDENCY_REGISTRY_ADDRESS);
     }
@@ -539,11 +525,9 @@ contract GenArt721CoreV3_Explorations is
      */
     function updateArtblocksPrimarySalesAddress(
         address payable _artblocksPrimarySalesAddress
-    )
-        external
-        onlyAdminACL(this.updateArtblocksPrimarySalesAddress.selector)
-        onlyNonZeroAddress(_artblocksPrimarySalesAddress)
-    {
+    ) external {
+        onlyAdminACL(this.updateArtblocksPrimarySalesAddress.selector);
+        _onlyNonZeroAddress(_artblocksPrimarySalesAddress);
         _updateArtblocksPrimarySalesAddress(_artblocksPrimarySalesAddress);
     }
 
@@ -555,11 +539,9 @@ contract GenArt721CoreV3_Explorations is
      */
     function updateArtblocksSecondarySalesAddress(
         address payable _artblocksSecondarySalesAddress
-    )
-        external
-        onlyAdminACL(this.updateArtblocksSecondarySalesAddress.selector)
-        onlyNonZeroAddress(_artblocksSecondarySalesAddress)
-    {
+    ) external {
+        onlyAdminACL(this.updateArtblocksSecondarySalesAddress.selector);
+        _onlyNonZeroAddress(_artblocksSecondarySalesAddress);
         _updateArtblocksSecondarySalesAddress(_artblocksSecondarySalesAddress);
     }
 
@@ -571,10 +553,8 @@ contract GenArt721CoreV3_Explorations is
      */
     function updateArtblocksPrimarySalesPercentage(
         uint256 artblocksPrimarySalesPercentage_
-    )
-        external
-        onlyAdminACL(this.updateArtblocksPrimarySalesPercentage.selector)
-    {
+    ) external {
+        onlyAdminACL(this.updateArtblocksPrimarySalesPercentage.selector);
         require(
             artblocksPrimarySalesPercentage_ <=
                 ART_BLOCKS_MAX_PRIMARY_SALES_PERCENTAGE,
@@ -599,7 +579,8 @@ contract GenArt721CoreV3_Explorations is
      */
     function updateArtblocksSecondarySalesBPS(
         uint256 _artblocksSecondarySalesBPS
-    ) external onlyAdminACL(this.updateArtblocksSecondarySalesBPS.selector) {
+    ) external {
+        onlyAdminACL(this.updateArtblocksSecondarySalesBPS.selector);
         require(
             _artblocksSecondarySalesBPS <= ART_BLOCKS_MAX_SECONDARY_SALES_BPS,
             "Max of ART_BLOCKS_MAX_SECONDARY_SALES_BPS BPS"
@@ -612,13 +593,9 @@ contract GenArt721CoreV3_Explorations is
      * @notice Updates minter to `_address`.
      * @param _address Address of new minter.
      */
-    function updateMinterContract(
-        address _address
-    )
-        external
-        onlyAdminACL(this.updateMinterContract.selector)
-        onlyNonZeroAddress(_address)
-    {
+    function updateMinterContract(address _address) external {
+        onlyAdminACL(this.updateMinterContract.selector);
+        _onlyNonZeroAddress(_address);
         minterContract = _address;
         emit MinterUpdated(_address);
     }
@@ -627,13 +604,9 @@ contract GenArt721CoreV3_Explorations is
      * @notice Updates randomizer to `_randomizerAddress`.
      * @param _randomizerAddress Address of new randomizer.
      */
-    function updateRandomizerAddress(
-        address _randomizerAddress
-    )
-        external
-        onlyAdminACL(this.updateRandomizerAddress.selector)
-        onlyNonZeroAddress(_randomizerAddress)
-    {
+    function updateRandomizerAddress(address _randomizerAddress) external {
+        onlyAdminACL(this.updateRandomizerAddress.selector);
+        _onlyNonZeroAddress(_randomizerAddress);
         _updateRandomizerAddress(_randomizerAddress);
     }
 
@@ -641,13 +614,9 @@ contract GenArt721CoreV3_Explorations is
      * @notice Toggles project `_projectId` as active/inactive.
      * @param _projectId Project ID to be toggled.
      */
-    function toggleProjectIsActive(
-        uint256 _projectId
-    )
-        external
-        onlyAdminACL(this.toggleProjectIsActive.selector)
-        onlyValidProjectId(_projectId)
-    {
+    function toggleProjectIsActive(uint256 _projectId) external {
+        onlyAdminACL(this.toggleProjectIsActive.selector);
+        _onlyValidProjectId(_projectId);
         projects[_projectId].active = !projects[_projectId].active;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_ACTIVE);
     }
@@ -688,12 +657,10 @@ contract GenArt721CoreV3_Explorations is
         uint256 _additionalPayeePrimarySalesPercentage,
         address payable _additionalPayeeSecondarySales,
         uint256 _additionalPayeeSecondarySalesPercentage
-    )
-        external
-        onlyValidProjectId(_projectId)
-        onlyArtist(_projectId)
-        onlyNonZeroAddress(_artistAddress)
-    {
+    ) external {
+        _onlyValidProjectId(_projectId);
+        _onlyArtist(_projectId);
+        _onlyNonZeroAddress(_artistAddress);
         ProjectFinance storage projectFinance = projectIdToFinancials[
             _projectId
         ];
@@ -808,15 +775,13 @@ contract GenArt721CoreV3_Explorations is
         uint256 _additionalPayeePrimarySalesPercentage,
         address payable _additionalPayeeSecondarySales,
         uint256 _additionalPayeeSecondarySalesPercentage
-    )
-        external
-        onlyValidProjectId(_projectId)
-        onlyAdminACLOrRenouncedArtist(
+    ) external {
+        _onlyValidProjectId(_projectId);
+        _onlyAdminACLOrRenouncedArtist(
             _projectId,
             this.adminAcceptArtistAddressesAndSplits.selector
-        )
-        onlyNonZeroAddress(_artistAddress)
-    {
+        );
+        _onlyNonZeroAddress(_artistAddress);
         // checks
         require(
             proposedArtistAddressesAndSplitsHash[_projectId] ==
@@ -862,15 +827,13 @@ contract GenArt721CoreV3_Explorations is
     function updateProjectArtistAddress(
         uint256 _projectId,
         address payable _artistAddress
-    )
-        external
-        onlyValidProjectId(_projectId)
-        onlyAdminACLOrRenouncedArtist(
+    ) external {
+        _onlyValidProjectId(_projectId);
+        _onlyAdminACLOrRenouncedArtist(
             _projectId,
             this.updateProjectArtistAddress.selector
-        )
-        onlyNonZeroAddress(_artistAddress)
-    {
+        );
+        _onlyNonZeroAddress(_artistAddress);
         projectIdToFinancials[_projectId].artistAddress = _artistAddress;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_ARTIST_ADDRESS);
     }
@@ -879,9 +842,8 @@ contract GenArt721CoreV3_Explorations is
      * @notice Toggles paused state of project `_projectId`.
      * @param _projectId Project ID to be toggled.
      */
-    function toggleProjectIsPaused(
-        uint256 _projectId
-    ) external onlyArtist(_projectId) {
+    function toggleProjectIsPaused(uint256 _projectId) external {
+        _onlyArtist(_projectId);
         projects[_projectId].paused = !projects[_projectId].paused;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_PAUSED);
     }
@@ -895,12 +857,10 @@ contract GenArt721CoreV3_Explorations is
     function addProject(
         string memory _projectName,
         address payable _artistAddress
-    )
-        external
-        onlyAdminACL(this.addProject.selector)
-        onlyNonEmptyString(_projectName)
-        onlyNonZeroAddress(_artistAddress)
-    {
+    ) external {
+        onlyAdminACL(this.addProject.selector);
+        _onlyNonEmptyString(_projectName);
+        _onlyNonZeroAddress(_artistAddress);
         require(!newProjectsForbidden, "New projects forbidden");
         uint256 projectId = _nextProjectId;
         projectIdToFinancials[projectId].artistAddress = _artistAddress;
@@ -916,10 +876,8 @@ contract GenArt721CoreV3_Explorations is
     /**
      * @notice Forever forbids new projects from being added to this contract.
      */
-    function forbidNewProjects()
-        external
-        onlyAdminACL(this.forbidNewProjects.selector)
-    {
+    function forbidNewProjects() external {
+        onlyAdminACL(this.forbidNewProjects.selector);
         require(!newProjectsForbidden, "Already forbidden");
         _forbidNewProjects();
     }
@@ -932,12 +890,10 @@ contract GenArt721CoreV3_Explorations is
     function updateProjectName(
         uint256 _projectId,
         string memory _projectName
-    )
-        external
-        onlyUnlocked(_projectId)
-        onlyArtistOrAdminACL(_projectId, this.updateProjectName.selector)
-        onlyNonEmptyString(_projectName)
-    {
+    ) external {
+        _onlyUnlocked(_projectId);
+        _onlyArtistOrAdminACL(_projectId, this.updateProjectName.selector);
+        _onlyNonEmptyString(_projectName);
         projects[_projectId].name = _projectName;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_NAME);
     }
@@ -951,12 +907,13 @@ contract GenArt721CoreV3_Explorations is
     function updateProjectArtistName(
         uint256 _projectId,
         string memory _projectArtistName
-    )
-        external
-        onlyUnlocked(_projectId)
-        onlyArtistOrAdminACL(_projectId, this.updateProjectArtistName.selector)
-        onlyNonEmptyString(_projectArtistName)
-    {
+    ) external {
+        _onlyUnlocked(_projectId);
+        _onlyArtistOrAdminACL(
+            _projectId,
+            this.updateProjectArtistName.selector
+        );
+        _onlyNonEmptyString(_projectArtistName);
         projects[_projectId].artist = _projectArtistName;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_ARTIST_NAME);
     }
@@ -975,7 +932,8 @@ contract GenArt721CoreV3_Explorations is
     function updateProjectSecondaryMarketRoyaltyPercentage(
         uint256 _projectId,
         uint256 _secondMarketRoyalty
-    ) external onlyArtist(_projectId) {
+    ) external {
+        _onlyArtist(_projectId);
         require(
             _secondMarketRoyalty <= ARTIST_MAX_SECONDARY_ROYALTY_PERCENTAGE,
             "Max of ARTIST_MAX_SECONDARY_ROYALTY_PERCENTAGE percent"
@@ -1023,7 +981,8 @@ contract GenArt721CoreV3_Explorations is
     function updateProjectWebsite(
         uint256 _projectId,
         string memory _projectWebsite
-    ) external onlyArtist(_projectId) {
+    ) external {
+        _onlyArtist(_projectId);
         projects[_projectId].website = _projectWebsite;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_WEBSITE);
     }
@@ -1036,12 +995,10 @@ contract GenArt721CoreV3_Explorations is
     function updateProjectLicense(
         uint256 _projectId,
         string memory _projectLicense
-    )
-        external
-        onlyUnlocked(_projectId)
-        onlyArtistOrAdminACL(_projectId, this.updateProjectLicense.selector)
-        onlyNonEmptyString(_projectLicense)
-    {
+    ) external {
+        _onlyUnlocked(_projectId);
+        _onlyArtistOrAdminACL(_projectId, this.updateProjectLicense.selector);
+        _onlyNonEmptyString(_projectLicense);
         projects[_projectId].license = _projectLicense;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_LICENSE);
     }
@@ -1058,7 +1015,8 @@ contract GenArt721CoreV3_Explorations is
     function updateProjectMaxInvocations(
         uint256 _projectId,
         uint24 _maxInvocations
-    ) external onlyArtist(_projectId) {
+    ) external {
+        _onlyArtist(_projectId);
         // CHECKS
         Project storage project = projects[_projectId];
         uint256 _invocations = project.invocations;
@@ -1088,12 +1046,10 @@ contract GenArt721CoreV3_Explorations is
     function addProjectScript(
         uint256 _projectId,
         string memory _script
-    )
-        external
-        onlyUnlocked(_projectId)
-        onlyArtistOrAdminACL(_projectId, this.addProjectScript.selector)
-        onlyNonEmptyString(_script)
-    {
+    ) external {
+        _onlyUnlocked(_projectId);
+        _onlyArtistOrAdminACL(_projectId, this.addProjectScript.selector);
+        _onlyNonEmptyString(_script);
         Project storage project = projects[_projectId];
         // store script in contract bytecode
         project.scriptBytecodeAddresses[project.scriptCount] = _script
@@ -1112,12 +1068,10 @@ contract GenArt721CoreV3_Explorations is
         uint256 _projectId,
         uint256 _scriptId,
         string memory _script
-    )
-        external
-        onlyUnlocked(_projectId)
-        onlyArtistOrAdminACL(_projectId, this.updateProjectScript.selector)
-        onlyNonEmptyString(_script)
-    {
+    ) external {
+        _onlyUnlocked(_projectId);
+        _onlyArtistOrAdminACL(_projectId, this.updateProjectScript.selector);
+        _onlyNonEmptyString(_script);
         Project storage project = projects[_projectId];
         require(_scriptId < project.scriptCount, "scriptId out of range");
         // purge old contract bytecode contract from the blockchain state
@@ -1132,13 +1086,12 @@ contract GenArt721CoreV3_Explorations is
      * @notice Removes last script from project `_projectId`.
      * @param _projectId Project to be updated.
      */
-    function removeProjectLastScript(
-        uint256 _projectId
-    )
-        external
-        onlyUnlocked(_projectId)
-        onlyArtistOrAdminACL(_projectId, this.removeProjectLastScript.selector)
-    {
+    function removeProjectLastScript(uint256 _projectId) external {
+        _onlyUnlocked(_projectId);
+        _onlyArtistOrAdminACL(
+            _projectId,
+            this.removeProjectLastScript.selector
+        );
         Project storage project = projects[_projectId];
         require(project.scriptCount > 0, "there are no scripts to remove");
         // purge old contract bytecode contract from the blockchain state
@@ -1162,11 +1115,12 @@ contract GenArt721CoreV3_Explorations is
     function updateProjectScriptType(
         uint256 _projectId,
         bytes32 _scriptTypeAndVersion
-    )
-        external
-        onlyUnlocked(_projectId)
-        onlyArtistOrAdminACL(_projectId, this.updateProjectScriptType.selector)
-    {
+    ) external {
+        _onlyUnlocked(_projectId);
+        _onlyArtistOrAdminACL(
+            _projectId,
+            this.updateProjectScriptType.selector
+        );
         Project storage project = projects[_projectId];
         // require exactly one @ symbol in _scriptTypeAndVersion
         require(
@@ -1190,12 +1144,13 @@ contract GenArt721CoreV3_Explorations is
     function updateProjectAspectRatio(
         uint256 _projectId,
         string memory _aspectRatio
-    )
-        external
-        onlyUnlocked(_projectId)
-        onlyArtistOrAdminACL(_projectId, this.updateProjectAspectRatio.selector)
-        onlyNonEmptyString(_aspectRatio)
-    {
+    ) external {
+        _onlyUnlocked(_projectId);
+        _onlyArtistOrAdminACL(
+            _projectId,
+            this.updateProjectAspectRatio.selector
+        );
+        _onlyNonEmptyString(_aspectRatio);
         // Perform more detailed input validation for aspect ratio.
         bytes memory aspectRatioBytes = bytes(_aspectRatio);
         uint256 bytesLength = aspectRatioBytes.length;
@@ -1238,7 +1193,9 @@ contract GenArt721CoreV3_Explorations is
     function updateProjectBaseURI(
         uint256 _projectId,
         string memory _newBaseURI
-    ) external onlyArtist(_projectId) onlyNonEmptyString(_newBaseURI) {
+    ) external {
+        _onlyArtist(_projectId);
+        _onlyNonEmptyString(_newBaseURI);
         projects[_projectId].projectBaseURI = _newBaseURI;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_BASE_URI);
     }
@@ -1249,13 +1206,9 @@ contract GenArt721CoreV3_Explorations is
      * projects. Token URIs are determined by their project's `projectBaseURI`.
      * @param _defaultBaseURI New default base URI.
      */
-    function updateDefaultBaseURI(
-        string memory _defaultBaseURI
-    )
-        external
-        onlyAdminACL(this.updateDefaultBaseURI.selector)
-        onlyNonEmptyString(_defaultBaseURI)
-    {
+    function updateDefaultBaseURI(string memory _defaultBaseURI) external {
+        onlyAdminACL(this.updateDefaultBaseURI.selector);
+        _onlyNonEmptyString(_defaultBaseURI);
         _updateDefaultBaseURI(_defaultBaseURI);
     }
 
@@ -1658,9 +1611,9 @@ contract GenArt721CoreV3_Explorations is
     )
         external
         view
-        onlyValidTokenId(_tokenId)
         returns (address payable[] memory recipients, uint256[] memory bps)
     {
+        _onlyValidTokenId(_tokenId);
         // initialize arrays with maximum potential length
         recipients = new address payable[](3);
         bps = new uint256[](3);
@@ -1855,7 +1808,8 @@ contract GenArt721CoreV3_Explorations is
      */
     function tokenURI(
         uint256 _tokenId
-    ) public view override onlyValidTokenId(_tokenId) returns (string memory) {
+    ) public view override returns (string memory) {
+        _onlyValidTokenId(_tokenId);
         string memory _projectBaseURI = projects[tokenIdToProjectId(_tokenId)]
             .projectBaseURI;
         return string.concat(_projectBaseURI, _tokenId.toString());
@@ -1975,9 +1929,8 @@ contract GenArt721CoreV3_Explorations is
      * @return bool true if project is unlocked, false otherwise.
      * @dev This also enforces that the `_projectId` passed in is valid.
      */
-    function _projectUnlocked(
-        uint256 _projectId
-    ) internal view onlyValidProjectId(_projectId) returns (bool) {
+    function _projectUnlocked(uint256 _projectId) internal view returns (bool) {
+        _onlyValidProjectId(_projectId);
         uint256 projectCompletedTimestamp = projects[_projectId]
             .completedTimestamp;
         bool projectOpen = projectCompletedTimestamp == 0;


### PR DESCRIPTION
## Description of the change

Remove modifiers from all active contracts.

This fixes #483 

Note that gas impacts are very minimal (maybe ~30 gas total impact), and gas tests will be updated after #498 is merged into main.
