### PR TITLE
Dependabot: igore gnosis safe version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,15 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: "daily"
+    # ignore updates to these packages
+    ignore:
+      - dependency-name: "@gnosis.pm/safe-*"
+        update-types:
+          [
+            "version-update:semver-patch",
+            "version-update:semver-minor",
+            "version-update:semver-major",
+          ]
     # Add proper reviewers to the PR
     reviewers:
       - "ArtBlocks/eng-approvers-contracts"


### PR DESCRIPTION
## Description of the change

Eliminate nuisance bump reminders to my email by configuring dependabot to ignore gnosis safe updates.

Using the outdated gnosis safe is fine, because we intend to support all gnosis safe wallets on our minter contracts, and using an outdated gnosis safe still accomplishes that goal 😃 