### PR TITLE
Refactor hash generation to base class

### DIFF
--- a/contracts/mock/RandomizerV2_NoAssignMock.sol
+++ b/contracts/mock/RandomizerV2_NoAssignMock.sol
@@ -3,7 +3,7 @@
 
 pragma solidity 0.8.17;
 
-import "../BasicRandomizerV2.sol";
+import "../randomizer/BasicRandomizerV2.sol";
 
 /// @title RandomizerV2_NoAssignMock
 /// @notice WARNING - This is a mock contract. Do not use it in production.
@@ -20,16 +20,7 @@ contract RandomizerV2_NoAssignMock is BasicRandomizerV2 {
     // on the core contract. Used for test purposes only.
     // @dev WARNING - THIS IS NOT SECURE AND SHOULD NOT BE USED IN PRODUCTION.
     function actuallyAssignTokenHash(uint256 _tokenId) external {
-        uint256 time = block.timestamp;
-        bytes32 hash = keccak256(
-            abi.encodePacked(
-                _tokenId,
-                block.number,
-                blockhash(block.number - 1),
-                time,
-                (time % 200) + 1
-            )
-        );
+        bytes32 hash = _getPseudorandom(_tokenId);
         genArt721Core.setTokenHash_8PT(_tokenId, hash);
     }
 

--- a/contracts/randomizer/BasicRandomizer.sol
+++ b/contracts/randomizer/BasicRandomizer.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Creatd By: Art Blocks Inc.
 
-import "./interfaces/0.8.x/IRandomizer.sol";
+import "../interfaces/0.8.x/IRandomizer.sol";
 
 pragma solidity 0.8.9;
 

--- a/contracts/randomizer/BasicRandomizerBase_v0_0_0.sol
+++ b/contracts/randomizer/BasicRandomizerBase_v0_0_0.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Creatd By: Art Blocks Inc.
+
+pragma solidity 0.8.17;
+
+abstract contract BasicRandomizerBase {
+    // base class that returns
+    function _getPseudorandom(
+        uint256 _tokenId
+    ) internal virtual returns (bytes32) {
+        uint256 time = block.timestamp;
+        return
+            keccak256(
+                abi.encodePacked(
+                    _tokenId,
+                    block.number,
+                    blockhash(block.number - 1),
+                    time,
+                    (time % 200) + 1
+                )
+            );
+    }
+}

--- a/contracts/randomizer/BasicRandomizerV2.sol
+++ b/contracts/randomizer/BasicRandomizerV2.sol
@@ -3,12 +3,13 @@
 
 pragma solidity 0.8.17;
 
-import "./interfaces/0.8.x/IRandomizerV2.sol";
-import "./interfaces/0.8.x/IGenArt721CoreContractV3_Base.sol";
+import "../interfaces/0.8.x/IRandomizerV2.sol";
+import "../interfaces/0.8.x/IGenArt721CoreContractV3_Base.sol";
+import "./BasicRandomizerBase_v0_0_0.sol";
 
 import "@openzeppelin-4.7/contracts/access/Ownable.sol";
 
-contract BasicRandomizerV2 is IRandomizerV2, Ownable {
+contract BasicRandomizerV2 is IRandomizerV2, BasicRandomizerBase, Ownable {
     // The core contract that may interact with this randomizer contract.
     IGenArt721CoreContractV3_Base public genArt721Core;
 
@@ -21,16 +22,7 @@ contract BasicRandomizerV2 is IRandomizerV2, Ownable {
     // will set a bytes32 hash for tokenId `_tokenId` on the core contract.
     function assignTokenHash(uint256 _tokenId) external virtual {
         require(msg.sender == address(genArt721Core), "Only core may call");
-        uint256 time = block.timestamp;
-        bytes32 hash = keccak256(
-            abi.encodePacked(
-                _tokenId,
-                block.number,
-                blockhash(block.number - 1),
-                time,
-                (time % 200) + 1
-            )
-        );
+        bytes32 hash = _getPseudorandom(_tokenId);
         genArt721Core.setTokenHash_8PT(_tokenId, hash);
     }
 }

--- a/test/randomizer/basicRandomizerV2.test.ts
+++ b/test/randomizer/basicRandomizerV2.test.ts
@@ -19,17 +19,13 @@ import {
   deployCoreWithMinterFilter,
   mintProjectUntilRemaining,
   advanceEVMByTime,
-} from "../../util/common";
-import { FOUR_WEEKS } from "../../util/constants";
-
-import { Logger } from "@ethersproject/logger";
-// hide nuisance logs about event overloading
-Logger.setLogLevel(Logger.levels.ERROR);
+} from "../util/common";
+import { FOUR_WEEKS } from "../util/constants";
 
 /**
- * General Integration tests for Polyptych Randomizer V0 with V3 core.
+ * General Integration tests for Basic Randomizer V2 with V3 core.
  */
-describe("PolyptychRandomizerV0 w/V3 core", async function () {
+describe("BasicRandomizerV2 w/V3 core", async function () {
   async function _beforeEach() {
     let config: T_Config = {
       accounts: await getAccounts(),
@@ -44,42 +40,13 @@ describe("PolyptychRandomizerV0 w/V3 core", async function () {
       adminACL: config.adminACL,
     } = await deployCoreWithMinterFilter(
       config,
-      "GenArt721CoreV3_Engine",
-      "MinterFilterV1",
-      false,
-      undefined,
-      "BasicPolyptychRandomizerV0"
+      "GenArt721CoreV3",
+      "MinterFilterV1"
     ));
-
-    config.delegationRegistry = await deployAndGet(
-      config,
-      "DelegationRegistry",
-      []
-    );
 
     config.minter = await deployAndGet(config, "MinterSetPriceV2", [
       config.genArt721Core.address,
       config.minterFilter.address,
-    ]);
-
-    ({
-      genArt721Core: config.genArt721CorePolyptych,
-      minterFilter: config.minterFilterPolyptych,
-      randomizer: config.randomizerPolyptych,
-      adminACL: config.adminACLPolyptych,
-    } = await deployCoreWithMinterFilter(
-      config,
-      "GenArt721CoreV3_Engine",
-      "MinterFilterV1",
-      false,
-      undefined,
-      "BasicPolyptychRandomizerV0"
-    ));
-
-    config.minterPolyptych = await deployAndGet(config, "MinterPolyptychV0", [
-      config.genArt721CorePolyptych.address,
-      config.minterFilterPolyptych.address,
-      config.delegationRegistry.address,
     ]);
 
     // add project
@@ -90,15 +57,6 @@ describe("PolyptychRandomizerV0 w/V3 core", async function () {
       .connect(config.accounts.deployer)
       .toggleProjectIsActive(config.projectZero);
     await config.genArt721Core
-      .connect(config.accounts.artist)
-      .updateProjectMaxInvocations(config.projectZero, config.maxInvocations);
-    await config.genArt721CorePolyptych
-      .connect(config.accounts.deployer)
-      .addProject("name", config.accounts.artist.address);
-    await config.genArt721CorePolyptych
-      .connect(config.accounts.deployer)
-      .toggleProjectIsActive(config.projectZero);
-    await config.genArt721CorePolyptych
       .connect(config.accounts.artist)
       .updateProjectMaxInvocations(config.projectZero, config.maxInvocations);
 
@@ -112,57 +70,14 @@ describe("PolyptychRandomizerV0 w/V3 core", async function () {
     await config.minter
       .connect(config.accounts.artist)
       .updatePricePerTokenInWei(config.projectZero, 0);
-    await config.minterFilterPolyptych
-      .connect(config.accounts.deployer)
-      .addApprovedMinter(config.minterPolyptych.address);
-    await config.minterFilterPolyptych
-      .connect(config.accounts.deployer)
-      .setMinterForProject(config.projectZero, config.minterPolyptych.address);
-    await config.minterPolyptych
-      .connect(config.accounts.artist)
-      .updatePricePerTokenInWei(config.projectZero, 0);
     return config;
   }
-
-  describe("Polyptych project hash seed settings", function () {
-    it("only the artist can set a project as polyptych", async function () {
-      const config = await loadFixture(_beforeEach);
-      await config.randomizerPolyptych
-        .connect(config.accounts.artist)
-        .toggleProjectIsPolyptych(0);
-      await expectRevert(
-        config.randomizerPolyptych
-          .connect(config.accounts.deployer)
-          .toggleProjectIsPolyptych(0),
-        "Only Artist"
-      );
-    });
-    it("requires the hash seed setter contract to be configured", async function () {
-      const config = await loadFixture(_beforeEach);
-      await expectRevert(
-        config.randomizerPolyptych
-          .connect(config.accounts.deployer)
-          .setPolyptychHashSeed(0, "0x000000000000000000000000"),
-        "Only hashSeedSetterContract"
-      );
-      await config.randomizerPolyptych.setHashSeedSetterContract(
-        config.accounts.deployer.address
-      );
-      await config.randomizerPolyptych
-        .connect(config.accounts.deployer)
-        .setPolyptychHashSeed(0, "0x000000000000000000000000");
-    });
-  });
 
   describe("assignCoreAndRenounce", function () {
     it("does not allow non-owner to call", async function () {
       const config = await loadFixture(_beforeEach);
       // deploy new randomizer
-      const randomizer = await deployAndGet(
-        config,
-        "BasicPolyptychRandomizerV0",
-        []
-      );
+      const randomizer = await deployAndGet(config, "BasicRandomizerV2", []);
       // expect failure when non-owner calls renounce and assign core
       await expectRevert(
         randomizer
@@ -175,11 +90,7 @@ describe("PolyptychRandomizerV0 w/V3 core", async function () {
     it("allows owner to call", async function () {
       const config = await loadFixture(_beforeEach);
       // deploy new randomizer
-      const randomizer = await deployAndGet(
-        config,
-        "BasicPolyptychRandomizerV0",
-        []
-      );
+      const randomizer = await deployAndGet(config, "BasicRandomizerV2", []);
       // expect success when owner calls renounce and assign core
       await randomizer
         .connect(config.accounts.deployer)
@@ -189,11 +100,7 @@ describe("PolyptychRandomizerV0 w/V3 core", async function () {
     it("does not allow owner to call twice", async function () {
       const config = await loadFixture(_beforeEach);
       // deploy new randomizer
-      const randomizer = await deployAndGet(
-        config,
-        "BasicPolyptychRandomizerV0",
-        []
-      );
+      const randomizer = await deployAndGet(config, "BasicRandomizerV2", []);
       // expect failure when owner calls renounce and assign core twice
       await randomizer
         .connect(config.accounts.deployer)
@@ -259,54 +166,6 @@ describe("PolyptychRandomizerV0 w/V3 core", async function () {
       console.info(`projectZeroTokenZeroHash: ${projectZeroTokenZeroHash}`);
       console.info(`projectZeroTokenOneHash: ${projectZeroTokenOneHash}`);
     });
-
-    it("copies the token hash from a previous token as expected", async function () {
-      const config = await loadFixture(_beforeEach);
-      await config.minterPolyptych
-        .connect(config.accounts.deployer)
-        .registerNFTAddress(config.genArt721Core.address);
-      await config.minterPolyptych
-        .connect(config.accounts.artist)
-        .allowHoldersOfProjects(
-          config.projectZero,
-          [config.genArt721Core.address],
-          [config.projectZero]
-        );
-      await config.randomizerPolyptych
-        .connect(config.accounts.deployer)
-        .setHashSeedSetterContract(config.minterPolyptych.address);
-      await config.randomizerPolyptych
-        .connect(config.accounts.artist)
-        .toggleProjectIsPolyptych(0);
-
-      await expectRevert(
-        config.minterPolyptych
-          .connect(config.accounts.artist)
-          ["purchase(uint256,address,uint256)"](
-            config.projectZero,
-            config.genArt721Core.address,
-            0,
-            {
-              value: 0,
-            }
-          ),
-        "Cannot have an empty hash seed to copy."
-      );
-
-      await config.minter.connect(config.accounts.artist).purchase(0);
-
-      // mint a token
-      await config.minterPolyptych
-        .connect(config.accounts.artist)
-        ["purchase(uint256,address,uint256)"](
-          config.projectZero,
-          config.genArt721Core.address,
-          0,
-          {
-            value: 0,
-          }
-        );
-    });
   });
 
   describe("owner", function () {
@@ -320,11 +179,7 @@ describe("PolyptychRandomizerV0 w/V3 core", async function () {
     it("returns deployer prior to being configured and renounced", async function () {
       const config = await loadFixture(_beforeEach);
       // deploy new randomizer
-      const randomizer = await deployAndGet(
-        config,
-        "BasicPolyptychRandomizerV0",
-        []
-      );
+      const randomizer = await deployAndGet(config, "BasicRandomizerV2", []);
       // expect owner to be deployer prior to being configured and renounced
       expect(await randomizer.owner()).to.be.equal(
         config.accounts.deployer.address

--- a/test/randomizer/polyptychRandomizerV0.test.ts
+++ b/test/randomizer/polyptychRandomizerV0.test.ts
@@ -19,13 +19,17 @@ import {
   deployCoreWithMinterFilter,
   mintProjectUntilRemaining,
   advanceEVMByTime,
-} from "../../util/common";
-import { FOUR_WEEKS } from "../../util/constants";
+} from "../util/common";
+import { FOUR_WEEKS } from "../util/constants";
+
+import { Logger } from "@ethersproject/logger";
+// hide nuisance logs about event overloading
+Logger.setLogLevel(Logger.levels.ERROR);
 
 /**
- * General Integration tests for Basic Randomizer V2 with V3 core.
+ * General Integration tests for Polyptych Randomizer V0 with V3 core.
  */
-describe("BasicRandomizerV2 w/V3 core", async function () {
+describe("PolyptychRandomizerV0 w/V3 core", async function () {
   async function _beforeEach() {
     let config: T_Config = {
       accounts: await getAccounts(),
@@ -40,13 +44,42 @@ describe("BasicRandomizerV2 w/V3 core", async function () {
       adminACL: config.adminACL,
     } = await deployCoreWithMinterFilter(
       config,
-      "GenArt721CoreV3",
-      "MinterFilterV1"
+      "GenArt721CoreV3_Engine",
+      "MinterFilterV1",
+      false,
+      undefined,
+      "BasicPolyptychRandomizerV0"
     ));
+
+    config.delegationRegistry = await deployAndGet(
+      config,
+      "DelegationRegistry",
+      []
+    );
 
     config.minter = await deployAndGet(config, "MinterSetPriceV2", [
       config.genArt721Core.address,
       config.minterFilter.address,
+    ]);
+
+    ({
+      genArt721Core: config.genArt721CorePolyptych,
+      minterFilter: config.minterFilterPolyptych,
+      randomizer: config.randomizerPolyptych,
+      adminACL: config.adminACLPolyptych,
+    } = await deployCoreWithMinterFilter(
+      config,
+      "GenArt721CoreV3_Engine",
+      "MinterFilterV1",
+      false,
+      undefined,
+      "BasicPolyptychRandomizerV0"
+    ));
+
+    config.minterPolyptych = await deployAndGet(config, "MinterPolyptychV0", [
+      config.genArt721CorePolyptych.address,
+      config.minterFilterPolyptych.address,
+      config.delegationRegistry.address,
     ]);
 
     // add project
@@ -57,6 +90,15 @@ describe("BasicRandomizerV2 w/V3 core", async function () {
       .connect(config.accounts.deployer)
       .toggleProjectIsActive(config.projectZero);
     await config.genArt721Core
+      .connect(config.accounts.artist)
+      .updateProjectMaxInvocations(config.projectZero, config.maxInvocations);
+    await config.genArt721CorePolyptych
+      .connect(config.accounts.deployer)
+      .addProject("name", config.accounts.artist.address);
+    await config.genArt721CorePolyptych
+      .connect(config.accounts.deployer)
+      .toggleProjectIsActive(config.projectZero);
+    await config.genArt721CorePolyptych
       .connect(config.accounts.artist)
       .updateProjectMaxInvocations(config.projectZero, config.maxInvocations);
 
@@ -70,14 +112,57 @@ describe("BasicRandomizerV2 w/V3 core", async function () {
     await config.minter
       .connect(config.accounts.artist)
       .updatePricePerTokenInWei(config.projectZero, 0);
+    await config.minterFilterPolyptych
+      .connect(config.accounts.deployer)
+      .addApprovedMinter(config.minterPolyptych.address);
+    await config.minterFilterPolyptych
+      .connect(config.accounts.deployer)
+      .setMinterForProject(config.projectZero, config.minterPolyptych.address);
+    await config.minterPolyptych
+      .connect(config.accounts.artist)
+      .updatePricePerTokenInWei(config.projectZero, 0);
     return config;
   }
+
+  describe("Polyptych project hash seed settings", function () {
+    it("only the artist can set a project as polyptych", async function () {
+      const config = await loadFixture(_beforeEach);
+      await config.randomizerPolyptych
+        .connect(config.accounts.artist)
+        .toggleProjectIsPolyptych(0);
+      await expectRevert(
+        config.randomizerPolyptych
+          .connect(config.accounts.deployer)
+          .toggleProjectIsPolyptych(0),
+        "Only Artist"
+      );
+    });
+    it("requires the hash seed setter contract to be configured", async function () {
+      const config = await loadFixture(_beforeEach);
+      await expectRevert(
+        config.randomizerPolyptych
+          .connect(config.accounts.deployer)
+          .setPolyptychHashSeed(0, "0x000000000000000000000000"),
+        "Only hashSeedSetterContract"
+      );
+      await config.randomizerPolyptych.setHashSeedSetterContract(
+        config.accounts.deployer.address
+      );
+      await config.randomizerPolyptych
+        .connect(config.accounts.deployer)
+        .setPolyptychHashSeed(0, "0x000000000000000000000000");
+    });
+  });
 
   describe("assignCoreAndRenounce", function () {
     it("does not allow non-owner to call", async function () {
       const config = await loadFixture(_beforeEach);
       // deploy new randomizer
-      const randomizer = await deployAndGet(config, "BasicRandomizerV2", []);
+      const randomizer = await deployAndGet(
+        config,
+        "BasicPolyptychRandomizerV0",
+        []
+      );
       // expect failure when non-owner calls renounce and assign core
       await expectRevert(
         randomizer
@@ -90,7 +175,11 @@ describe("BasicRandomizerV2 w/V3 core", async function () {
     it("allows owner to call", async function () {
       const config = await loadFixture(_beforeEach);
       // deploy new randomizer
-      const randomizer = await deployAndGet(config, "BasicRandomizerV2", []);
+      const randomizer = await deployAndGet(
+        config,
+        "BasicPolyptychRandomizerV0",
+        []
+      );
       // expect success when owner calls renounce and assign core
       await randomizer
         .connect(config.accounts.deployer)
@@ -100,7 +189,11 @@ describe("BasicRandomizerV2 w/V3 core", async function () {
     it("does not allow owner to call twice", async function () {
       const config = await loadFixture(_beforeEach);
       // deploy new randomizer
-      const randomizer = await deployAndGet(config, "BasicRandomizerV2", []);
+      const randomizer = await deployAndGet(
+        config,
+        "BasicPolyptychRandomizerV0",
+        []
+      );
       // expect failure when owner calls renounce and assign core twice
       await randomizer
         .connect(config.accounts.deployer)
@@ -166,6 +259,54 @@ describe("BasicRandomizerV2 w/V3 core", async function () {
       console.info(`projectZeroTokenZeroHash: ${projectZeroTokenZeroHash}`);
       console.info(`projectZeroTokenOneHash: ${projectZeroTokenOneHash}`);
     });
+
+    it("copies the token hash from a previous token as expected", async function () {
+      const config = await loadFixture(_beforeEach);
+      await config.minterPolyptych
+        .connect(config.accounts.deployer)
+        .registerNFTAddress(config.genArt721Core.address);
+      await config.minterPolyptych
+        .connect(config.accounts.artist)
+        .allowHoldersOfProjects(
+          config.projectZero,
+          [config.genArt721Core.address],
+          [config.projectZero]
+        );
+      await config.randomizerPolyptych
+        .connect(config.accounts.deployer)
+        .setHashSeedSetterContract(config.minterPolyptych.address);
+      await config.randomizerPolyptych
+        .connect(config.accounts.artist)
+        .toggleProjectIsPolyptych(0);
+
+      await expectRevert(
+        config.minterPolyptych
+          .connect(config.accounts.artist)
+          ["purchase(uint256,address,uint256)"](
+            config.projectZero,
+            config.genArt721Core.address,
+            0,
+            {
+              value: 0,
+            }
+          ),
+        "Cannot have an empty hash seed to copy."
+      );
+
+      await config.minter.connect(config.accounts.artist).purchase(0);
+
+      // mint a token
+      await config.minterPolyptych
+        .connect(config.accounts.artist)
+        ["purchase(uint256,address,uint256)"](
+          config.projectZero,
+          config.genArt721Core.address,
+          0,
+          {
+            value: 0,
+          }
+        );
+    });
   });
 
   describe("owner", function () {
@@ -179,7 +320,11 @@ describe("BasicRandomizerV2 w/V3 core", async function () {
     it("returns deployer prior to being configured and renounced", async function () {
       const config = await loadFixture(_beforeEach);
       // deploy new randomizer
-      const randomizer = await deployAndGet(config, "BasicRandomizerV2", []);
+      const randomizer = await deployAndGet(
+        config,
+        "BasicPolyptychRandomizerV0",
+        []
+      );
       // expect owner to be deployer prior to being configured and renounced
       expect(await randomizer.owner()).to.be.equal(
         config.accounts.deployer.address


### PR DESCRIPTION
## Only merge after #501 

## Description of the change

Move pseudorandom hash generation to a base class to improve separation of changes.

Note that a base class is used instead of a library to enable use of randomizer state during pseudorandom hash generation.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204024759451481