### PR TITLE
Add max mint gas tests

### DIFF
--- a/test/core/gas-tests/GenArt721CoreV3_GasTests_Mint.test.ts
+++ b/test/core/gas-tests/GenArt721CoreV3_GasTests_Mint.test.ts
@@ -53,7 +53,7 @@ describe("GenArt721CoreV3 Gas Tests", async function () {
       "MinterFilterV1"
     ));
 
-    config.minter = await deployAndGet(config, "MinterSetPriceV2", [
+    config.minter = await deployAndGet(config, "MinterSetPriceV4", [
       config.genArt721Core.address,
       config.minterFilter.address,
     ]);
@@ -64,7 +64,7 @@ describe("GenArt721CoreV3 Gas Tests", async function () {
       [config.genArt721Core.address, config.minterFilter.address]
     );
 
-    config.minterDAExp = await deployAndGet(config, "MinterDAExpV2", [
+    config.minterDAExp = await deployAndGet(config, "MinterDAExpV4", [
       config.genArt721Core.address,
       config.minterFilter.address,
     ]);
@@ -75,18 +75,18 @@ describe("GenArt721CoreV3 Gas Tests", async function () {
       [config.genArt721Core.address, config.minterFilter.address]
     );
 
-    config.minterDALin = await deployAndGet(config, "MinterDALinV2", [
+    config.minterDALin = await deployAndGet(config, "MinterDALinV4", [
       config.genArt721Core.address,
       config.minterFilter.address,
     ]);
 
-    config.minterMerkle = await deployAndGet(config, "MinterMerkleV3", [
+    config.minterMerkle = await deployAndGet(config, "MinterMerkleV5", [
       config.genArt721Core.address,
       config.minterFilter.address,
       constants.ZERO_ADDRESS, // dummy delegation registry address since not used in these tests
     ]);
 
-    config.minterHolder = await deployAndGet(config, "MinterHolderV2", [
+    config.minterHolder = await deployAndGet(config, "MinterHolderV4", [
       config.genArt721Core.address,
       config.minterFilter.address,
       constants.ZERO_ADDRESS, // dummy delegation registry address since not used in these tests
@@ -150,6 +150,8 @@ describe("GenArt721CoreV3 Gas Tests", async function () {
         receipts.push(await ethers.provider.getTransactionReceipt(tx.hash));
       }
       const gasUseds = receipts.map((receipt) => receipt.gasUsed);
+      const maxGasUsed = Math.max(...gasUseds);
+      console.log(`max gas used for all tested mints: ${maxGasUsed}`);
       const avgGasUsed = gasUseds
         .reduce((a, b) => a.add(b))
         .div(gasUseds.length);
@@ -197,6 +199,8 @@ describe("GenArt721CoreV3 Gas Tests", async function () {
         receipts.push(await ethers.provider.getTransactionReceipt(tx.hash));
       }
       const gasUseds = receipts.map((receipt) => receipt.gasUsed);
+      const maxGasUsed = Math.max(...gasUseds);
+      console.log(`max gas used for all tested mints: ${maxGasUsed}`);
       const avgGasUsed = gasUseds
         .reduce((a, b) => a.add(b))
         .div(gasUseds.length);
@@ -257,6 +261,8 @@ describe("GenArt721CoreV3 Gas Tests", async function () {
         receipts.push(await ethers.provider.getTransactionReceipt(tx.hash));
       }
       const gasUseds = receipts.map((receipt) => receipt.gasUsed);
+      const maxGasUsed = Math.max(...gasUseds);
+      console.log(`max gas used for all tested mints: ${maxGasUsed}`);
       const avgGasUsed = gasUseds
         .reduce((a, b) => a.add(b))
         .div(gasUseds.length);
@@ -320,6 +326,8 @@ describe("GenArt721CoreV3 Gas Tests", async function () {
         receipts.push(await ethers.provider.getTransactionReceipt(tx.hash));
       }
       const gasUseds = receipts.map((receipt) => receipt.gasUsed);
+      const maxGasUsed = Math.max(...gasUseds);
+      console.log(`max gas used for all tested mints: ${maxGasUsed}`);
       const avgGasUsed = gasUseds
         .reduce((a, b) => a.add(b))
         .div(gasUseds.length);
@@ -380,6 +388,8 @@ describe("GenArt721CoreV3 Gas Tests", async function () {
         receipts.push(await ethers.provider.getTransactionReceipt(tx.hash));
       }
       const gasUseds = receipts.map((receipt) => receipt.gasUsed);
+      const maxGasUsed = Math.max(...gasUseds);
+      console.log(`max gas used for all tested mints: ${maxGasUsed}`);
       const avgGasUsed = gasUseds
         .reduce((a, b) => a.add(b))
         .div(gasUseds.length);
@@ -456,6 +466,8 @@ describe("GenArt721CoreV3 Gas Tests", async function () {
         receipts.push(await ethers.provider.getTransactionReceipt(tx.hash));
       }
       const gasUseds = receipts.map((receipt) => receipt.gasUsed);
+      const maxGasUsed = Math.max(...gasUseds);
+      console.log(`max gas used for all tested mints: ${maxGasUsed}`);
       const avgGasUsed = gasUseds
         .reduce((a, b) => a.add(b))
         .div(gasUseds.length);
@@ -543,6 +555,8 @@ describe("GenArt721CoreV3 Gas Tests", async function () {
         receipts.push(await ethers.provider.getTransactionReceipt(tx.hash));
       }
       const gasUseds = receipts.map((receipt) => receipt.gasUsed);
+      const maxGasUsed = Math.max(...gasUseds);
+      console.log(`max gas used for all tested mints: ${maxGasUsed}`);
       const avgGasUsed = gasUseds
         .reduce((a, b) => a.add(b))
         .div(gasUseds.length);

--- a/test/core/gas-tests/GenArt721CoreV3_GasTests_Mint.test.ts
+++ b/test/core/gas-tests/GenArt721CoreV3_GasTests_Mint.test.ts
@@ -60,7 +60,7 @@ describe("GenArt721CoreV3 Gas Tests", async function () {
 
     config.minterSetPriceERC20 = await deployAndGet(
       config,
-      "MinterSetPriceERC20V2",
+      "MinterSetPriceERC20V4",
       [config.genArt721Core.address, config.minterFilter.address]
     );
 
@@ -139,6 +139,13 @@ describe("GenArt721CoreV3 Gas Tests", async function () {
   describe("mint gas optimization", function () {
     it("test gas cost of mint on MinterSetPrice [ @skip-on-coverage ]", async function () {
       const config = await loadFixture(_beforeEach);
+      // manually set minter max invocations such that max invocations is reached
+      await config.minter
+        .connect(config.accounts.artist)
+        .manuallyLimitProjectMaxInvocations(
+          config.projectThree,
+          numMintsToAverage * 2
+        );
       // report gas over an average of numMintsToAverage purchases
       const receipts = [];
       for (let index = 0; index < numMintsToAverage; index++) {
@@ -186,6 +193,13 @@ describe("GenArt721CoreV3 Gas Tests", async function () {
         .updatePricePerTokenInWei(
           config.projectThree,
           config.pricePerTokenInWei
+        );
+      // manually set minter max invocations such that max invocations is reached
+      await config.minterSetPriceERC20
+        .connect(config.accounts.artist)
+        .manuallyLimitProjectMaxInvocations(
+          config.projectThree,
+          numMintsToAverage * 2
         );
 
       // report gas over an average of numMintsToAverage purchases
@@ -247,6 +261,13 @@ describe("GenArt721CoreV3 Gas Tests", async function () {
           config.defaultHalfLife,
           config.startingPrice,
           config.basePrice
+        );
+      // manually set minter max invocations such that max invocations is reached
+      await config.minterDAExp
+        .connect(config.accounts.artist)
+        .manuallyLimitProjectMaxInvocations(
+          config.projectThree,
+          numMintsToAverage * 2
         );
       await ethers.provider.send("evm_mine", [
         config.startTime + config.auctionStartTimeOffset,
@@ -316,6 +337,13 @@ describe("GenArt721CoreV3 Gas Tests", async function () {
       await ethers.provider.send("evm_mine", [
         config.startTime + config.auctionStartTimeOffset,
       ]);
+      // manually set minter max invocations such that max invocations is reached
+      await config.minterDAExpSettlement
+        .connect(config.accounts.artist)
+        .manuallyLimitProjectMaxInvocations(
+          config.projectThree,
+          numMintsToAverage * 2
+        );
 
       // report gas over an average of numMintsToAverage purchases
       const receipts = [];
@@ -378,6 +406,13 @@ describe("GenArt721CoreV3 Gas Tests", async function () {
       await ethers.provider.send("evm_mine", [
         config.startTime + config.auctionStartTimeOffset,
       ]);
+      // manually set minter max invocations such that max invocations is reached
+      await config.minterDALin
+        .connect(config.accounts.artist)
+        .manuallyLimitProjectMaxInvocations(
+          config.projectThree,
+          numMintsToAverage * 2
+        );
 
       // report gas over an average of numMintsToAverage purchases
       const receipts = [];
@@ -454,6 +489,13 @@ describe("GenArt721CoreV3 Gas Tests", async function () {
       const userMerkleProof = _merkleTree.getHexProof(
         hashAddress(config.accounts.user.address)
       );
+      // manually set minter max invocations such that max invocations is reached
+      await config.minterMerkle
+        .connect(config.accounts.artist)
+        .manuallyLimitProjectMaxInvocations(
+          config.projectThree,
+          numMintsToAverage * 2
+        );
 
       // report gas over an average of numMintsToAverage purchases
       const receipts = [];
@@ -537,6 +579,13 @@ describe("GenArt721CoreV3 Gas Tests", async function () {
           .connect(config.accounts.user)
           .purchase(config.projectOne, { value: config.pricePerTokenInWei });
       }
+      // manually set minter max invocations such that max invocations is reached
+      await config.minterHolder
+        .connect(config.accounts.artist)
+        .manuallyLimitProjectMaxInvocations(
+          config.projectThree,
+          numMintsToAverage * 2
+        );
 
       // report gas over an average of numMintsToAverage purchases
       const receipts = [];


### PR DESCRIPTION
## Description of the change

Add some tests to better quantify maximum gas used when performing purchase transactions.

Note that these are quickly added tests to _help_ describe maximum gas expected when minting, but they by no means represent maximum possible gas.

The following items could increase gas to an unbounded amount:
- Transfers of payment to additional payee would add more gas to purchase transactions
- Any payee implementing a `receive()` or `fallback()` function can perform an arbitrary amount of execution during a purchase transaction, making purchase transaction gas costs unbounded.

The logs associated with the new tests are:

```
  GenArt721CoreV3 Gas Tests
    mint gas optimization
max gas used for all tested mints: 114731
average gas used for mint optimization test: 111911
=USD at 100gwei, $2k USD/ETH: $22.3822
      ✓ test gas cost of mint on MinterSetPrice [ @skip-on-coverage ]
max gas used for all tested mints: 114891
average gas used for mint optimization test: 112071
=USD at 100gwei, $2k USD/ETH: $22.414199999999997
      ✓ test gas cost of mint on MinterSetPriceERC20 [ @skip-on-coverage ]
max gas used for all tested mints: 124132
average gas used for mint optimization test: 121312
=USD at 100gwei, $2k USD/ETH: $24.2624
      ✓ test gas cost of mint on MinterDAExp [ @skip-on-coverage ]
max gas used for all tested mints: 137508
average gas used for mint optimization test: 105602
=USD at 100gwei, $2k USD/ETH: $21.1204
      ✓ test gas cost of mint on MinterDAExpSettlement [ @skip-on-coverage ]
max gas used for all tested mints: 124237
average gas used for mint optimization test: 121417
=USD at 100gwei, $2k USD/ETH: $24.2834
      ✓ test gas cost of mint on MinterDALin [ @skip-on-coverage ]
max gas used for all tested mints: 146006
average gas used for mint optimization test: 130247
=USD at 100gwei, $2k USD/ETH: $26.0494
      ✓ test gas cost of mint on MinterMerkle [ @skip-on-coverage ]
max gas used for all tested mints: 121354
average gas used for mint optimization test: 118534
=USD at 100gwei, $2k USD/ETH: $23.7068
      ✓ test gas cost of mint on MinterHolder [ @skip-on-coverage ]
max gas used for all tested mints: 146016
average gas used for mint optimization test: 130056
=USD at 100gwei, $2k USD/ETH: $26.011200000000002
      ✓ test gas cost of mint on MinterMerkle [ @skip-on-coverage ]
max gas used for all tested mints: 118333
average gas used for mint optimization test: 118333
=USD at 100gwei, $2k USD/ETH: $23.6666
      ✓ test gas cost of mint on MinterHolder [ @skip-on-coverage ]
```

## Conclusion
It seams reasonable to update the frontend to use a hard-coded upper limit of 250k gas based on the data above. That provides a margin of `250/146 = ~+70%` relative to the max observed Merkle minter purchase gas to account for additional payee splits, etc.
