### PR TITLE
try/catch generic minter deployment minter filter allowlisting

### DIFF
--- a/deployments/engine/V3/internal-testing/dev-example/DEPLOYMENTS.md
+++ b/deployments/engine/V3/internal-testing/dev-example/DEPLOYMENTS.md
@@ -111,3 +111,24 @@ Date: 2023-03-29T23:00:21.255Z
 
 ---
 
+
+# Minter Deployment
+
+Date: 2023-04-14T17:44:04.123Z
+
+## **Network:** goerli
+
+## **Environment:** dev
+
+**Deployment Input File:** `deployments/engine/V3/internal-testing/dev-example/minter-deploy-config-03.dev.ts`
+
+**MinterSEAV0:** https://goerli.etherscan.io/address/0x087D238971e11CCbF04268B9A55912C7e5dD6464#code
+
+**Associated core contract:** 0x5702797Ff45FCb0a70eB6AE1E4563299dCFa9Dd6
+
+**Associated minter filter:** 0x72AE7160A580893Fb1049D17Fbd736Ad39Ea7FbD
+
+**Deployment Args:** 0x5702797Ff45FCb0a70eB6AE1E4563299dCFa9Dd6,0x72AE7160A580893Fb1049D17Fbd736Ad39Ea7FbD,0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6
+
+---
+

--- a/deployments/engine/V3/internal-testing/dev-example/MINTER_DEPLOYMENT_LOGS.log
+++ b/deployments/engine/V3/internal-testing/dev-example/MINTER_DEPLOYMENT_LOGS.log
@@ -51,26 +51,6 @@ for verification on the block explorer. Waiting for verification result...
 Successfully verified contract MinterSEAV0 on Etherscan.
 https://goerli.etherscan.io/address/0x7cd69aa289BDb64AB8139F896a9FF7B8c8fB5a2B#code
 ----------------------------------------
-[INFO] Datetime of minter deployment: 2023-04-14T17:37:24.642Z
-[INFO] Minter deployment configuration file: /Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/deployments/engine/V3/internal-testing/dev-example/minter-deploy-config-03.dev.ts
-[INFO] Deploying to network: goerli
-[INFO] Deploying MinterSEAV0 with deploy args [0x5702797Ff45FCb0a70eB6AE1E4563299dCFa9Dd6,0x72AE7160A580893Fb1049D17Fbd736Ad39Ea7FbD,0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6]...
-----------------------------------------
-[INFO] Datetime of minter deployment: 2023-04-14T17:38:09.875Z
-[INFO] Minter deployment configuration file: /Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/deployments/engine/V3/internal-testing/dev-example/minter-deploy-config-03.dev.ts
-[INFO] Deploying to network: goerli
-[INFO] Deploying MinterSEAV0 with deploy args [0x5702797Ff45FCb0a70eB6AE1E4563299dCFa9Dd6,0x72AE7160A580893Fb1049D17Fbd736Ad39Ea7FbD,0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6]...
-----------------------------------------
-[INFO] Datetime of minter deployment: 2023-04-14T17:38:36.200Z
-[INFO] Minter deployment configuration file: /Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/deployments/engine/V3/internal-testing/dev-example/minter-deploy-config-03.dev.ts
-[INFO] Deploying to network: goerli
-[INFO] Deploying MinterSEAV0 with deploy args [0x5702797Ff45FCb0a70eB6AE1E4563299dCFa9Dd6,0x72AE7160A580893Fb1049D17Fbd736Ad39Ea7FbD,0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6]...
-----------------------------------------
-[INFO] Datetime of minter deployment: 2023-04-14T17:40:33.585Z
-[INFO] Minter deployment configuration file: /Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/deployments/engine/V3/internal-testing/dev-example/minter-deploy-config-03.dev.ts
-[INFO] Deploying to network: goerli
-[INFO] Deploying MinterSEAV0 with deploy args [0x5702797Ff45FCb0a70eB6AE1E4563299dCFa9Dd6,0x72AE7160A580893Fb1049D17Fbd736Ad39Ea7FbD,0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6]...
-----------------------------------------
 [INFO] Datetime of minter deployment: 2023-04-14T17:42:38.156Z
 [INFO] Minter deployment configuration file: /Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/deployments/engine/V3/internal-testing/dev-example/minter-deploy-config-03.dev.ts
 [INFO] Deploying to network: goerli

