### PR TITLE
Reduce minter gas test nuisance failures

### DIFF
--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV4.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV4.test.ts
@@ -19,6 +19,7 @@ import {
   deployAndGet,
   deployCoreWithMinterFilter,
   safeAddProject,
+  requireBigNumberIsClose,
 } from "../../../util/common";
 import { ONE_MINUTE, ONE_HOUR, ONE_DAY } from "../../../util/constants";
 import { MinterDAExp_Common } from "./MinterDAExp.common";
@@ -380,20 +381,20 @@ for (const coreContractName of coreContractsToTest) {
           });
 
         const receipt = await ethers.provider.getTransactionReceipt(tx.hash);
-        const txCost = receipt.effectiveGasPrice
-          .mul(receipt.gasUsed)
-          .toString();
+        const txCost = receipt.effectiveGasPrice.mul(receipt.gasUsed);
         console.log(
           "Gas cost for a successful Exponential DA mint: ",
-          ethers.utils.formatUnits(txCost, "ether").toString(),
+          ethers.utils.formatUnits(txCost.toString(), "ether").toString(),
           "ETH"
         );
         // assuming a cost of 100 GWEI
 
         // skip gas tests for engine, flagship is sufficient to identify gas cost changes
         if (!config.isEngine) {
-          expect(txCost.toString()).to.equal(
-            ethers.utils.parseEther("0.0138604")
+          requireBigNumberIsClose(
+            txCost,
+            ethers.utils.parseEther("0.0138604"),
+            1
           );
         }
       });

--- a/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV4.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExp/MinterDAExpV4.test.ts
@@ -390,11 +390,7 @@ for (const coreContractName of coreContractsToTest) {
         // assuming a cost of 100 GWEI
         // skip gas tests for engine, flagship is sufficient to identify gas cost changes
         if (!config.isEngine) {
-          requireBigNumberIsClose(
-            txCost,
-            ethers.utils.parseEther("0.0138604"),
-            1
-          );
+          requireBigNumberIsClose(txCost, ethers.utils.parseEther("0.0138604"));
         }
       });
     });

--- a/test/minter-suite-minters/DA/MinterDAExpSettlement/MinterDAExpSettlementV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExpSettlement/MinterDAExpSettlementV2.test.ts
@@ -1038,11 +1038,7 @@ for (const coreContractName of coreContractsToTest) {
         // assuming a cost of 100 GWEI
         // skip gas tests for engine, flagship is sufficient to identify gas cost changes
         if (!config.isEngine) {
-          requireBigNumberIsClose(
-            txCost,
-            ethers.utils.parseEther("0.0154846"),
-            1
-          );
+          requireBigNumberIsClose(txCost, ethers.utils.parseEther("0.0154846"));
         }
       });
     });

--- a/test/minter-suite-minters/DA/MinterDAExpSettlement/MinterDAExpSettlementV2.test.ts
+++ b/test/minter-suite-minters/DA/MinterDAExpSettlement/MinterDAExpSettlementV2.test.ts
@@ -23,6 +23,7 @@ import {
   deployAndGet,
   deployCoreWithMinterFilter,
   safeAddProject,
+  requireBigNumberIsClose,
 } from "../../../util/common";
 import { ONE_MINUTE, ONE_HOUR, ONE_DAY } from "../../../util/constants";
 import {
@@ -1028,19 +1029,19 @@ for (const coreContractName of coreContractsToTest) {
           });
 
         const receipt = await ethers.provider.getTransactionReceipt(tx.hash);
-        const txCost = receipt.effectiveGasPrice
-          .mul(receipt.gasUsed)
-          .toString();
+        const txCost = receipt.effectiveGasPrice.mul(receipt.gasUsed);
         console.log(
           "Gas cost for a successful Exponential DA mint: ",
-          ethers.utils.formatUnits(txCost, "ether").toString(),
+          ethers.utils.formatUnits(txCost.toString(), "ether").toString(),
           "ETH"
         );
         // assuming a cost of 100 GWEI
         // skip gas tests for engine, flagship is sufficient to identify gas cost changes
         if (!config.isEngine) {
-          expect(txCost.toString()).to.equal(
-            ethers.utils.parseEther("0.0154846")
+          requireBigNumberIsClose(
+            txCost,
+            ethers.utils.parseEther("0.0154846"),
+            1
           );
         }
       });

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV4.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV4.test.ts
@@ -22,6 +22,7 @@ import {
   deployAndGet,
   deployCoreWithMinterFilter,
   safeAddProject,
+  requireBigNumberIsClose,
 } from "../../../util/common";
 import { ONE_MINUTE, ONE_HOUR, ONE_DAY } from "../../../util/constants";
 import { MinterDALin_Common } from "./MinterDALin.common";
