### PR TITLE
added new testnet minter info

### DIFF
--- a/deployments/engine/V3/partners/fab/DEPLOYMENTS.md
+++ b/deployments/engine/V3/partners/fab/DEPLOYMENTS.md
@@ -21,6 +21,8 @@ Date: 2023-03-29T02:20:12.708Z
 
 **MinterSetPriceV4:** https://goerli.etherscan.io/address/0x7cd616910828Ef88Bd6882CCb7992061D6aE2AF3#code
 
+**MinterDAExpV4:** https://goerli.etherscan.io/address/0x568D0078D8AFf828d78637209a752f92526150Bf#code
+
 
 
 **Metadata**


### PR DESCRIPTION
## Description of the change

Included DA without settlement Goerli deployment address

> reminder: Any mainnet deployments after 10 Jan 2023 should be tagged as [Releases](https://github.com/ArtBlocks/artblocks-contracts/releases) in this repository. This ensures that the deployed contract source code is easily verifiable by anyone.