--- a/deployments/engine/V3/internal-testing/dev-example/MINTER_DEPLOYMENT_LOGS.log
+++ b/deployments/engine/V3/internal-testing/dev-example/MINTER_DEPLOYMENT_LOGS.log
@@ -50,3 +50,67 @@ for verification on the block explorer. Waiting for verification result...
 
 Successfully verified contract MinterSEAV0 on Etherscan.
 https://goerli.etherscan.io/address/0x7cd69aa289BDb64AB8139F896a9FF7B8c8fB5a2B#code
+----------------------------------------
+[INFO] Datetime of minter deployment: 2023-04-14T17:37:24.642Z
+[INFO] Minter deployment configuration file: /Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/deployments/engine/V3/internal-testing/dev-example/minter-deploy-config-03.dev.ts
+[INFO] Deploying to network: goerli
+[INFO] Deploying MinterSEAV0 with deploy args [0x5702797Ff45FCb0a70eB6AE1E4563299dCFa9Dd6,0x72AE7160A580893Fb1049D17Fbd736Ad39Ea7FbD,0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6]...
+----------------------------------------
+[INFO] Datetime of minter deployment: 2023-04-14T17:38:09.875Z
+[INFO] Minter deployment configuration file: /Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/deployments/engine/V3/internal-testing/dev-example/minter-deploy-config-03.dev.ts
+[INFO] Deploying to network: goerli
+[INFO] Deploying MinterSEAV0 with deploy args [0x5702797Ff45FCb0a70eB6AE1E4563299dCFa9Dd6,0x72AE7160A580893Fb1049D17Fbd736Ad39Ea7FbD,0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6]...
+----------------------------------------
+[INFO] Datetime of minter deployment: 2023-04-14T17:38:36.200Z
+[INFO] Minter deployment configuration file: /Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/deployments/engine/V3/internal-testing/dev-example/minter-deploy-config-03.dev.ts
+[INFO] Deploying to network: goerli
+[INFO] Deploying MinterSEAV0 with deploy args [0x5702797Ff45FCb0a70eB6AE1E4563299dCFa9Dd6,0x72AE7160A580893Fb1049D17Fbd736Ad39Ea7FbD,0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6]...
+----------------------------------------
+[INFO] Datetime of minter deployment: 2023-04-14T17:40:33.585Z
+[INFO] Minter deployment configuration file: /Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/deployments/engine/V3/internal-testing/dev-example/minter-deploy-config-03.dev.ts
+[INFO] Deploying to network: goerli
+[INFO] Deploying MinterSEAV0 with deploy args [0x5702797Ff45FCb0a70eB6AE1E4563299dCFa9Dd6,0x72AE7160A580893Fb1049D17Fbd736Ad39Ea7FbD,0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6]...
+----------------------------------------
+[INFO] Datetime of minter deployment: 2023-04-14T17:42:38.156Z
+[INFO] Minter deployment configuration file: /Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/deployments/engine/V3/internal-testing/dev-example/minter-deploy-config-03.dev.ts
+[INFO] Deploying to network: goerli
+[INFO] Deploying MinterSEAV0 with deploy args [0x5702797Ff45FCb0a70eB6AE1E4563299dCFa9Dd6,0x72AE7160A580893Fb1049D17Fbd736Ad39Ea7FbD,0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6]...
+[INFO] MinterSEAV0 deployed at 0x087D238971e11CCbF04268B9A55912C7e5dD6464
+Error: cannot estimate gas; transaction may fail or may require manual gas limit [ See: https://links.ethers.org/v5-errors-UNPREDICTABLE_GAS_LIMIT ] (reason="execution reverted: Only Core AdminACL allowed", method="estimateGas", transaction={"from":"0x215e83b62424cb4337573a66a759f813913826b3","to":"0x72AE7160A580893Fb1049D17Fbd736Ad39Ea7FbD","data":"0xbee4d106000000000000000000000000087d238971e11ccbf04268b9a55912c7e5dd6464","accessList":null}, error={"name":"ProviderError","_stack":"ProviderError: execution reverted: Only Core AdminACL allowed\n    at HttpProvider.request (/Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/node_modules/hardhat/src/internal/core/providers/http.ts:88:21)\n    at processTicksAndRejections (node:internal/process/task_queues:96:5)\n    at EthersProviderWrapper.send (/Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/node_modules/@nomiclabs/hardhat-ethers/src/internal/ethers-provider-wrapper.ts:13:20)","code":3,"_isProviderError":true,"data":"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001a4f6e6c7920436f72652041646d696e41434c20616c6c6f776564000000000000"}, code=UNPREDICTABLE_GAS_LIMIT, version=providers/5.7.2)
+    at Logger.makeError (/Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/node_modules/@ethersproject/logger/src.ts/index.ts:269:28)
+    at Logger.throwError (/Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/node_modules/@ethersproject/logger/src.ts/index.ts:281:20)
+    at checkError (/Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/node_modules/@ethersproject/providers/src.ts/json-rpc-provider.ts:78:20)
+    at EthersProviderWrapper.<anonymous> (/Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/node_modules/@ethersproject/providers/src.ts/json-rpc-provider.ts:642:20)
+    at step (/Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/node_modules/@ethersproject/providers/lib/json-rpc-provider.js:48:23)
+    at Object.throw (/Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/node_modules/@ethersproject/providers/lib/json-rpc-provider.js:29:53)
+    at rejected (/Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/node_modules/@ethersproject/providers/lib/json-rpc-provider.js:21:65)
+    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
+  reason: 'execution reverted: Only Core AdminACL allowed',
+  code: 'UNPREDICTABLE_GAS_LIMIT',
+  method: 'estimateGas',
+  transaction: {
+    from: '0x215e83b62424cb4337573a66a759f813913826b3',
+    to: '0x72AE7160A580893Fb1049D17Fbd736Ad39Ea7FbD',
+    data: '0xbee4d106000000000000000000000000087d238971e11ccbf04268b9a55912c7e5dd6464',
+    accessList: null
+  },
+  error: ProviderError: execution reverted: Only Core AdminACL allowed
+      at HttpProvider.request (/Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/node_modules/hardhat/src/internal/core/providers/http.ts:88:21)
+      at processTicksAndRejections (node:internal/process/task_queues:96:5)
+      at EthersProviderWrapper.send (/Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/node_modules/@nomiclabs/hardhat-ethers/src/internal/ethers-provider-wrapper.ts:13:20)
+}
+[ERROR] unable to allowlist the new minter on the minter filter at 0x72AE7160A580893Fb1049D17Fbd736Ad39Ea7FbD
+[INFO] this may be because the minter filter has already been transferred to a partner's wallet
+[INFO] Verifying MinterSEAV0 contract deployment...
+Nothing to compile
+Successfully submitted source code for contract
+contracts/minter-suite/Minters/MinterSEAV0.sol:MinterSEAV0 at 0x087D238971e11CCbF04268B9A55912C7e5dD6464
+for verification on the block explorer. Waiting for verification result...
+
+Successfully verified contract MinterSEAV0 on Etherscan.
+https://goerli.etherscan.io/address/0x087D238971e11CCbF04268B9A55912C7e5dD6464#code
+[INFO] MinterSEAV0 contract verified on Etherscan at 0x087D238971e11CCbF04268B9A55912C7e5dD6464}
+[INFO] Minter deployment details written/appended to /Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/deployments/engine/V3/internal-testing/dev-example/DEPLOYMENTS.md
+[INFO] Completed minter deployment! MinterSEAV0 deployed to 0x087D238971e11CCbF04268B9A55912C7e5dD6464, and allowlisted on the minter filter at 0x72AE7160A580893Fb1049D17Fbd736Ad39Ea7FbD
+[ACTION] If this minter is to be indexed in a subgraph, ensure it is added to the subgraph's config.
+[ACTION] The minter was not able to be allowlisted on the minter filter, ensure the minter filter is updated by appropriate admin.

