### PR TITLE
MinterFilterV1: Update documentation to match function names

### DIFF
--- a/contracts/minter-suite/MinterFilter/MinterFilterV1.sol
+++ b/contracts/minter-suite/MinterFilter/MinterFilterV1.sol
@@ -27,8 +27,8 @@ pragma solidity 0.8.17;
  * ----------------------------------------------------------------------------
  * The following functions are restricted to the core contract's Admin ACL
  * contract:
- * - addApprovedMinters
- * - removeApprovedMinters
+ * - addApprovedMinter
+ * - removeApprovedMinter
  * - removeMintersForProjects
  * ----------------------------------------------------------------------------
  * The following functions are restricted to the core contract's Admin ACL


### PR DESCRIPTION
## Description of the change

Docs had plural names, code had singular names. Defaulted to working code as the correct version. Please let me know if incorrect