### PR TITLE
fix ci coverage config for recent update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
           name: save coverage
           command: |
             mkdir -p /tmp/coverage
-            cp coverage.json /tmp/coverage/cov_$CIRCLE_NODE_INDEX.json
+            cp coverage-final.json /tmp/coverage/cov_$CIRCLE_NODE_INDEX.json
             chmod -R 777 /tmp/coverage/cov_$CIRCLE_NODE_INDEX.json
       - persist_to_workspace:
           root: /tmp/coverage


### PR DESCRIPTION
## Description of the change

Fix ci coverage config for recent update to hardhat in #622

(the coverage output json has a new filename)