--- a/deployments/engine/V3/internal-testing/dev-example/minter-deploy-config-03.dev.ts
+++ b/deployments/engine/V3/internal-testing/dev-example/minter-deploy-config-03.dev.ts
@@ -1,0 +1,14 @@
+// This file is used to configure the deployment of minter contracts
+// It is intended to be imported by the generic minter deployer in `/scripts/minter-deployments/generic-minter-deployer-v3core.ts`
+
+export const minterDeployDetailsArray = [
+  {
+    network: "goerli",
+    // environment is only used for metadata purposes, and is not used in the deployment process
+    // Please set to "dev", "staging", or "mainnet", as appropriate
+    environment: "dev",
+    minterName: "MinterSEAV0",
+    genArt721V3CoreAddress: "0x5702797Ff45FCb0a70eB6AE1E4563299dCFa9Dd6",
+    minterFilterAddress: "0x72AE7160A580893Fb1049D17Fbd736Ad39Ea7FbD",
+  },
+];

--- a/deployments/engine/V3/partners/fab/DEPLOYMENTS.md
+++ b/deployments/engine/V3/partners/fab/DEPLOYMENTS.md
@@ -1,4 +1,3 @@
-
 # Deployment
 
 Date: 2023-03-29T02:20:12.708Z
@@ -21,10 +20,6 @@ Date: 2023-03-29T02:20:12.708Z
 
 **MinterSetPriceV4:** https://goerli.etherscan.io/address/0x7cd616910828Ef88Bd6882CCb7992061D6aE2AF3#code
 
