### PR TITLE
Fixed V3_PERFORMANCE.md link

### DIFF
--- a/contracts/V3_CHANGELOG.md
+++ b/contracts/V3_CHANGELOG.md
@@ -2,7 +2,7 @@
 
 _This document is intended to document and explain the Art Blocks Core V3 changes, relative to the Art Blocks Core V1 contract_
 
-V3 performance metrics are available in [V3_Performance.md](V3_Performance.md)
+V3 performance metrics are available in [V3_Performance.md](V3_PERFORMANCE.md)
 
 ## The following changes were made in the Core V3 contract:
 


### PR DESCRIPTION
## Description of the change

\<add description here\>

> reminder: Any mainnet deployments after 10 Jan 2023 should be tagged as [Releases](https://github.com/ArtBlocks/artblocks-contracts/releases) in this repository. This ensures that the deployed contract source code is easily verifiable by anyone.
