### PR TITLE
Bug fix deployment etherscan links

### DIFF
--- a/contracts/libs/integration-refs/weth9/weth9.sol
+++ b/contracts/libs/integration-refs/weth9/weth9.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+
 // Copyright (C) 2015, 2016, 2017, 2019 Dapphub
 
 // This program is free software: you can redistribute it and/or modify

--- a/deployments/engine/V3/internal-testing/dev-example-2/DEPLOYMENTS.md
+++ b/deployments/engine/V3/internal-testing/dev-example-2/DEPLOYMENTS.md
@@ -1,4 +1,3 @@
-
 # Deployment
 
 Date: 2023-02-22T00:50:09.262Z
@@ -9,21 +8,19 @@ Date: 2023-02-22T00:50:09.262Z
 
 **Deployment Input File:** `deployments/engine/V3/internal-testing/dev-example-2/deployment-config.dev.ts`
 
-**GenArt721CoreV3_Engine:** https://etherscan.io/address/0x97B46d394924ca8196F3Cfb75434Ae3d66229dFC#code
+**GenArt721CoreV3_Engine:** https://goerli.etherscan.io/address/0x97B46d394924ca8196F3Cfb75434Ae3d66229dFC#code
 
-**AdminACLV1:** https://etherscan.io/address/0x6A07bec83A1241194609bf06b22Bf0b090A1cdf6#code
+**AdminACLV1:** https://goerli.etherscan.io/address/0x6A07bec83A1241194609bf06b22Bf0b090A1cdf6#code
 
-**Engine Registry:** https://etherscan.io/address/0x2A39132E8d594d2c840D6656327fB26d900C05bA#code
+**Engine Registry:** https://goerli.etherscan.io/address/0x2A39132E8d594d2c840D6656327fB26d900C05bA#code
 
-**MinterFilterV1:** https://etherscan.io/address/0xb666a50c127B6Ea2e8f523bE2dFb22648D5AB8FF#code
+**MinterFilterV1:** https://goerli.etherscan.io/address/0xb666a50c127B6Ea2e8f523bE2dFb22648D5AB8FF#code
 
 **Minters:**
 
-**MinterSetPriceV4:** https://etherscan.io/address/0xC9438D8021E0d1da6E94419F80bf7538A887eA70#code
+**MinterSetPriceV4:** https://goerli.etherscan.io/address/0xC9438D8021E0d1da6E94419F80bf7538A887eA70#code
 
-**MinterDAExpSettlementV1:** https://etherscan.io/address/0xd00F2D2ad7F7Fdc644Ce8A5ee622921c6E0ae779#code
-
-
+**MinterDAExpSettlementV1:** https://goerli.etherscan.io/address/0xd00F2D2ad7F7Fdc644Ce8A5ee622921c6E0ae779#code
 
 **Metadata**
 
@@ -41,4 +38,3 @@ Date: 2023-02-22T00:50:09.262Z
 - **Image Bucket:** test-engine-partner-autodeploy-goerli
 
 ---
-

--- a/deployments/engine/V3/internal-testing/dev-example-wins-demo/DEPLOYMENTS.md
+++ b/deployments/engine/V3/internal-testing/dev-example-wins-demo/DEPLOYMENTS.md
@@ -1,4 +1,3 @@
-
 # Deployment
 
 Date: 2023-03-03T18:15:32.253Z
@@ -9,21 +8,19 @@ Date: 2023-03-03T18:15:32.253Z
 
 **Deployment Input File:** `deployments/engine/V3/internal-testing/dev-example-wins-demo/deployment-config.dev.ts`
 
-**GenArt721CoreV3_Engine:** https://etherscan.io/address/0x4A185f9A8ee3d247fD564407658602228a8de265#code
+**GenArt721CoreV3_Engine:** https://goerli.etherscan.io/address/0x4A185f9A8ee3d247fD564407658602228a8de265#code
 
-**AdminACLV1:** https://etherscan.io/address/0x4210a9477d0B0e4FfB20Ec04c649DA9982803Ac2#code
+**AdminACLV1:** https://goerli.etherscan.io/address/0x4210a9477d0B0e4FfB20Ec04c649DA9982803Ac2#code
 
-**Engine Registry:** https://etherscan.io/address/0x2A39132E8d594d2c840D6656327fB26d900C05bA#code
+**Engine Registry:** https://goerli.etherscan.io/address/0x2A39132E8d594d2c840D6656327fB26d900C05bA#code
 
-**MinterFilterV1:** https://etherscan.io/address/0x19254c1226Dbb83EC08Ab07Ba0B5c3994792D9D8#code
+**MinterFilterV1:** https://goerli.etherscan.io/address/0x19254c1226Dbb83EC08Ab07Ba0B5c3994792D9D8#code
 
 **Minters:**
 
