### PR TITLE
tokenIdToHash to base V3 interface

### DIFF
--- a/contracts/interfaces/0.8.x/IGenArt721CoreContractV3_Base.sol
+++ b/contracts/interfaces/0.8.x/IGenArt721CoreContractV3_Base.sol
@@ -115,6 +115,8 @@ interface IGenArt721CoreContractV3_Base is IManifold {
             bool locked
         );
 
+    function tokenIdToHash(uint256 _tokenId) external view returns (bytes32);
+
     // function to set a token's hash (must be guarded)
     function setTokenHash_8PT(uint256 _tokenId, bytes32 _hash) external;
 

--- a/contracts/interfaces/0.8.x/IGenArt721CoreContractV3_Engine.sol
+++ b/contracts/interfaces/0.8.x/IGenArt721CoreContractV3_Engine.sol
@@ -70,9 +70,6 @@ interface IGenArt721CoreContractV3_Engine is IGenArt721CoreContractV3_Base {
         view
         returns (uint256);
 
-    // function to read the hash for a given tokenId
-    function tokenIdToHash(uint256 _tokenId) external view returns (bytes32);
-
     // function to read the hash-seed for a given tokenId
     function tokenIdToHashSeed(
         uint256 _tokenId


### PR DESCRIPTION
## Description of the change

Move tokenIdToHash to base V3 core interface instead of V3 Engine interface.

This is required for some follow-on subgraph refactoring work. It also just makes sense 😅 
