### PR TITLE
Improve minter base class naming convention

### DIFF
--- a/contracts/mock/RandomizerV2_NoAssignMock.sol
+++ b/contracts/mock/RandomizerV2_NoAssignMock.sol
@@ -3,7 +3,7 @@
 
 pragma solidity 0.8.17;
 
-import "../randomizer/BasicRandomizerV2.sol";
+import "../randomizer/RandomizerV2.sol";
 
 /// @title RandomizerV2_NoAssignMock
 /// @notice WARNING - This is a mock contract. Do not use it in production.

--- a/contracts/randomizer/BasicRandomizerBase_v0_0_0.sol
+++ b/contracts/randomizer/BasicRandomizerBase_v0_0_0.sol
@@ -3,7 +3,7 @@
 
 pragma solidity 0.8.17;
 
-abstract contract BasicRandomizerBase {
+abstract contract RandomizerBase {
     // base class that returns
     function _getPseudorandom(
         uint256 _tokenId

--- a/contracts/randomizer/PolyptychRandomizerV0.sol
+++ b/contracts/randomizer/PolyptychRandomizerV0.sol
@@ -26,7 +26,7 @@ import "@openzeppelin-4.7/contracts/access/Ownable.sol";
  */
 contract BasicPolyptychRandomizerV0 is
     IRandomizerPolyptychV0,
-    BasicRandomizerBase,
+    RandomizerBase,
     Ownable
 {
     // The core contract that may interact with this randomizer contract.

--- a/contracts/randomizer/RandomizerV2.sol
+++ b/contracts/randomizer/RandomizerV2.sol
@@ -9,7 +9,7 @@ import "./BasicRandomizerBase_v0_0_0.sol";
 
 import "@openzeppelin-4.7/contracts/access/Ownable.sol";
 
-contract BasicRandomizerV2 is IRandomizerV2, BasicRandomizerBase, Ownable {
+contract BasicRandomizerV2 is IRandomizerV2, RandomizerBase, Ownable {
     // The core contract that may interact with this randomizer contract.
     IGenArt721CoreContractV3_Base public genArt721Core;
 


### PR DESCRIPTION
## Description of the change
Update minter base class with naming convention nit.

It is better to not specify `Basic` in the contract name, and instead use the `.sol` filename to specify that a base class implementation is a basic implementation.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204108367471971