-**MinterSetPriceV4:** https://etherscan.io/address/0x2cf1978Cf9C66Ac98a9cb0259b9F4Ca51aF149f1#code
+**MinterSetPriceV4:** https://goerli.etherscan.io/address/0x2cf1978Cf9C66Ac98a9cb0259b9F4Ca51aF149f1#code
 
-**MinterDAExpSettlementV1:** https://etherscan.io/address/0xf1A6EF1FA55AbF58fC801109D622A0b68E142bF0#code
-
-
+**MinterDAExpSettlementV1:** https://goerli.etherscan.io/address/0xf1A6EF1FA55AbF58fC801109D622A0b68E142bF0#code
 
 **Metadata**
 
@@ -41,4 +38,3 @@ Date: 2023-03-03T18:15:32.253Z
 - **Image Bucket:** weekly-wins-demo-goerli
 
 ---
-

--- a/deployments/engine/V3/internal-testing/dev-example/DEPLOYMENTS.md
+++ b/deployments/engine/V3/internal-testing/dev-example/DEPLOYMENTS.md
@@ -1,4 +1,3 @@
-
 # Deployment
 
 Date: 2023-02-08T22:32:37.580Z
@@ -9,31 +8,29 @@ Date: 2023-02-08T22:32:37.580Z
 
 **Deployment Input File:** `deployments/engine/V3/internal-testing/dev-example/deployment-config.dev.ts`
 
-**GenArt721CoreV3_Engine:** https://etherscan.io/address/0x5702797Ff45FCb0a70eB6AE1E4563299dCFa9Dd6#code
+**GenArt721CoreV3_Engine:** https://goerli.etherscan.io/address/0x5702797Ff45FCb0a70eB6AE1E4563299dCFa9Dd6#code
 
-**AdminACLV1:** https://etherscan.io/address/0x8CD0035E53816EED79aA96aB1442114400731D74#code
+**AdminACLV1:** https://goerli.etherscan.io/address/0x8CD0035E53816EED79aA96aB1442114400731D74#code
 
-**Engine Registry:** https://etherscan.io/address/0x2A39132E8d594d2c840D6656327fB26d900C05bA#code
+**Engine Registry:** https://goerli.etherscan.io/address/0x2A39132E8d594d2c840D6656327fB26d900C05bA#code
 
-**MinterFilterV1:** https://etherscan.io/address/0x72AE7160A580893Fb1049D17Fbd736Ad39Ea7FbD#code
+**MinterFilterV1:** https://goerli.etherscan.io/address/0x72AE7160A580893Fb1049D17Fbd736Ad39Ea7FbD#code
 
 **Minters:**
 
-**MinterSetPriceV4:** https://etherscan.io/address/0x293293BCb2f18D02EB4C451ecf39d7f5c1BD55f9#code
+**MinterSetPriceV4:** https://goerli.etherscan.io/address/0x293293BCb2f18D02EB4C451ecf39d7f5c1BD55f9#code
 
-**MinterSetPriceERC20V4:** https://etherscan.io/address/0xa6c7eEB30b0FFB04e87080093c77629A147bA4fB#code
+**MinterSetPriceERC20V4:** https://goerli.etherscan.io/address/0xa6c7eEB30b0FFB04e87080093c77629A147bA4fB#code
 
-**MinterDAExpV4:** https://etherscan.io/address/0x7eaC47C4e712e3A2094F453C35f3Ef9ef73e8986#code
+**MinterDAExpV4:** https://goerli.etherscan.io/address/0x7eaC47C4e712e3A2094F453C35f3Ef9ef73e8986#code
 
-**MinterDAExpSettlementV1:** https://etherscan.io/address/0xaBEDC313274eFF4895cbbE35d29f054d00352e0a#code
+**MinterDAExpSettlementV1:** https://goerli.etherscan.io/address/0xaBEDC313274eFF4895cbbE35d29f054d00352e0a#code
 
-**MinterDALinV4:** https://etherscan.io/address/0x2f7174b0c780adaD89f1deA0D41BE31A1F578a38#code
+**MinterDALinV4:** https://goerli.etherscan.io/address/0x2f7174b0c780adaD89f1deA0D41BE31A1F578a38#code
 
-**MinterHolderV4:** https://etherscan.io/address/0x98aAd1504420219f95486feF1f7A00E901043cfB#code
+**MinterHolderV4:** https://goerli.etherscan.io/address/0x98aAd1504420219f95486feF1f7A00E901043cfB#code
 
