### PR TITLE
Simplify bidding interface of SEA minter

### DIFF
--- a/contracts/interfaces/0.8.x/IFilteredMinterSEAV0.sol
+++ b/contracts/interfaces/0.8.x/IFilteredMinterSEAV0.sol
@@ -88,7 +88,7 @@ interface IFilteredMinterSEAV0 is IFilteredMinterV2 {
 
     function settleAndCreateBid(
         uint256 _settleTokenId,
-        uint256 _initializeTokenId
+        uint256 _bidTokenId
     ) external payable;
 
     function settleAuction(uint256 _tokenId) external;

--- a/contracts/interfaces/0.8.x/IFilteredMinterSEAV0.sol
+++ b/contracts/interfaces/0.8.x/IFilteredMinterSEAV0.sol
@@ -86,14 +86,12 @@ interface IFilteredMinterSEAV0 is IFilteredMinterV2 {
 
     function resetAuctionDetails(uint256 _projectId) external;
 
-    function settleAndInitializeAuction(
+    function settleAndCreateBid(
         uint256 _settleTokenId,
         uint256 _initializeTokenId
     ) external payable;
 
     function settleAuction(uint256 _tokenId) external;
-
-    function initializeAuction(uint256 _targetTokenId) external payable;
 
     function createBid(uint256 _tokenId) external payable;
 
@@ -126,7 +124,5 @@ interface IFilteredMinterSEAV0 is IFilteredMinterV2 {
         uint256 _projectId
     ) external view returns (Auction memory);
 
-    function getTokenToBidOrInitialize(
-        uint256 _projectId
-    ) external view returns (uint256);
+    function getTokenToBid(uint256 _projectId) external view returns (uint256);
 }

--- a/contracts/minter-suite/Minters/MinterSEAV0.sol
+++ b/contracts/minter-suite/Minters/MinterSEAV0.sol
@@ -451,7 +451,7 @@ contract MinterSEAV0 is ReentrancyGuard, MinterBase, IFilteredMinterSEAV0 {
     /**
      * @notice Settles any complete auction for token `_settleTokenId` (if
      * applicable), then attempts to create a bid for token
-     * `_initializeTokenId` with bid amount and bidder address equal to
+     * `_bidTokenId` with bid amount and bidder address equal to
      * `msg.value` and `msg.sender`, respectively.
      * Intended to gracefully handle the case where a user is front-run by
      * one or more transactions to settle and/or initialize a new auction.

--- a/contracts/minter-suite/Minters/MinterSEAV0.sol
+++ b/contracts/minter-suite/Minters/MinterSEAV0.sol
@@ -454,7 +454,9 @@ contract MinterSEAV0 is ReentrancyGuard, MinterBase, IFilteredMinterSEAV0 {
      * `_bidTokenId` with bid amount and bidder address equal to
      * `msg.value` and `msg.sender`, respectively.
      * Intended to gracefully handle the case where a user is front-run by
-     * one or more transactions to settle and/or initialize a new auction.
+     * one or more transactions to settle and/or initialize a new auction,
+     * potentially still placing a bid on the auction for the token ID if the
+     * bid value is sufficiently higher than the current highest bid.
      * This function requires a target token ID that is the next token ID for
      * the project, and will revert if `_targetTokenId` is not the next token.
      * Note that the use of `_targetTokenId` is to prevent the possibility of

--- a/contracts/mock/ReentrancySEAMock.sol
+++ b/contracts/mock/ReentrancySEAMock.sol
@@ -20,7 +20,7 @@ contract ReentrancySEAAutoBidderMock {
         uint256 _initialBidValue
     ) external payable {
         targetTokenId = _targetTokenId;
-        IFilteredMinterSEAV0(_minterContractAddress).initializeAuction{
+        IFilteredMinterSEAV0(_minterContractAddress).createBid{
             value: _initialBidValue
         }(_targetTokenId);
     }

--- a/test/minter-suite-minters/SEA/MinterSEAV0.test.ts
+++ b/test/minter-suite-minters/SEA/MinterSEAV0.test.ts
@@ -32,9 +32,9 @@ import { Minter_Common } from "../Minter.common";
 // test the following V3 core contract derivatives:
 const coreContractsToTest = [
   "GenArt721CoreV3", // flagship V3 core
-  "GenArt721CoreV3_Explorations", // V3 core explorations contract
-  "GenArt721CoreV3_Engine", // V3 core engine contract
-  "GenArt721CoreV3_EngineFlex", // V3 core engine contract
+  // "GenArt721CoreV3_Explorations", // V3 core explorations contract
+  // "GenArt721CoreV3_Engine", // V3 core engine contract
+  // "GenArt721CoreV3_EngineFlex", // V3 core engine contract
 ];
 
 const TARGET_MINTER_NAME = "MinterSEAV0";
@@ -49,11 +49,9 @@ async function initializeProjectZeroTokenZeroAuction(config: T_Config) {
   await ethers.provider.send("evm_mine", [config.startTime - 1]);
   // someone initializes the auction
   const targetToken = BigNumber.from(config.projectZeroTokenZero.toString());
-  await config.minter
-    .connect(config.accounts.user)
-    .initializeAuction(targetToken, {
-      value: config.basePrice,
-    });
+  await config.minter.connect(config.accounts.user).createBid(targetToken, {
+    value: config.basePrice,
+  });
 }
 
 // helper function to initialize a token auction on project zero, and then
@@ -713,7 +711,7 @@ for (const coreContractName of coreContractsToTest) {
       });
     });
 
-    describe("initializeAuction", async function () {
+    describe("createBid w/ auction initialization", async function () {
       it("attempts to create bid if token auction is already initialized", async function () {
         const config = await loadFixture(_beforeEach);
         await initializeProjectZeroTokenZeroAuction(config);
@@ -725,7 +723,7 @@ for (const coreContractName of coreContractsToTest) {
         await expect(
           config.minter
             .connect(config.accounts.user2)
-            .initializeAuction(targetToken, { value: nextBidValue })
+            .createBid(targetToken, { value: nextBidValue })
         )
           .to.emit(config.minter, "AuctionBid")
           .withArgs(targetToken, config.accounts.user2.address, nextBidValue);
@@ -745,7 +743,7 @@ for (const coreContractName of coreContractsToTest) {
           await expectRevert(
             config.minter
               .connect(config.accounts.artist)
-              .initializeAuction(targetToken, { value: config.basePrice }),
+              .createBid(targetToken, { value: config.basePrice }),
             "Project max has been invoked"
           );
         });
@@ -763,7 +761,7 @@ for (const coreContractName of coreContractsToTest) {
           await expectRevert(
             config.minter
               .connect(config.accounts.artist)
-              .initializeAuction(targetToken, { value: config.basePrice }),
+              .createBid(targetToken, { value: config.basePrice }),
             "Project not configured"
           );
         });
@@ -778,7 +776,7 @@ for (const coreContractName of coreContractsToTest) {
           await expectRevert(
             config.minter
               .connect(config.accounts.artist)
-              .initializeAuction(targetToken, { value: config.basePrice }),
+              .createBid(targetToken, { value: config.basePrice }),
             "Only gte project start time"
           );
         });
@@ -794,8 +792,8 @@ for (const coreContractName of coreContractsToTest) {
           await expectRevert(
             config.minter
               .connect(config.accounts.user)
-              .initializeAuction(targetToken, { value: config.basePrice }),
-            "Prior auction not yet settled"
+              .createBid(targetToken, { value: config.basePrice }),
+            "Token ID does not match auction"
           );
         });
 
@@ -809,7 +807,7 @@ for (const coreContractName of coreContractsToTest) {
           );
           await config.minter
             .connect(config.accounts.user)
-            .initializeAuction(targetToken, { value: config.basePrice });
+            .createBid(targetToken, { value: config.basePrice });
         });
 
         it("reverts if minimum bid value is not sent", async function () {
@@ -821,11 +819,9 @@ for (const coreContractName of coreContractsToTest) {
             config.projectZeroTokenZero.toString()
           );
           await expectRevert(
-            config.minter
-              .connect(config.accounts.user)
-              .initializeAuction(targetToken, {
-                value: config.basePrice.sub(1),
-              }),
+            config.minter.connect(config.accounts.user).createBid(targetToken, {
+              value: config.basePrice.sub(1),
+            }),
             "Insufficient initial bid"
           );
         });
@@ -841,11 +837,9 @@ for (const coreContractName of coreContractsToTest) {
             config.projectZeroTokenOne.toString() // <--- incorrect target token ID
           );
           await expectRevert(
-            config.minter
-              .connect(config.accounts.user)
-              .initializeAuction(targetToken, {
-                value: bidValue,
-              }),
+            config.minter.connect(config.accounts.user).createBid(targetToken, {
+              value: bidValue,
+            }),
             "Incorrect target token ID"
           );
         });
@@ -887,11 +881,9 @@ for (const coreContractName of coreContractsToTest) {
             config.projectZeroTokenOne.toString()
           );
           await expectRevert(
-            config.minter
-              .connect(config.accounts.user)
-              .initializeAuction(targetToken, {
-                value: config.basePrice,
-              }),
+            config.minter.connect(config.accounts.user).createBid(targetToken, {
+              value: config.basePrice,
+            }),
             "Maximum invocations reached"
           );
         });
@@ -911,7 +903,7 @@ for (const coreContractName of coreContractsToTest) {
           );
           await config.minter
             .connect(config.accounts.user)
-            .initializeAuction(targetToken, {
+            .createBid(targetToken, {
               value: bidValue,
             });
           // validate auction state
@@ -938,11 +930,9 @@ for (const coreContractName of coreContractsToTest) {
             config.projectZeroTokenZero.toString() // <--- incorrect target token ID
           );
           await expect(
-            config.minter
-              .connect(config.accounts.user)
-              .initializeAuction(targetToken, {
-                value: config.basePrice,
-              })
+            config.minter.connect(config.accounts.user).createBid(targetToken, {
+              value: config.basePrice,
+            })
           )
             .to.emit(config.minter, "AuctionInitialized")
             .withArgs(
@@ -957,16 +947,13 @@ for (const coreContractName of coreContractsToTest) {
 
     describe("createBid", function () {
       describe("CHECKS", function () {
-        it("reverts if auction is not initialized", async function () {
+        it("does not revert if auction is not initialized (i.e. auto-initializes)", async function () {
           const config = await loadFixture(_beforeEach);
           // advance time to auction start time
           await ethers.provider.send("evm_mine", [config.startTime]);
-          await expectRevert(
-            config.minter.connect(config.accounts.user).createBid(0, {
-              value: config.basePrice,
-            }),
-            "Auction not yet initialized"
-          );
+          await config.minter.connect(config.accounts.user).createBid(0, {
+            value: config.basePrice,
+          });
         });
 
         it("reverts if different token is active", async function () {
@@ -1174,7 +1161,7 @@ for (const coreContractName of coreContractsToTest) {
       });
     });
 
-    describe("settleAndInitializeAuction", function () {
+    describe("settleAndCreateBid", function () {
       it("settles and initializes an auction", async function () {
         const config = await loadFixture(_beforeEach);
         // initialize and advance to end of auction for token zero
@@ -1194,7 +1181,7 @@ for (const coreContractName of coreContractsToTest) {
         await expect(
           config.minter
             .connect(config.accounts.user2)
-            .settleAndInitializeAuction(settleTokenId, initializeTokenId, {
+            .settleAndCreateBid(settleTokenId, initializeTokenId, {
               value: config.basePrice,
             })
         )
@@ -1238,7 +1225,7 @@ for (const coreContractName of coreContractsToTest) {
         await expect(
           config.minter
             .connect(config.accounts.user2)
-            .settleAndInitializeAuction(settleTokenId, initializeTokenId, {
+            .settleAndCreateBid(settleTokenId, initializeTokenId, {
               value: config.basePrice,
             })
         )
@@ -1267,7 +1254,7 @@ for (const coreContractName of coreContractsToTest) {
         );
         await config.minter
           .connect(config.accounts.additional)
-          .initializeAuction(initializeTokenId, {
+          .createBid(initializeTokenId, {
             value: config.basePrice,
           });
         // settle and initialize a new auction still attempts to place a new bid on the new auction
@@ -1276,7 +1263,7 @@ for (const coreContractName of coreContractsToTest) {
         await expect(
           config.minter
             .connect(config.accounts.user2)
-            .settleAndInitializeAuction(settleTokenId, initializeTokenId, {
+            .settleAndCreateBid(settleTokenId, initializeTokenId, {
               value: newValidBidValue,
             })
         )
@@ -1312,7 +1299,7 @@ for (const coreContractName of coreContractsToTest) {
     });
 
     describe("view functions", function () {
-      describe("getTokenToBidOrInitialize", function () {
+      describe("getTokenToBid", function () {
         it("reverts when project has already reached max invocations on core contract, and no active auction", async function () {
           const config = await loadFixture(_beforeEach);
           // set project max invocations to 1 on core contract
@@ -1323,7 +1310,7 @@ for (const coreContractName of coreContractsToTest) {
           await initializeProjectZeroTokenZeroAuctionAndAdvanceToEnd(config);
           // view function to get next token ID should revert, since project has reached max invocations
           await expectRevert(
-            config.minter.getTokenToBidOrInitialize(config.projectZero),
+            config.minter.getTokenToBid(config.projectZero),
             "Project reached max invocations"
           );
         });
@@ -1340,7 +1327,7 @@ for (const coreContractName of coreContractsToTest) {
           const targetExpectedTokenId = BigNumber.from(
             config.projectZeroTokenZero.toString()
           );
-          const returnedTokenId = await config.minter.getTokenToBidOrInitialize(
+          const returnedTokenId = await config.minter.getTokenToBid(
             config.projectZero
           );
           expect(returnedTokenId).to.equal(targetExpectedTokenId);
@@ -1351,8 +1338,9 @@ for (const coreContractName of coreContractsToTest) {
           const targetExpectedTokenId = BigNumber.from(
             config.projectZeroTokenZero.toString()
           );
-          const returnedExpectedTokenId =
-            await config.minter.getTokenToBidOrInitialize(config.projectZero);
+          const returnedExpectedTokenId = await config.minter.getTokenToBid(
+            config.projectZero
+          );
           expect(returnedExpectedTokenId).to.equal(targetExpectedTokenId);
         });
 
@@ -1363,8 +1351,9 @@ for (const coreContractName of coreContractsToTest) {
           const targetExpectedTokenId = BigNumber.from(
             config.projectZeroTokenOne.toString()
           );
-          const returnedExpectedTokenId =
-            await config.minter.getTokenToBidOrInitialize(config.projectZero);
+          const returnedExpectedTokenId = await config.minter.getTokenToBid(
+            config.projectZero
+          );
           expect(returnedExpectedTokenId).to.equal(targetExpectedTokenId);
         });
       });
@@ -1513,15 +1502,6 @@ for (const coreContractName of coreContractsToTest) {
             autoBidder.address
           );
           expect(autoBidderWethBalance).to.equal(initialBidValue);
-        });
-      });
-
-      describe("_initializeAuction", function () {
-        it("nonReentrant commentary", async function () {
-          console.log(
-            "This nonReentrant modifier is implemented to achieve dual redundancy, and therefore cannot be tested with the standard core contract implementation.",
-            "This is considered sufficient for the purposes of this test suite."
-          );
         });
       });
 

--- a/test/minter-suite-minters/SEA/MinterSEAV0.test.ts
+++ b/test/minter-suite-minters/SEA/MinterSEAV0.test.ts
@@ -34,7 +34,7 @@ const coreContractsToTest = [
   "GenArt721CoreV3", // flagship V3 core
   "GenArt721CoreV3_Explorations", // V3 core explorations contract
   "GenArt721CoreV3_Engine", // V3 core engine contract
-  "GenArt721CoreV3_EngineFlex", // V3 core engine contract
+  "GenArt721CoreV3_Engine_Flex", // V3 core engine contract
 ];
 
 const TARGET_MINTER_NAME = "MinterSEAV0";
@@ -678,9 +678,11 @@ for (const coreContractName of coreContractsToTest) {
         const artistBalanceAfter = await config.accounts.artist.getBalance();
         const deployerBalanceAfter =
           await config.accounts.deployer.getBalance();
-        expect(artistBalanceAfter).to.equal(
-          artistBalanceBefore.add(config.basePrice.mul(90).div(100))
-        );
+        // artist receives 90% of base price for non-engine, 80% for engine
+        const expectedArtistBalance = config.isEngine
+          ? artistBalanceBefore.add(config.basePrice.mul(80).div(100))
+          : artistBalanceBefore.add(config.basePrice.mul(90).div(100));
+        expect(artistBalanceAfter).to.equal(expectedArtistBalance);
         expect(deployerBalanceAfter).to.equal(
           deployerBalanceBefore.add(config.basePrice.mul(10).div(100))
         );

--- a/test/minter-suite-minters/SEA/MinterSEAV0.test.ts
+++ b/test/minter-suite-minters/SEA/MinterSEAV0.test.ts
@@ -32,9 +32,9 @@ import { Minter_Common } from "../Minter.common";
 // test the following V3 core contract derivatives:
 const coreContractsToTest = [
   "GenArt721CoreV3", // flagship V3 core
-  // "GenArt721CoreV3_Explorations", // V3 core explorations contract
-  // "GenArt721CoreV3_Engine", // V3 core engine contract
-  // "GenArt721CoreV3_EngineFlex", // V3 core engine contract
+  "GenArt721CoreV3_Explorations", // V3 core explorations contract
+  "GenArt721CoreV3_Engine", // V3 core engine contract
+  "GenArt721CoreV3_EngineFlex", // V3 core engine contract
 ];
 
 const TARGET_MINTER_NAME = "MinterSEAV0";


### PR DESCRIPTION
## Description of the change

This is an iteration on #504 (that may be folded into that PR) that simplifies the bidding interface of the SEA minter by abstracting the concept of "initializing" an auction.

I think this is a meaningful improvement relative to the implementation in #504 because it simplifies the collector actions:

**with this change:**
- `Settle`
- `Bid`

**without this change**
- `Settle`
- `Initialize`(which would bid if already initialized for protection against front-running)
- `Bid`

Variable and function names are updated as part of this change.


## downstream effects

Elected to keep this as a PR to fold into #504, and will update design document if this is LGTM'd 🙏 

This has no downstream effects in indexing/database, other than how the frontend purchase flow will interact with the minter (which has not been built yet), and our design document'

# Tests
Tests are updated for this change. We have a redundant check that cannot achieve branch coverage, which I prefer to keep to avoid introducing bugs in future changes. Unfortunately there isn't a "solcover skip next line" command, so coveralls yells about the new missed branch.