@@ -381,20 +382,19 @@ for (const coreContractName of coreContractsToTest) {
           });
 
         const receipt = await ethers.provider.getTransactionReceipt(tx.hash);
-        const txCost = receipt.effectiveGasPrice
-          .mul(receipt.gasUsed)
-          .toString();
-
+        const txCost = receipt.effectiveGasPrice.mul(receipt.gasUsed);
         console.log(
           "Gas cost for a successful Linear DA mint: ",
-          ethers.utils.formatUnits(txCost, "ether").toString(),
+          ethers.utils.formatUnits(txCost.toString(), "ether").toString(),
           "ETH"
         );
         // assuming a cost of 100 GWEI
         // skip gas tests for engine, flagship is sufficient to identify gas cost changes
         if (!config.isEngine) {
-          expect(txCost.toString()).to.equal(
-            ethers.utils.parseEther("0.0138687")
+          requireBigNumberIsClose(
+            txCost,
+            ethers.utils.parseEther("0.0138687"),
+            1
           );
         }
       });

--- a/test/minter-suite-minters/DA/MinterDALin/MinterDALinV4.test.ts
+++ b/test/minter-suite-minters/DA/MinterDALin/MinterDALinV4.test.ts
@@ -391,11 +391,7 @@ for (const coreContractName of coreContractsToTest) {
         // assuming a cost of 100 GWEI
         // skip gas tests for engine, flagship is sufficient to identify gas cost changes
         if (!config.isEngine) {
-          requireBigNumberIsClose(
-            txCost,
-            ethers.utils.parseEther("0.0138687"),
-            1
-          );
+          requireBigNumberIsClose(txCost, ethers.utils.parseEther("0.0138687"));
         }
       });
     });

--- a/test/minter-suite-minters/MinterHolder/MinterHolderV4.test.ts
+++ b/test/minter-suite-minters/MinterHolder/MinterHolderV4.test.ts
@@ -9,7 +9,7 @@ import {
   assignDefaultConstants,
   deployAndGet,
   deployCoreWithMinterFilter,
-  compareBN,
+  requireBigNumberIsClose,
   safeAddProject,
 } from "../../util/common";
 
@@ -819,12 +819,13 @@ for (const coreContractName of coreContractsToTest) {
           ethers.utils.formatUnits(txCost.toString(), "ether").toString(),
           "ETH"
         );
-        if (config.isEngine) {
-          expect(compareBN(txCost, ethers.utils.parseEther("0.0128176"), 1)).to
-            .be.true;
-        } else {
-          expect(compareBN(txCost, ethers.utils.parseEther("0.0115824"), 1)).to
-            .be.true;
+        // skip gas tests for engine, flagship is sufficient to identify gas cost changes
+        if (!config.isEngine) {
+          requireBigNumberIsClose(
+            txCost,
+            ethers.utils.parseEther("0.0115824"),
+            1
+          );
         }
       });
     });

--- a/test/minter-suite-minters/MinterHolder/MinterHolderV4.test.ts
+++ b/test/minter-suite-minters/MinterHolder/MinterHolderV4.test.ts
@@ -821,11 +821,7 @@ for (const coreContractName of coreContractsToTest) {
         );
         // skip gas tests for engine, flagship is sufficient to identify gas cost changes
         if (!config.isEngine) {
-          requireBigNumberIsClose(
-            txCost,
-            ethers.utils.parseEther("0.0115824"),
-            1
-          );
+          requireBigNumberIsClose(txCost, ethers.utils.parseEther("0.0115824"));
         }
       });
     });

--- a/test/minter-suite-minters/MinterMerkle/MinterMerkleV5.test.ts
+++ b/test/minter-suite-minters/MinterMerkle/MinterMerkleV5.test.ts
@@ -954,11 +954,7 @@ for (const coreContractName of coreContractsToTest) {
         // assuming a cost of 100 GWEI
         // skip gas tests for engine, flagship is sufficient to identify gas cost changes
         if (!config.isEngine) {
-          requireBigNumberIsClose(
-            txCost,
-            ethers.utils.parseEther("0.0155614"),
-            1
-          );
+          requireBigNumberIsClose(txCost, ethers.utils.parseEther("0.0155614"));
         }
       });
 