-**MinterMerkleV5:** https://etherscan.io/address/0xcab32b53DA814659A6B36F29768F30ea4f5B4F3F#code
-
-
+**MinterMerkleV5:** https://goerli.etherscan.io/address/0xcab32b53DA814659A6B36F29768F30ea4f5B4F3F#code
 
 **Metadata**
 
@@ -52,7 +49,6 @@ Date: 2023-02-08T22:32:37.580Z
 
 ---
 
-
 # Minter Deployment
 
 Date: 2023-02-16T00:13:46.593Z
@@ -63,7 +59,7 @@ Date: 2023-02-16T00:13:46.593Z
 
 **Deployment Input File:** `deployments/engine/V3/internal-testing/dev-example/minter-deploy-config-01.dev.ts`
 
-**MinterDAExpSettlementV2:** https://etherscan.io/address/0x1732eA26A4dbA4863527F7Eee4a9272607fE9db6#code
+**MinterDAExpSettlementV2:** https://goerli.etherscan.io/address/0x1732eA26A4dbA4863527F7Eee4a9272607fE9db6#code
 
 **Associated core contract:** 0x5702797Ff45FCb0a70eB6AE1E4563299dCFa9Dd6
 
@@ -72,4 +68,3 @@ Date: 2023-02-16T00:13:46.593Z
 **Deployment Args:** 0x5702797Ff45FCb0a70eB6AE1E4563299dCFa9Dd6,0x72AE7160A580893Fb1049D17Fbd736Ad39Ea7FbD
 
 ---
-

--- a/deployments/engine/V3/partners/dev-example-flex/DEPLOYMENTS.md
+++ b/deployments/engine/V3/partners/dev-example-flex/DEPLOYMENTS.md
@@ -1,4 +1,3 @@
-
 # Deployment
 
 Date: 2023-02-22T20:50:43.959Z
@@ -9,19 +8,17 @@ Date: 2023-02-22T20:50:43.959Z
 
 **Deployment Input File:** `deployments/engine/V3/partners/dev-example-flex/deployment-config.dev.ts`
 
-**GenArt721CoreV3_Engine_Flex:** https://etherscan.io/address/0xd2363Acbf8CdF01A5FdfcB8f0295e0a5dF94518D#code
+**GenArt721CoreV3_Engine_Flex:** https://goerli.etherscan.io/address/0xd2363Acbf8CdF01A5FdfcB8f0295e0a5dF94518D#code
 
-**AdminACLV1:** https://etherscan.io/address/0x2e84869f024c90445A35DB81cD7940A206520848#code
+**AdminACLV1:** https://goerli.etherscan.io/address/0x2e84869f024c90445A35DB81cD7940A206520848#code
 
-**Engine Registry:** https://etherscan.io/address/0x263113c07CB69eE047E6572E135E8C3C6302feFE#code
+**Engine Registry:** https://goerli.etherscan.io/address/0x263113c07CB69eE047E6572E135E8C3C6302feFE#code
 
-**MinterFilterV1:** https://etherscan.io/address/0x2c321e8306E9F8843562313c32F39833a1C2966b#code
+**MinterFilterV1:** https://goerli.etherscan.io/address/0x2c321e8306E9F8843562313c32F39833a1C2966b#code
 
 **Minters:**
 
-**MinterSetPriceV4:** https://etherscan.io/address/0xB2670C23F6dFce72c913B9f039162d9470CE4d06#code
-
-
+**MinterSetPriceV4:** https://goerli.etherscan.io/address/0xB2670C23F6dFce72c913B9f039162d9470CE4d06#code
 
 **Metadata**
 
@@ -39,4 +36,3 @@ Date: 2023-02-22T20:50:43.959Z
 - **Image Bucket:** engine-partner-flex-goerli
 
 ---
-

--- a/deployments/engine/V3/partners/dev-example/DEPLOYMENTS.md
+++ b/deployments/engine/V3/partners/dev-example/DEPLOYMENTS.md
@@ -1,4 +1,3 @@
-
 # Deployment
 
 Date: 2023-02-22T00:08:49.944Z
@@ -9,19 +8,17 @@ Date: 2023-02-22T00:08:49.944Z
 
 **Deployment Input File:** `deployments/engine/V3/partners/dev-example/deployment-config.dev.ts`
 
-**GenArt721CoreV3_Engine:** https://etherscan.io/address/0x5b224b92b8673B5762C4212EC9f7B86918657Ee6#code
+**GenArt721CoreV3_Engine:** https://goerli.etherscan.io/address/0x5b224b92b8673B5762C4212EC9f7B86918657Ee6#code
 