-**MinterDAExpV4:** https://goerli.etherscan.io/address/0x568D0078D8AFf828d78637209a752f92526150Bf#code
-
-
-
 **Metadata**
 
 - **Starting Project Id:** 0
@@ -42,3 +37,22 @@ Date: 2023-03-29T02:20:12.708Z
 
 ---
 
+# Minter Deployment
+
+Date: 2023-04-14
+
+## **Network:** goerli
+
+## **Environment:** staging
+
+**Deployment Input File:** `deployments/engine/V3/partners/fab/minter-deploy-config.dev.ts`
+
+**MinterDAExpV4:** https://goerli.etherscan.io/address/0x568D0078D8AFf828d78637209a752f92526150Bf#code
+
+**Associated core contract:** 0x043Eeb8bFd416666b57dd2C5Be439e6fB23e9ce1
+
+**Associated minter filter:** 0x1A6b570499195139E38Cfa56044Dd748839beE1A
+
+**Deployment Args:** 0x043Eeb8bFd416666b57dd2C5Be439e6fB23e9ce1,0x1A6b570499195139E38Cfa56044Dd748839beE1A
+
+---

--- a/deployments/engine/V3/partners/hodlers-projects/DEPLOYMENTS.md
+++ b/deployments/engine/V3/partners/hodlers-projects/DEPLOYMENTS.md
@@ -1,4 +1,3 @@
-
 # Deployment
 
 Date: 2023-03-29T02:45:29.928Z
@@ -25,8 +24,6 @@ Date: 2023-03-29T02:45:29.928Z
 
 **MinterHolderV2:** https://goerli.etherscan.io/address/0xc3EA837e7595d3839Ec26546C4B14b2CDE8B0E93#code
 
-
-
 **Metadata**
 
 - **Starting Project Id:** 1
@@ -43,7 +40,6 @@ Date: 2023-03-29T02:45:29.928Z
 - **Image Bucket:** hodlers-projects-goerli
 
 ---
-
 
 # Deployment
 
@@ -69,8 +65,6 @@ Date: 2023-03-31T00:34:16.052Z
 
 **MinterMerkleV5:** https://etherscan.io/address/0xcBA628BcF6f458f6F929d875B69FE5f0F3fB99b6#code
 
