### PR TITLE
bug fix - SEA minter - mint next token with auth of msg.sender

### DIFF
--- a/contracts/minter-suite/Minters/MinterSEAV0.sol
+++ b/contracts/minter-suite/Minters/MinterSEAV0.sol
@@ -1078,6 +1078,10 @@ contract MinterSEAV0 is ReentrancyGuard, MinterBase, IFilteredMinterSEAV0 {
      *     contract or minter
      *   - the project config's `nextTokenNumberIsPopulated` is already true
      * @param _projectId The ID of the project to mint a new token for.
+     * @dev this calls mint with `msg.sender` as the sender, allowing artists
+     * to mint tokens to the next token slot for their project while a project
+     * is still paused. This happens when an artist is configuring their
+     * project's auction parameters or minter max invocations.
      */
     function _tryMintTokenToNextSlot(uint256 _projectId) internal {
         ProjectConfig storage _projectConfig = projectConfig[_projectId];
@@ -1114,7 +1118,7 @@ contract MinterSEAV0 is ReentrancyGuard, MinterBase, IFilteredMinterSEAV0 {
         uint256 nextTokenId = minterFilter.mint(
             address(this),
             _projectId,
-            address(this)
+            msg.sender
         );
         // update state to reflect new token number
         // @dev state changes after trusted contract interaction

--- a/test/minter-suite-minters/SEA/MinterSEAV0.test.ts
+++ b/test/minter-suite-minters/SEA/MinterSEAV0.test.ts
@@ -209,6 +209,27 @@ for (const coreContractName of coreContractsToTest) {
           );
         });
 
+        it("allows artist to call when project is paused", async function () {
+          const config = await loadFixture(_beforeEach);
+          // use project one, because it has not yet been configured on the minter
+          await safeAddProject(
+            config.genArt721Core,
+            config.accounts.deployer,
+            config.accounts.artist2.address
+          );
+          // make project active, but not unpaused, and configure minter
+          await config.genArt721Core
+            .connect(config.accounts.deployer)
+            .toggleProjectIsActive(config.projectOne);
+          await config.minterFilter
+            .connect(config.accounts.deployer)
+            .setMinterForProject(config.projectOne, config.minter.address);
+          // manually limit minter max invocations, which tries to mint a token to next slot
+          await config.minter
+            .connect(config.accounts.artist2)
+            .manuallyLimitProjectMaxInvocations(config.projectOne, 50);
+        });
+
         it("reverts for unconfigured/non-existent project", async function () {
           const config = await loadFixture(_beforeEach);
           // trying to set config on unconfigured project (e.g. 99) should cause


### PR DESCRIPTION
## Description of the change

Update SEA minter to mint next token with auth of `msg.sender` to enable artists to configure projects while paused.

This correctly handles the scenario where an artist is configuring their auction or minter max invocations while their project is still paused.

>note: this bug fix does not patch anything that would result in loss of funds. additionally, the SEA minter has only been deployed to the dev environment, and the deployed minter will be removed from the minter filter to prevent non-fixed versions of this minter being used (even on dev).
