### PR TITLE
SEA minter - hold n+1 token to improve UX

### DIFF
--- a/contracts/interfaces/0.8.x/IFilteredMinterSEAV0.sol
+++ b/contracts/interfaces/0.8.x/IFilteredMinterSEAV0.sol
@@ -77,6 +77,9 @@ interface IFilteredMinterSEAV0 is IFilteredMinterV2 {
         uint256 price
     );
 
+    // Next token ID for project `projectId` updated
+    event ProjectNextTokenUpdated(uint256 indexed projectId, uint256 tokenId);
+
     function configureFutureAuctions(
         uint256 _projectId,
         uint256 _timestampStart,
@@ -86,7 +89,11 @@ interface IFilteredMinterSEAV0 is IFilteredMinterV2 {
 
     function resetAuctionDetails(uint256 _projectId) external;
 
-    function settleAndCreateBid(
+    // artist-only function that populates the next token ID to be auctioned
+    // for project `projectId`
+    function tryPopulateNextToken(uint256 _projectId) external;
+
+    function settleAuctionAndCreateBid(
         uint256 _settleTokenId,
         uint256 _bidTokenId
     ) external payable;
@@ -95,7 +102,7 @@ interface IFilteredMinterSEAV0 is IFilteredMinterV2 {
 
     function createBid(uint256 _tokenId) external payable;
 
-    function createBid_4cM(uint256 _tokenId) external payable;
+    function createBid_l34(uint256 _tokenId) external payable;
 
     function minterConfigurationDetails()
         external
@@ -117,6 +124,8 @@ interface IFilteredMinterSEAV0 is IFilteredMinterV2 {
             uint64 timestampStart,
             uint32 auctionDurationSeconds,
             uint256 basePrice,
+            bool nextTokenNumberIsPopulated,
+            uint24 nextTokenNumber,
             Auction memory auction
         );
 

--- a/contracts/minter-suite/Minters/MinterSEAV0.sol
+++ b/contracts/minter-suite/Minters/MinterSEAV0.sol
@@ -53,6 +53,7 @@ import "@openzeppelin-4.7/contracts/utils/math/Math.sol";
  * - setProjectMaxInvocations
  * - manuallyLimitProjectMaxInvocations
  * - configureFutureAuctions
+ * - tryPopulateNextToken
  * ----------------------------------------------------------------------------
  * The following functions are restricted to a project's artist or the core
  * contract's Admin ACL contract:
@@ -63,11 +64,11 @@ import "@openzeppelin-4.7/contracts/utils/math/Math.sol";
  *
  * @dev Note that while this minter makes use of `block.timestamp` and it is
  * technically possible that this value is manipulated by block producers, such
- * manipulation will not have material impact on the price values of this minter
- * given the business practices for how pricing is congfigured for this minter
- * and that variations on the order of less than a minute should not
- * meaningfully impact price given the minimum allowable price decay rate that
- * this minter intends to support.
+ * manipulation will not have material impact on the ability for collectors to
+ * place a bid before auction end time. This is due to the admin-configured
+ * `minterTimeBufferSeconds` parameter, which will used to ensure that
+ * collectors have sufficient time to place a bid after the final bid and
+ * before the auction end time.
  */
 contract MinterSEAV0 is ReentrancyGuard, MinterBase, IFilteredMinterSEAV0 {
     using SafeCast for uint256;

--- a/contracts/minter-suite/Minters/MinterSEAV0.sol
+++ b/contracts/minter-suite/Minters/MinterSEAV0.sol
@@ -607,6 +607,11 @@ contract MinterSEAV0 is ReentrancyGuard, MinterBase, IFilteredMinterSEAV0 {
      * Note that the use of `_tokenId` is to prevent the possibility of
      * transactions that are stuck in the pending pool for long periods of time
      * from unintentionally bidding on auctions for future tokens.
+     * If a new auction is initialized during this call, the project's next
+     * token will be attempted to be minted to this minter contract, preparing
+     * it for the next auction. If the project's next token cannot be minted
+     * due to e.g. reaching the maximum invocations on the core contract or
+     * minter, the project's next token will not be minted.
      * @param _tokenId Token ID being bidded on
      */
     function createBid(uint256 _tokenId) external payable {

--- a/contracts/minter-suite/Minters/MinterSEAV0.sol
+++ b/contracts/minter-suite/Minters/MinterSEAV0.sol
@@ -562,13 +562,12 @@ contract MinterSEAV0 is ReentrancyGuard, MinterBase, IFilteredMinterSEAV0 {
         ProjectConfig storage _projectConfig = projectConfig[_projectId];
         Auction storage _auction = _projectConfig.activeAuction;
         // CHECKS
-        if (
-            (!_auction.initialized) ||
-            _auction.settled ||
-            (_auction.tokenId != _tokenId)
-        ) {
-            // auction not initialized, already settled, or is for a different
-            // token ID, so return early
+        // @dev this check is not strictly necessary, but is included for
+        // clear error messaging
+        require(_auction.initialized, "Auction not initialized");
+        if (_auction.settled || (_auction.tokenId != _tokenId)) {
+            // auction already settled or is for a different token ID, so
+            // return early and do not modify state
             return;
         }
         require(block.timestamp > _auction.endTime, "Auction not yet ended");

--- a/contracts/minter-suite/Minters/MinterSEAV0.sol
+++ b/contracts/minter-suite/Minters/MinterSEAV0.sol
@@ -928,6 +928,7 @@ contract MinterSEAV0 is ReentrancyGuard, MinterBase, IFilteredMinterSEAV0 {
         // internal function is called, but it is included for protection
         // against future changes that could easily introduce a bug if this
         // check is not present
+        // @dev no cover else branch of next line because unreachable
         require(
             (!_auction.initialized) || _auction.settled,
             "Existing auction not settled"
@@ -940,6 +941,8 @@ contract MinterSEAV0 is ReentrancyGuard, MinterBase, IFilteredMinterSEAV0 {
         // require next token number is populated, giving intuitive error
         // message if project has reached its max invocations
         if (!_projectConfig.nextTokenNumberIsPopulated) {
+            // @dev no cover else branch of next line because considered
+            // unreachable
             if (_projectConfig.maxHasBeenInvoked) {
                 revert("Max invocations reached");
             } else {
@@ -947,6 +950,7 @@ contract MinterSEAV0 is ReentrancyGuard, MinterBase, IFilteredMinterSEAV0 {
                 // because users should only mint a new new token if they
                 // are able to know what it is a prori
                 // @dev this is an unexpected case, but is included for safety
+                // @dev no cover next line because considered unreachable
                 revert(
                     "No next token, Artist may need to call `tryPopulateNextToken`"
                 );

--- a/test/minter-suite-minters/SEA/MinterSEAV0.test.ts
+++ b/test/minter-suite-minters/SEA/MinterSEAV0.test.ts
@@ -32,9 +32,9 @@ import { Minter_Common } from "../Minter.common";
 // test the following V3 core contract derivatives:
 const coreContractsToTest = [
   "GenArt721CoreV3", // flagship V3 core
-  // "GenArt721CoreV3_Explorations", // V3 core explorations contract
-  // "GenArt721CoreV3_Engine", // V3 core engine contract
-  // "GenArt721CoreV3_Engine_Flex", // V3 core engine contract
+  "GenArt721CoreV3_Explorations", // V3 core explorations contract
+  "GenArt721CoreV3_Engine", // V3 core engine contract
+  "GenArt721CoreV3_Engine_Flex", // V3 core engine contract
 ];
 
 const TARGET_MINTER_NAME = "MinterSEAV0";

--- a/test/minter-suite-minters/SEA/MinterSEAV0.test.ts
+++ b/test/minter-suite-minters/SEA/MinterSEAV0.test.ts
@@ -639,14 +639,17 @@ for (const coreContractName of coreContractsToTest) {
     });
 
     describe("settleAuction", async function () {
-      it("does not revert or change state when auction not initialized", async function () {
+      it("reverts when no auction initialized on project (for clear error messaging)", async function () {
         const config = await loadFixture(_beforeEach);
         const targetToken = BigNumber.from(
           config.projectZeroTokenZero.toString()
         );
-        await config.minter
-          .connect(config.accounts.user)
-          .settleAuction(targetToken);
+        await expectRevert(
+          config.minter
+            .connect(config.accounts.user)
+            .settleAuction(targetToken),
+          "Auction not initialized"
+        );
         // verify no state change
         const projectconfig = await config.minter.projectConfigurationDetails(
           config.projectZero

--- a/test/minter-suite-minters/SEA/MinterSEAV0.test.ts
+++ b/test/minter-suite-minters/SEA/MinterSEAV0.test.ts
@@ -1395,6 +1395,56 @@ for (const coreContractName of coreContractsToTest) {
       });
     });
 
+    describe("handles next token well when project reaches max invocations", function () {
+      it("auto-populates next token number when project max invocations are manually increased", async function () {
+        const config = await loadFixture(_beforeEach);
+        // set project max invocations to 1
+        await config.minter
+          .connect(config.accounts.artist)
+          .manuallyLimitProjectMaxInvocations(config.projectZero, 1);
+        // initialize and advance to end of auction for token zero
+        await initializeProjectZeroTokenZeroAuctionAndAdvanceToEnd(config);
+        // confirm that next token number is not populated
+        const initialProjectConfig = await config.minter.projectConfig(
+          config.projectZero
+        );
+        expect(initialProjectConfig.nextTokenNumberIsPopulated).to.equal(false);
+        // artist increases max invocations
+        await config.minter
+          .connect(config.accounts.artist)
+          .manuallyLimitProjectMaxInvocations(config.projectZero, 2);
+        // confirm that next token number is populated
+        const updatedProjectConfig = await config.minter.projectConfig(
+          config.projectZero
+        );
+        expect(updatedProjectConfig.nextTokenNumberIsPopulated).to.equal(true);
+      });
+
+      it("auto-populates next token number when project max invocations are synced to core contract value", async function () {
+        const config = await loadFixture(_beforeEach);
+        // set project max invocations to 1
+        await config.minter
+          .connect(config.accounts.artist)
+          .manuallyLimitProjectMaxInvocations(config.projectZero, 1);
+        // initialize and advance to end of auction for token zero
+        await initializeProjectZeroTokenZeroAuctionAndAdvanceToEnd(config);
+        // confirm that next token number is not populated
+        const initialProjectConfig = await config.minter.projectConfig(
+          config.projectZero
+        );
+        expect(initialProjectConfig.nextTokenNumberIsPopulated).to.equal(false);
+        // artist increases max invocations to equal core contract value
+        await config.minter
+          .connect(config.accounts.artist)
+          .setProjectMaxInvocations(config.projectZero);
+        // confirm that next token number is populated
+        const updatedProjectConfig = await config.minter.projectConfig(
+          config.projectZero
+        );
+        expect(updatedProjectConfig.nextTokenNumberIsPopulated).to.equal(true);
+      });
+    });
+
     describe("purchase", function () {
       it("is an inactive function", async function () {
         const config = await loadFixture(_beforeEach);

--- a/test/util/common.ts
+++ b/test/util/common.ts
@@ -40,6 +40,7 @@ export type T_Config = {
   // token IDs
   projectZeroTokenZero?: BigNumber;
   projectZeroTokenOne?: BigNumber;
+  projectZeroTokenTwo?: BigNumber;
   projectOneTokenZero?: BigNumber;
   projectOneTokenOne?: BigNumber;
   projectTwoTokenZero?: BigNumber;
@@ -112,6 +113,7 @@ export async function assignDefaultConstants(
     new BN("1000000")
   );
   config.projectZeroTokenOne = config.projectZeroTokenZero.add(new BN("1"));
+  config.projectZeroTokenTwo = config.projectZeroTokenOne.add(new BN("1"));
   config.projectOneTokenZero = new BN(config.projectOne).mul(new BN("1000000"));
   config.projectOneTokenOne = config.projectOneTokenZero.add(new BN("1"));
   config.projectTwoTokenZero = new BN(config.projectTwo).mul(new BN("1000000"));


### PR DESCRIPTION
## Description of the change

Update SEA minter smart contracts to hold "next token" to improve UX when shifting from one auction to the next.

**Proposed to be folded into #504**

This iteration adds smart contract complexity and minter-state complexity relative to #504, but results in an improved UX. The main benefit is that when transitioning from one auction to the next, the next token to be auctioned is known before the initial bid. Additionally, since the auction holds the next token to be minted, it is possible for a single transaction to settle the previous auction, initialize the auction for the known, next token, and place a bid on said token.

## Tests
Tests are updated for these changes, and full coverage is reached for the portions of code that are considered reachable.
 
_a couple lines are "unreachable" and are not covered during testing. These "unreachable" lines are included in the minter to provide redundant protection against a state that is thought to be impossible, but would be dangerous if possible_