@@ -1004,11 +1000,7 @@ for (const coreContractName of coreContractsToTest) {
         // assuming a cost of 100 GWEI
         // skip gas tests for engine, flagship is sufficient to identify gas cost changes
         if (!config.isEngine) {
-          requireBigNumberIsClose(
-            txCost,
-            ethers.utils.parseEther("0.0165514"),
-            1
-          );
+          requireBigNumberIsClose(txCost, ethers.utils.parseEther("0.0165514"));
         }
       });
     });

--- a/test/minter-suite-minters/MinterMerkle/MinterMerkleV5.test.ts
+++ b/test/minter-suite-minters/MinterMerkle/MinterMerkleV5.test.ts
@@ -1002,12 +1002,13 @@ for (const coreContractName of coreContractsToTest) {
         );
         // the following is not much more than the gas cost with a very small allowlist
         // assuming a cost of 100 GWEI
-        if (config.isEngine) {
-          expect(compareBN(txCost, ethers.utils.parseEther("0.0175339"), 1)).to
-            .be.true;
-        } else {
-          expect(compareBN(txCost, ethers.utils.parseEther("0.0165514"), 1)).to
-            .be.true;
+        // skip gas tests for engine, flagship is sufficient to identify gas cost changes
+        if (!config.isEngine) {
+          requireBigNumberIsClose(
+            txCost,
+            ethers.utils.parseEther("0.0165514"),
+            1
+          );
         }
       });
     });

--- a/test/minter-suite-minters/MinterMerkle/MinterMerkleV5.test.ts
+++ b/test/minter-suite-minters/MinterMerkle/MinterMerkleV5.test.ts
@@ -14,7 +14,7 @@ import {
   assignDefaultConstants,
   deployAndGet,
   deployCoreWithMinterFilter,
-  compareBN,
+  requireBigNumberIsClose,
   safeAddProject,
 } from "../../util/common";
 
@@ -952,12 +952,13 @@ for (const coreContractName of coreContractsToTest) {
           "ETH"
         );
         // assuming a cost of 100 GWEI
-        if (config.isEngine) {
-          expect(compareBN(txCost, ethers.utils.parseEther("0.0167932"), 1)).to
-            .be.true;
-        } else {
-          expect(compareBN(txCost, ethers.utils.parseEther("0.0155614"), 1)).to
-            .be.true;
+        // skip gas tests for engine, flagship is sufficient to identify gas cost changes
+        if (!config.isEngine) {
+          requireBigNumberIsClose(
+            txCost,
+            ethers.utils.parseEther("0.0155614"),
+            1
+          );
         }
       });
 

--- a/test/minter-suite-minters/PolyptychMinter/PolyptychMinterV0.test.ts
+++ b/test/minter-suite-minters/PolyptychMinter/PolyptychMinterV0.test.ts
@@ -9,7 +9,7 @@ import {
   assignDefaultConstants,
   deployAndGet,
   deployCoreWithMinterFilter,
-  compareBN,
+  requireBigNumberIsClose,
   safeAddProject,
 } from "../../util/common";
 
@@ -947,8 +947,11 @@ for (const coreContractName of coreContractsToTest) {
           ethers.utils.formatUnits(txCost.toString(), "ether").toString(),
           "ETH"
         );
-        expect(compareBN(txCost, ethers.utils.parseEther("0.0187214"), 1)).to.be
-          .true;
+        requireBigNumberIsClose(
+          txCost,
+          ethers.utils.parseEther("0.0187214"),
+          1
+        );
       });
     });
   });

--- a/test/minter-suite-minters/PolyptychMinter/PolyptychMinterV0.test.ts
+++ b/test/minter-suite-minters/PolyptychMinter/PolyptychMinterV0.test.ts
@@ -947,11 +947,7 @@ for (const coreContractName of coreContractsToTest) {
           ethers.utils.formatUnits(txCost.toString(), "ether").toString(),
           "ETH"
         );
-        requireBigNumberIsClose(
-          txCost,
-          ethers.utils.parseEther("0.0187214"),
-          1
-        );
+        requireBigNumberIsClose(txCost, ethers.utils.parseEther("0.0187214"));
       });
     });
   });

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV4.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV4.test.ts
@@ -18,6 +18,7 @@ import {
   deployAndGet,
   deployCoreWithMinterFilter,
   safeAddProject,
+  requireBigNumberIsClose,
 } from "../../../util/common";
 
 import { MinterSetPrice_ETH_Common } from "./MinterSetPrice.common";
@@ -370,19 +371,19 @@ for (const coreContractName of coreContractsToTest) {
           });
 
         const receipt = await ethers.provider.getTransactionReceipt(tx.hash);
