### PR TITLE
Update SEA minter with constructor events

### DIFF
--- a/contracts/minter-suite/Minters/MinterSEAV0.sol
+++ b/contracts/minter-suite/Minters/MinterSEAV0.sol
@@ -251,6 +251,16 @@ contract MinterSEAV0 is ReentrancyGuard, MinterBase, IFilteredMinterSEAV0 {
             "Illegal contract pairing"
         );
         weth = IWETH(_wethAddress);
+        // emit events indicating default minter configuration values
+        emit AuctionDurationSecondsRangeUpdated(
+            minAuctionDurationSeconds,
+            maxAuctionDurationSeconds
+        );
+        emit MinterMinBidIncrementPercentageUpdated(
+            minterMinBidIncrementPercentage
+        );
+        emit MinterTimeBufferUpdated(minterTimeBufferSeconds);
+        emit MinterRefundGasLimitUpdated(minterRefundGasLimit);
     }
 
     /**


### PR DESCRIPTION
## Description of the change

Update the SEA minter to emit events during contract construction to automatically populate subgraph with default configuration values.
