### PR TITLE
Extra delay time of 5 seconds

### DIFF
--- a/scripts/adminACL-deployments/1_reference_mainnet_AdminACL_deployer.ts
+++ b/scripts/adminACL-deployments/1_reference_mainnet_AdminACL_deployer.ts
@@ -7,7 +7,7 @@ import { AdminACLV1__factory } from "../contracts/factories/AdminACLV1__factory"
 
 // delay to avoid issues with reorgs and tx failures
 import { delay } from "../util/utils";
-const EXTRA_DELAY_BETWEEN_TX = 5000; // ms
+import { EXTRA_DELAY_BETWEEN_TX } from "../util/constants";
 
 /**
  * This script was created to deploy the AdminACLV1 contract to the Ethereum

--- a/scripts/engine/V3/generic-engine-deployer.ts
+++ b/scripts/engine/V3/generic-engine-deployer.ts
@@ -19,13 +19,13 @@ import {
 import {
   DELEGATION_REGISTRY_ADDRESSES,
   KNOWN_ENGINE_REGISTRIES,
+  EXTRA_DELAY_BETWEEN_TX,
 } from "../../util/constants";
 import { tryVerify } from "../../util/verification";
 // image bucket creation
 import { createPBABBucket } from "../../util/aws_s3";
 // delay to avoid issues with reorgs and tx failures
 import { delay, getAppPath } from "../../util/utils";
-const EXTRA_DELAY_BETWEEN_TX = 1000; // ms
 const MANUAL_GAS_LIMIT = 500000; // gas
 var log_stdout = process.stdout;
 

--- a/scripts/minter-deployments/V3/generic-minter-deployer-v3core.ts
+++ b/scripts/minter-deployments/V3/generic-minter-deployer-v3core.ts
@@ -5,7 +5,7 @@ import { ethers } from "hardhat";
 import path from "path";
 import fs from "fs";
 var util = require("util");
-import { tryVerify } from "../util/verification";
+import { tryVerify } from "../../util/verification";
 
 // hide nuisance logs about event overloading
 import { Logger } from "@ethersproject/logger";
@@ -13,9 +13,11 @@ Logger.setLogLevel(Logger.levels.ERROR);
 import prompt from "prompt";
 
 // delay to avoid issues with reorgs and tx failures
-import { delay, getAppPath } from "../util/utils";
-import { DELEGATION_REGISTRY_ADDRESSES } from "../util/constants";
-const EXTRA_DELAY_BETWEEN_TX = 5000; // ms
+import { delay, getAppPath } from "../../util/utils";
+import {
+  DELEGATION_REGISTRY_ADDRESSES,
+  EXTRA_DELAY_BETWEEN_TX,
+} from "../../util/constants";
 
 /**
  * This script was created to deploy a generic minter contract to the Ethereum

--- a/scripts/randomizer-deployments/dev/1_reference_goerli-dev_randomizerPolyptych_deployer.ts
+++ b/scripts/randomizer-deployments/dev/1_reference_goerli-dev_randomizerPolyptych_deployer.ts
@@ -10,7 +10,7 @@ Logger.setLogLevel(Logger.levels.ERROR);
 
 // delay to avoid issues with reorgs and tx failures
 import { delay } from "../../util/utils";
-const EXTRA_DELAY_BETWEEN_TX = 5000; // ms
+import { EXTRA_DELAY_BETWEEN_TX } from "../../util/constants";
 
 /**
  * This script was created to deploy polyptych randomizer as required for the MinterPolyptychV0 contract to the Ethereum

--- a/scripts/util/constants.ts
+++ b/scripts/util/constants.ts
@@ -1,3 +1,7 @@
+// empirically have found adding 5 seconds between txs in scripts is enough to
+// avoid chain reorgs and tx failures
+export const EXTRA_DELAY_BETWEEN_TX = 5000; // ms
+
 // delegation registry addresses on supported networks
 export const DELEGATION_REGISTRY_ADDRESSES = {
   // note: same address for goerli and mainnet


### PR DESCRIPTION
## Description of the change

Export a unified extra delay time of 5 seconds, and use in deployment scripts.

This should help avoid the issue encountered in #566, since the generic deployer would now use a delay of 5 seconds instead of 1 second.
