### PR TITLE
Update readme V3 performance metrics link

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Core contracts use the versioning schema below:
 | Engine Partner Cores (V2) | V2_PRTNR |   All PRTNR   | Various - see `deployments/engine/` directory [DEPLOYMENTS.md files](https://github.com/search?q=repo%3AArtBlocks%2Fartblocks-contracts+extension%3Amd+filename%3ADEPLOYMENTS&type=Code&ref=advsearch&l=&l=) |
 |   AB Core V3 (current)    |    V3    |     374+      | `0x99a9B7c1116f9ceEB1652de04d5969CcE509B069`                                                                                                                                                                 |
 
-> AB Core V3 [changelog here](./contracts/V3_CHANGELOG.md), and [performance metrics here](./contracts/V3_Performance.md).
+> AB Core V3 [changelog here](./contracts/V3_CHANGELOG.md), and [performance metrics here](./contracts/V3_PERFORMANCE.md).
 
 ### Testnet Contracts
 


### PR DESCRIPTION
## Description of the change
This just updates the readme to the correct link

> reminder: Any mainnet deployments after 10 Jan 2023 should be tagged as [Releases](https://github.com/ArtBlocks/artblocks-contracts/releases) in this repository. This ensures that the deployed contract source code is easily verifiable by anyone.