-**AdminACLV1:** https://etherscan.io/address/0x0882de23BeC1b99D9AcEe8B04eA9Bae69b8664d3#code
+**AdminACLV1:** https://goerli.etherscan.io/address/0x0882de23BeC1b99D9AcEe8B04eA9Bae69b8664d3#code
 
-**Engine Registry:** https://etherscan.io/address/0x263113c07CB69eE047E6572E135E8C3C6302feFE#code
+**Engine Registry:** https://goerli.etherscan.io/address/0x263113c07CB69eE047E6572E135E8C3C6302feFE#code
 
-**MinterFilterV1:** https://etherscan.io/address/0x2ce218A94a8ffBe78a2C67FE9b302D66d3C42e6e#code
+**MinterFilterV1:** https://goerli.etherscan.io/address/0x2ce218A94a8ffBe78a2C67FE9b302D66d3C42e6e#code
 
 **Minters:**
 
-**MinterSetPriceV4:** https://etherscan.io/address/0xde1486A8aF6170707C98dd87F8Ff35BE80db7F7b#code
-
-
+**MinterSetPriceV4:** https://goerli.etherscan.io/address/0xde1486A8aF6170707C98dd87F8Ff35BE80db7F7b#code
 
 **Metadata**
 
@@ -39,4 +36,3 @@ Date: 2023-02-22T00:08:49.944Z
 - **Image Bucket:** engine-partner-goerli
 
 ---
-

--- a/scripts/engine/V3/generic-engine-deployer.ts
+++ b/scripts/engine/V3/generic-engine-deployer.ts
@@ -482,6 +482,8 @@ async function main() {
     //////////////////////////////////////////////////////////////////////////////
 
     const outputSummaryFile = path.join(inputFileDirectory, "DEPLOYMENTS.md");
+    const etherscanSubdomain =
+      networkName === "mainnet" ? "" : `${networkName}.`;
     const outputMd = `
 # Deployment
 
@@ -493,19 +495,23 @@ Date: ${new Date().toISOString()}
 
 **Deployment Input File:** \`${deploymentConfigFile}\`
 
-**${deployDetails.genArt721CoreContractName}:** https://etherscan.io/address/${
+**${
+      deployDetails.genArt721CoreContractName
+    }:** https://${etherscanSubdomain}etherscan.io/address/${
       genArt721Core.address
     }#code
 
 **${
       deployDetails.adminACLContractName
-    }:** https://etherscan.io/address/${adminACLAddress}#code
+    }:** https://${etherscanSubdomain}etherscan.io/address/${adminACLAddress}#code
 
-**Engine Registry:** https://etherscan.io/address/${
+**Engine Registry:** https://${etherscanSubdomain}etherscan.io/address/${
       deployDetails.engineRegistryAddress
     }#code
 
-**${deployDetails.minterFilterContractName}:** https://etherscan.io/address/${
+**${
+      deployDetails.minterFilterContractName
+    }:** https://${etherscanSubdomain}etherscan.io/address/${
       minterFilter.address
     }#code
 
@@ -513,7 +519,7 @@ Date: ${new Date().toISOString()}
 
 ${deployedMinterNames
   .map((minterName, i) => {
-    return `**${minterName}:** https://etherscan.io/address/${deployedMinterAddresses[i]}#code
+    return `**${minterName}:** https://${etherscanSubdomain}etherscan.io/address/${deployedMinterAddresses[i]}#code
 
 `;
   })

--- a/scripts/minter-deployments/V3/generic-minter-deployer-v3core.ts
+++ b/scripts/minter-deployments/V3/generic-minter-deployer-v3core.ts
@@ -149,6 +149,8 @@ async function main() {
     //////////////////////////////////////////////////////////////////////////////
 
     const outputSummaryFile = path.join(inputFileDirectory, "DEPLOYMENTS.md");
+    const etherscanSubdomain =
+      networkName === "mainnet" ? "" : `${networkName}.`;
     const outputMd = `
 # Minter Deployment
 
@@ -162,7 +164,7 @@ Date: ${new Date().toISOString()}
 
 **${
       deployDetails.minterName
-    }:** https://etherscan.io/address/${minterAddress}#code
+    }:** https://${etherscanSubdomain}etherscan.io/address/${minterAddress}#code
 
 **Associated core contract:** ${deployDetails.genArt721V3CoreAddress}
 


### PR DESCRIPTION
## Description of the change

Fix bug in how generic scripts have been outputting testnet etherscan links.

This PR updates the generic scripts that contain the bug, and also updates the handful of deployment markdown files that were output while the bug was still active.

also contains a SPDX license ID to an integration reference contract to silence an nuisance warning in the compiler.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204253284032273