-
-
 **Metadata**
 
 - **Starting Project Id:** 1
@@ -88,3 +82,22 @@ Date: 2023-03-31T00:34:16.052Z
 
 ---
 
+# Minter Deployment
+
+Date: 2023-04-14
+
+## **Network:** mainnet
+
+## **Environment:** dev
+
+**Deployment Input File:** `deployments/engine/V3/partners/hodlers-projects/minter-deploy-config.mainnet.ts`
+
+**MinterSetPriceV4:** https://etherscan.io/address/0x0eB38A2666A74a8d4a8cb4E718B699E1651a4893#code
+
+**Associated core contract:** 0xD00495689D5161C511882364E0C342e12Dcc5f08
+
+**Associated minter filter:** 0xB64116A7D5D84fE9795DD022ea191217A2e32076
+
+**Deployment Args:** 0xD00495689D5161C511882364E0C342e12Dcc5f08,0xB64116A7D5D84fE9795DD022ea191217A2e32076
+
+---

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -46,7 +46,7 @@ module.exports = {
       url: GOERLI_JSON_RPC_PROVIDER_URL,
       accounts: [`0x${TESTNET_PRIVATE_KEY}`],
       gasPrice: "auto",
-      gasMultiplier: 1.0,
+      gasMultiplier: 4.0,
     },
     palm_mainnet: {
       url: PALM_MAINNET_JSON_RPC_PROVIDER_URL,

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -46,7 +46,7 @@ module.exports = {
       url: GOERLI_JSON_RPC_PROVIDER_URL,
       accounts: [`0x${TESTNET_PRIVATE_KEY}`],
       gasPrice: "auto",
-      gasMultiplier: 4.0,
+      gasMultiplier: 1.0,
     },
     palm_mainnet: {
       url: PALM_MAINNET_JSON_RPC_PROVIDER_URL,

--- a/scripts/minter-deployments/V3/generic-minter-deployer-v3core.ts
+++ b/scripts/minter-deployments/V3/generic-minter-deployer-v3core.ts
@@ -138,11 +138,23 @@ async function main() {
       "MinterFilterV1",
       deployDetails.minterFilterAddress
     );
-    await minterFilterContract.addApprovedMinter(minterAddress);
-    console.log(
-      `[INFO] allowlisted the new minter on the minter filter at ${deployDetails.minterFilterAddress}`
-    );
-    await delay(EXTRA_DELAY_BETWEEN_TX);
+    let successfulAllowlist = false;
+    try {
+      await minterFilterContract.addApprovedMinter(minterAddress);
+      console.log(
+        `[INFO] allowlisted the new minter on the minter filter at ${deployDetails.minterFilterAddress}`
+      );
+      successfulAllowlist = true;
+      await delay(EXTRA_DELAY_BETWEEN_TX);
+    } catch (error) {
+      console.log(error);
+      console.log(
+        `[ERROR] unable to allowlist the new minter on the minter filter at ${deployDetails.minterFilterAddress}`
+      );
+      console.log(
+        `[INFO] this may be because the minter filter has already been transferred to a partner's wallet`
+      );
+    }
 
     // Attempt to verify source code on Etherscan
     await tryVerify(
@@ -204,6 +216,13 @@ Date: ${new Date().toISOString()}
     console.log(
       `[ACTION] If this minter is to be indexed in a subgraph, ensure it is added to the subgraph's config.`
     );
+    if (!successfulAllowlist) {
+      console.log(
+        `[ACTION] The minter was not able to be allowlisted on the minter filter, ensure the minter filter is updated by appropriate admin.`
+      );
+    }
+    // await to ensure logs are all written to files before process ends
+    await delay(EXTRA_DELAY_BETWEEN_TX);
   }
 }
 


### PR DESCRIPTION
## Description of the change

Add try/catch on generic minter deployment minter filter allowlisting.

This also reports+logs any necessary follow-on actions to the user running the script.

Tested on goerli to ensure WAI

follow on from #631, so it also fixes the bugged DEPLOYMENTS.md from the deployments in that PR.