-        const txCost = receipt.effectiveGasPrice
-          .mul(receipt.gasUsed)
-          .toString();
+        const txCost = receipt.effectiveGasPrice.mul(receipt.gasUsed);
         console.log(
           "Gas cost for a successful Ether mint: ",
-          ethers.utils.formatUnits(txCost, "ether").toString(),
+          ethers.utils.formatUnits(txCost.toString(), "ether").toString(),
           "ETH"
         );
         // assuming a cost of 100 GWEI
         // skip gas tests for engine, flagship is sufficient to identify gas cost changes
         if (!config.isEngine) {
-          expect(txCost.toString()).to.equal(
-            ethers.utils.parseEther("0.0129093")
+          requireBigNumberIsClose(
+            txCost,
+            ethers.utils.parseEther("0.0129093"),
+            1
           );
         }
       });

--- a/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV4.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPrice/MinterSetPriceV4.test.ts
@@ -380,11 +380,7 @@ for (const coreContractName of coreContractsToTest) {
         // assuming a cost of 100 GWEI
         // skip gas tests for engine, flagship is sufficient to identify gas cost changes
         if (!config.isEngine) {
-          requireBigNumberIsClose(
-            txCost,
-            ethers.utils.parseEther("0.0129093"),
-            1
-          );
+          requireBigNumberIsClose(txCost, ethers.utils.parseEther("0.0129093"));
         }
       });
     });

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V4.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V4.test.ts
@@ -648,11 +648,7 @@ for (const coreContractName of coreContractsToTest) {
         // assuming a cost of 100 GWEI
         // skip gas tests for engine, flagship is sufficient to identify gas cost changes
         if (!config.isEngine) {
-          requireBigNumberIsClose(
-            txCost,
-            ethers.utils.parseEther("0.0129309"),
-            1
-          );
+          requireBigNumberIsClose(txCost, ethers.utils.parseEther("0.0129309"));
         }
       });
     });

--- a/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V4.test.ts
+++ b/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/MinterSetPriceERC20V4.test.ts
@@ -9,6 +9,7 @@ import {
   deployAndGet,
   deployCoreWithMinterFilter,
   safeAddProject,
+  requireBigNumberIsClose,
 } from "../../../util/common";
 
 import { MinterSetPriceERC20_Common } from "./MinterSetPriceERC20.common";
@@ -638,20 +639,19 @@ for (const coreContractName of coreContractsToTest) {
           });
 
         const receipt = await ethers.provider.getTransactionReceipt(tx.hash);
-        const txCost = receipt.effectiveGasPrice
-          .mul(receipt.gasUsed)
-          .toString();
-
+        const txCost = receipt.effectiveGasPrice.mul(receipt.gasUsed);
         console.log(
           "Gas cost for a successful ERC20 mint: ",
-          ethers.utils.formatUnits(txCost, "ether").toString(),
+          ethers.utils.formatUnits(txCost.toString(), "ether").toString(),
           "ETH"
         );
         // assuming a cost of 100 GWEI
         // skip gas tests for engine, flagship is sufficient to identify gas cost changes
         if (!config.isEngine) {
-          expect(txCost.toString()).to.equal(
-            ethers.utils.parseEther("0.0129309")
+          requireBigNumberIsClose(
+            txCost,
+            ethers.utils.parseEther("0.0129309"),
+            1
           );
         }
       });

--- a/test/util/common.ts
+++ b/test/util/common.ts
@@ -290,14 +290,21 @@ export async function advanceEVMByTime(_timeSeconds: number) {
 }
 
 // utility funciton to compare Big Numbers, expecting them to be within x%, +/-
-export function compareBN(
+export function requireBigNumberIsClose(
   actual: BigNumber,
   expected: BigNumber,
   tolerancePercent: number = 1
-): boolean {
+) {
   const diff = actual.sub(expected);
   const percentDiff = diff.mul(BigNumber.from("100")).div(expected);
-  return percentDiff.abs().lte(BigNumber.from(tolerancePercent.toString()));
+  const passes = percentDiff
+    .abs()
+    .lte(BigNumber.from(tolerancePercent.toString()));
+  if (!passes) {
+    throw new Error(
+      `BN's out of tolerance ${tolerancePercent} percent. Expected ${expected.toString()} but got ${actual.toString()}`
+    );
+  }
 }
 
 // utility function to return if core is V3


### PR DESCRIPTION
## Only merge after #505

## Description of the change

Update minter gas tests to reduce nuisance failures.

Gas tests for minters are updated to:

- only test gas cost of minting with one core contract
  - this is because the gas tests are only meant to alert for changes, and testing with a single core is sufficient to do this
- only fail if expected gas is >1% different than target
  - we shouldn't receive nuisance warnings about negligible changes


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203960042742717