### PR TITLE
Provide tokenIdToHashSeed consistency in V3

### DIFF
--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -6,6 +6,7 @@ pragma solidity 0.8.17;
 import "./interfaces/0.8.x/IRandomizerV2.sol";
 import "./interfaces/0.8.x/IAdminACLV0.sol";
 import "./interfaces/0.8.x/IGenArt721CoreContractV3.sol";
+import "./interfaces/0.8.x/IGenArt721CoreContractExposesHashSeed.sol";
 import "./interfaces/0.8.x/IManifold.sol";
 
 import "@openzeppelin-4.7/contracts/utils/Strings.sol";
@@ -89,7 +90,8 @@ import "./libs/0.8.x/Bytes32Strings.sol";
 contract GenArt721CoreV3 is
     ERC721_PackedHashSeed,
     Ownable,
-    IGenArt721CoreContractV3
+    IGenArt721CoreContractV3,
+    IGenArt721CoreContractExposesHashSeed
 {
     using BytecodeStorage for string;
     using BytecodeStorage for address;

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -240,7 +240,7 @@ contract GenArt721CoreV3 is
     bool public newProjectsForbidden;
 
     /// version & type of this core contract
-    string public constant coreVersion = "v3.0.2";
+    string public constant coreVersion = "v3.1.0";
     string public constant coreType = "GenArt721CoreV3";
 
     /// default base URI to initialize all new project projectBaseURI values to
@@ -1245,6 +1245,20 @@ contract GenArt721CoreV3 is
             return 0;
         }
         return keccak256(abi.encode(_hashSeed));
+    }
+
+    /**
+     * @notice Returns token hash **seed** for token ID `_tokenId`. Returns
+     * null if hash seed has not been set. The hash seed id the bytes12 value
+     * which is hashed to produce the token hash.
+     * @param _tokenId Token ID to be queried.
+     * @return bytes12 Token hash seed.
+     * @dev token hash seed is keccak256 hashed to give the token hash
+     */
+    function tokenIdToHashSeed(
+        uint256 _tokenId
+    ) external view returns (bytes12) {
+        return _ownersAndHashSeeds[_tokenId].hashSeed;
     }
 
     /**

--- a/contracts/V3_CHANGELOG.md
+++ b/contracts/V3_CHANGELOG.md
@@ -88,3 +88,7 @@ V3 performance metrics are available in [V3_Performance.md](V3_PERFORMANCE.md)
 ## The following changes were made in the Core V3 (3.0.2) contract:
 
 - Change modifiers to internal functions, preventing duplication of the logic throughout the bytecode
+
+## The following changes were made in the Core V3 (3.1.0) contract:
+
+- Expose a `tokenIdToHashSeed` method in addition to `tokenIdToHash` on the CoreContract.

--- a/contracts/engine/V3/GenArt721CoreV3_Engine.sol
+++ b/contracts/engine/V3/GenArt721CoreV3_Engine.sol
@@ -7,6 +7,7 @@ import "../../interfaces/0.8.x/IRandomizerV2.sol";
 import "../../interfaces/0.8.x/IAdminACLV0.sol";
 import "../../interfaces/0.8.x/IEngineRegistryV0.sol";
 import "../../interfaces/0.8.x/IGenArt721CoreContractV3_Engine.sol";
+import "../../interfaces/0.8.x/IGenArt721CoreContractExposesHashSeed.sol";
 import "../../interfaces/0.8.x/IDependencyRegistryCompatibleV0.sol";
 import "../../interfaces/0.8.x/IManifold.sol";
 
@@ -96,7 +97,8 @@ contract GenArt721CoreV3_Engine is
     Ownable,
     IDependencyRegistryCompatibleV0,
     IManifold,
-    IGenArt721CoreContractV3_Engine
+    IGenArt721CoreContractV3_Engine,
+    IGenArt721CoreContractExposesHashSeed
 {
     using BytecodeStorage for string;
     using BytecodeStorage for address;

--- a/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
+++ b/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
@@ -7,6 +7,7 @@ import "../../interfaces/0.8.x/IRandomizerV2.sol";
 import "../../interfaces/0.8.x/IAdminACLV0.sol";
 import "../../interfaces/0.8.x/IEngineRegistryV0.sol";
 import "../../interfaces/0.8.x/IGenArt721CoreContractV3_Engine_Flex.sol";
+import "../../interfaces/0.8.x/IGenArt721CoreContractExposesHashSeed.sol";
 import "../../interfaces/0.8.x/IDependencyRegistryCompatibleV0.sol";
 import "../../interfaces/0.8.x/IManifold.sol";
 
@@ -104,7 +105,8 @@ contract GenArt721CoreV3_Engine_Flex is
     Ownable,
     IDependencyRegistryCompatibleV0,
     IManifold,
-    IGenArt721CoreContractV3_Engine_Flex
+    IGenArt721CoreContractV3_Engine_Flex,
+    IGenArt721CoreContractExposesHashSeed
 {
     using BytecodeStorage for string;
     using BytecodeStorage for address;

--- a/contracts/explorations/GenArt721CoreV3_Explorations.sol
+++ b/contracts/explorations/GenArt721CoreV3_Explorations.sol
@@ -237,7 +237,7 @@ contract GenArt721CoreV3_Explorations is
     /// version & type of this core contract
     /// coreVersion is updated from Flagship V3 core due to minor changes
     /// implemented in the Explorations version of the contract.
-    string public constant coreVersion = "v3.1.0";
+    string public constant coreVersion = "v3.1.1";
     /// coreType remains consistent with flagship V3 core because external &
     /// public functions used for indexing are unchanged.
     string public constant coreType = "GenArt721CoreV3";

--- a/contracts/explorations/GenArt721CoreV3_Explorations.sol
+++ b/contracts/explorations/GenArt721CoreV3_Explorations.sol
@@ -237,7 +237,7 @@ contract GenArt721CoreV3_Explorations is
     /// version & type of this core contract
     /// coreVersion is updated from Flagship V3 core due to minor changes
     /// implemented in the Explorations version of the contract.
-    string public constant coreVersion = "v3.0.3";
+    string public constant coreVersion = "v3.1.0";
     /// coreType remains consistent with flagship V3 core because external &
     /// public functions used for indexing are unchanged.
     string public constant coreType = "GenArt721CoreV3";
@@ -1251,6 +1251,20 @@ contract GenArt721CoreV3_Explorations is
             return 0;
         }
         return keccak256(abi.encode(_hashSeed));
+    }
+
+    /**
+     * @notice Returns token hash **seed** for token ID `_tokenId`. Returns
+     * null if hash seed has not been set. The hash seed id the bytes12 value
+     * which is hashed to produce the token hash.
+     * @param _tokenId Token ID to be queried.
+     * @return bytes12 Token hash seed.
+     * @dev token hash seed is keccak256 hashed to give the token hash
+     */
+    function tokenIdToHashSeed(
+        uint256 _tokenId
+    ) external view returns (bytes12) {
+        return _ownersAndHashSeeds[_tokenId].hashSeed;
     }
 
     /**

--- a/contracts/explorations/GenArt721CoreV3_Explorations.sol
+++ b/contracts/explorations/GenArt721CoreV3_Explorations.sol
@@ -6,6 +6,7 @@ pragma solidity 0.8.17;
 import "../interfaces/0.8.x/IRandomizerV2.sol";
 import "../interfaces/0.8.x/IAdminACLV0.sol";
 import "../interfaces/0.8.x/IGenArt721CoreContractV3.sol";
+import "../interfaces/0.8.x/IGenArt721CoreContractExposesHashSeed.sol";
 import "../interfaces/0.8.x/IManifold.sol";
 
 import "@openzeppelin-4.7/contracts/utils/Strings.sol";
@@ -88,7 +89,8 @@ import "../libs/0.8.x/Bytes32Strings.sol";
 contract GenArt721CoreV3_Explorations is
     ERC721_PackedHashSeed,
     Ownable,
-    IGenArt721CoreContractV3
+    IGenArt721CoreContractV3,
+    IGenArt721CoreContractExposesHashSeed
 {
     using BytecodeStorage for string;
     using BytecodeStorage for address;

--- a/contracts/interfaces/0.8.x/IGenArt721CoreContractExposesHashSeed.sol
+++ b/contracts/interfaces/0.8.x/IGenArt721CoreContractExposesHashSeed.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Created By: Art Blocks Inc.
+
+pragma solidity ^0.8.0;
+
+interface IGenArt721CoreContractExposesHashSeed {
+    // function to read the hash-seed for a given tokenId
+    function tokenIdToHashSeed(
+        uint256 _tokenId
+    ) external view returns (bytes12);
+}

--- a/contracts/interfaces/0.8.x/IGenArt721CoreContractV3_Engine.sol
+++ b/contracts/interfaces/0.8.x/IGenArt721CoreContractV3_Engine.sol
@@ -69,9 +69,4 @@ interface IGenArt721CoreContractV3_Engine is IGenArt721CoreContractV3_Base {
         external
         view
         returns (uint256);
-
-    // function to read the hash-seed for a given tokenId
-    function tokenIdToHashSeed(
-        uint256 _tokenId
-    ) external view returns (bytes12);
 }

--- a/test/core/V3/GenArt721CoreV3_Integration.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Integration.test.ts
@@ -296,9 +296,9 @@ for (const coreContractName of coreContractsToTest) {
         const config = await loadFixture(_beforeEach);
         let targetCoreVersion;
         if (coreContractName === "GenArt721CoreV3") {
-          targetCoreVersion = "v3.0.2";
+          targetCoreVersion = "v3.1.0";
         } else if (coreContractName === "GenArt721CoreV3_Explorations") {
-          targetCoreVersion = "v3.0.3";
+          targetCoreVersion = "v3.1.0";
         } else if (coreContractName.includes("GenArt721CoreV3_Engine")) {
           targetCoreVersion = "v3.1.2";
         } else {
@@ -642,6 +642,27 @@ for (const coreContractName of coreContractsToTest) {
           ),
           "Token ID does not exist"
         );
+      });
+    });
+
+    describe("tokenIdToHashSeed", function () {
+      it("updates token hash seed from null to non-null when token is minted", async function () {
+        const config = await loadFixture(_beforeEach);
+        // ensure token hash is initially zero
+        expect(
+          await config.genArt721Core.tokenIdToHashSeed(
+            config.projectZeroTokenZero.toNumber()
+          )
+        ).to.be.equal("0x000000000000000000000000"); // bytes12(0)
+        // mint a token and expect token hash seed to be updated to a non-zero hash
+        await config.minter
+          .connect(config.accounts.artist)
+          .purchase(config.projectZero);
+        expect(
+          await config.genArt721Core.tokenIdToHashSeed(
+            config.projectZeroTokenZero.toNumber()
+          )
+        ).to.not.be.equal(ethers.constants.HashZero);
       });
     });
 

--- a/test/core/V3/GenArt721CoreV3_Integration.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Integration.test.ts
@@ -298,7 +298,7 @@ for (const coreContractName of coreContractsToTest) {
         if (coreContractName === "GenArt721CoreV3") {
           targetCoreVersion = "v3.1.0";
         } else if (coreContractName === "GenArt721CoreV3_Explorations") {
-          targetCoreVersion = "v3.1.0";
+          targetCoreVersion = "v3.1.1";
         } else if (coreContractName.includes("GenArt721CoreV3_Engine")) {
           targetCoreVersion = "v3.1.2";
         } else {

--- a/test/core/V3/GenArt721CoreV3_Views.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Views.test.ts
@@ -118,6 +118,9 @@ for (const coreContractName of coreContractsToTest) {
       it("returns expected value", async function () {
         const config = await loadFixture(_beforeEach);
         let targetCoreVersion = "v3.1.0";
+        if (coreContractName === "GenArt721CoreV3_Explorations") {
+          targetCoreVersion = "v3.1.1";
+        }
         const coreVersion = await config.genArt721Core
           .connect(config.accounts.deployer)
           .coreVersion();

--- a/test/core/V3/GenArt721CoreV3_Views.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Views.test.ts
@@ -117,10 +117,7 @@ for (const coreContractName of coreContractsToTest) {
     describe("coreVersion", function () {
       it("returns expected value", async function () {
         const config = await loadFixture(_beforeEach);
-        let targetCoreVersion = "v3.0.2";
-        if (coreContractName === "GenArt721CoreV3_Explorations") {
-          targetCoreVersion = "v3.0.3";
-        }
+        let targetCoreVersion = "v3.1.0";
         const coreVersion = await config.genArt721Core
           .connect(config.accounts.deployer)
           .coreVersion();

--- a/test/core/V3/GenArt721CoreV3_Views_Engine.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Views_Engine.test.ts
@@ -1818,26 +1818,5 @@ for (const coreContractName of coreContractsToTest) {
         expect(projectId).to.be.equal(config.projectTwo);
       });
     });
-
-    describe("tokenIdToHashSeed", function () {
-      it("updates token hash seed from null to non-null when token is minted", async function () {
-        const config = await loadFixture(_beforeEach);
-        // ensure token hash is initially zero
-        expect(
-          await config.genArt721Core.tokenIdToHashSeed(
-            config.projectZeroTokenZero.toNumber()
-          )
-        ).to.be.equal("0x000000000000000000000000"); // bytes12(0)
-        // mint a token and expect token hash seed to be updated to a non-zero hash
-        await config.minter
-          .connect(config.accounts.artist)
-          .purchase(config.projectZero);
-        expect(
-          await config.genArt721Core.tokenIdToHashSeed(
-            config.projectZeroTokenZero.toNumber()
-          )
-        ).to.not.be.equal(ethers.constants.HashZero);
-      });
-    });
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -179,16 +179,16 @@
     tslib "^2.5.0"
 
 "@aws-sdk/client-s3@^3.245.0":
-  version "3.315.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-s3/-/client-s3-3.315.0.tgz#3e68d301389bc51763880ac2b5c8ba9f376a481c"
-  integrity sha512-sE2pCFNrhkn1XdqkHx1GEd4eKg/kITk2zHETpkQCUMAVZ1MDuY/uUZzRjbAn9sm9EsJ03Z/vOuK4DkxlLFY+8g==
+  version "3.317.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-s3/-/client-s3-3.317.0.tgz#0e3f9eedefc92f809ba358dfeac8c7de463199a5"
+  integrity sha512-Y7AZMO/ikKFARsGYv7LKNELTDqJHjEpDTGEBBWnFkVoTmlquBsa9r0tU2nofP3uxSIkySPkkQpR50Zm/Q6zWyw==
   dependencies:
     "@aws-crypto/sha1-browser" "3.0.0"
     "@aws-crypto/sha256-browser" "3.0.0"
     "@aws-crypto/sha256-js" "3.0.0"
-    "@aws-sdk/client-sts" "3.315.0"
+    "@aws-sdk/client-sts" "3.316.0"
     "@aws-sdk/config-resolver" "3.310.0"
-    "@aws-sdk/credential-provider-node" "3.315.0"
+    "@aws-sdk/credential-provider-node" "3.316.0"
     "@aws-sdk/eventstream-serde-browser" "3.310.0"
     "@aws-sdk/eventstream-serde-config-resolver" "3.310.0"
     "@aws-sdk/eventstream-serde-node" "3.310.0"
@@ -218,14 +218,14 @@
     "@aws-sdk/node-http-handler" "3.310.0"
     "@aws-sdk/protocol-http" "3.310.0"
     "@aws-sdk/signature-v4-multi-region" "3.310.0"
-    "@aws-sdk/smithy-client" "3.315.0"
+    "@aws-sdk/smithy-client" "3.316.0"
     "@aws-sdk/types" "3.310.0"
     "@aws-sdk/url-parser" "3.310.0"
     "@aws-sdk/util-base64" "3.310.0"
     "@aws-sdk/util-body-length-browser" "3.310.0"
     "@aws-sdk/util-body-length-node" "3.310.0"
-    "@aws-sdk/util-defaults-mode-browser" "3.315.0"
-    "@aws-sdk/util-defaults-mode-node" "3.315.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.316.0"
+    "@aws-sdk/util-defaults-mode-node" "3.316.0"
     "@aws-sdk/util-endpoints" "3.310.0"
     "@aws-sdk/util-retry" "3.310.0"
     "@aws-sdk/util-stream-browser" "3.310.0"
@@ -236,44 +236,6 @@
     "@aws-sdk/util-waiter" "3.310.0"
     "@aws-sdk/xml-builder" "3.310.0"
     fast-xml-parser "4.1.2"
-    tslib "^2.5.0"
-
-"@aws-sdk/client-sso-oidc@3.315.0":
-  version "3.315.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.315.0.tgz#6a89f54c8b5f389eea59589cf96007361050d125"
-  integrity sha512-OJgtmx6SpCWHBDCxBBi36Ro44uCqZBufGkThP/PVYrgVnRVnJ4V18d2wNGKmS37zKmCHHJPnhMPlGOgE2qyVPQ==
-  dependencies:
-    "@aws-crypto/sha256-browser" "3.0.0"
-    "@aws-crypto/sha256-js" "3.0.0"
-    "@aws-sdk/config-resolver" "3.310.0"
-    "@aws-sdk/fetch-http-handler" "3.310.0"
-    "@aws-sdk/hash-node" "3.310.0"
-    "@aws-sdk/invalid-dependency" "3.310.0"
-    "@aws-sdk/middleware-content-length" "3.310.0"
-    "@aws-sdk/middleware-endpoint" "3.310.0"
-    "@aws-sdk/middleware-host-header" "3.310.0"
-    "@aws-sdk/middleware-logger" "3.310.0"
-    "@aws-sdk/middleware-recursion-detection" "3.310.0"
-    "@aws-sdk/middleware-retry" "3.310.0"
-    "@aws-sdk/middleware-serde" "3.310.0"
-    "@aws-sdk/middleware-stack" "3.310.0"
-    "@aws-sdk/middleware-user-agent" "3.310.0"
-    "@aws-sdk/node-config-provider" "3.310.0"
-    "@aws-sdk/node-http-handler" "3.310.0"
-    "@aws-sdk/protocol-http" "3.310.0"
-    "@aws-sdk/smithy-client" "3.315.0"
-    "@aws-sdk/types" "3.310.0"
-    "@aws-sdk/url-parser" "3.310.0"
-    "@aws-sdk/util-base64" "3.310.0"
-    "@aws-sdk/util-body-length-browser" "3.310.0"
-    "@aws-sdk/util-body-length-node" "3.310.0"
-    "@aws-sdk/util-defaults-mode-browser" "3.315.0"
-    "@aws-sdk/util-defaults-mode-node" "3.315.0"
-    "@aws-sdk/util-endpoints" "3.310.0"
-    "@aws-sdk/util-retry" "3.310.0"
-    "@aws-sdk/util-user-agent-browser" "3.310.0"
-    "@aws-sdk/util-user-agent-node" "3.310.0"
-    "@aws-sdk/util-utf8" "3.310.0"
     tslib "^2.5.0"
 
 "@aws-sdk/client-sso-oidc@3.316.0":
@@ -307,44 +269,6 @@
     "@aws-sdk/util-body-length-node" "3.310.0"
     "@aws-sdk/util-defaults-mode-browser" "3.316.0"
     "@aws-sdk/util-defaults-mode-node" "3.316.0"
-    "@aws-sdk/util-endpoints" "3.310.0"
-    "@aws-sdk/util-retry" "3.310.0"
-    "@aws-sdk/util-user-agent-browser" "3.310.0"
-    "@aws-sdk/util-user-agent-node" "3.310.0"
-    "@aws-sdk/util-utf8" "3.310.0"
-    tslib "^2.5.0"
-
-"@aws-sdk/client-sso@3.315.0":
-  version "3.315.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso/-/client-sso-3.315.0.tgz#436b2ef30a56c65cf7bc328a540a988160f2b246"
-  integrity sha512-P3QOOyHQER7EDVCzXOsAaJE2p/qfdsSFsYv8k2S8LqEKGH0fViQ4Ph540uKlmaOt1kEhwH1wI6cLRMJJX9XV4Q==
-  dependencies:
-    "@aws-crypto/sha256-browser" "3.0.0"
-    "@aws-crypto/sha256-js" "3.0.0"
-    "@aws-sdk/config-resolver" "3.310.0"
-    "@aws-sdk/fetch-http-handler" "3.310.0"
-    "@aws-sdk/hash-node" "3.310.0"
-    "@aws-sdk/invalid-dependency" "3.310.0"
-    "@aws-sdk/middleware-content-length" "3.310.0"
-    "@aws-sdk/middleware-endpoint" "3.310.0"
-    "@aws-sdk/middleware-host-header" "3.310.0"
-    "@aws-sdk/middleware-logger" "3.310.0"
-    "@aws-sdk/middleware-recursion-detection" "3.310.0"
-    "@aws-sdk/middleware-retry" "3.310.0"
-    "@aws-sdk/middleware-serde" "3.310.0"
-    "@aws-sdk/middleware-stack" "3.310.0"
-    "@aws-sdk/middleware-user-agent" "3.310.0"
-    "@aws-sdk/node-config-provider" "3.310.0"
-    "@aws-sdk/node-http-handler" "3.310.0"
-    "@aws-sdk/protocol-http" "3.310.0"
-    "@aws-sdk/smithy-client" "3.315.0"
-    "@aws-sdk/types" "3.310.0"
-    "@aws-sdk/url-parser" "3.310.0"
-    "@aws-sdk/util-base64" "3.310.0"
-    "@aws-sdk/util-body-length-browser" "3.310.0"
-    "@aws-sdk/util-body-length-node" "3.310.0"
-    "@aws-sdk/util-defaults-mode-browser" "3.315.0"
-    "@aws-sdk/util-defaults-mode-node" "3.315.0"
     "@aws-sdk/util-endpoints" "3.310.0"
     "@aws-sdk/util-retry" "3.310.0"
     "@aws-sdk/util-user-agent-browser" "3.310.0"
@@ -388,48 +312,6 @@
     "@aws-sdk/util-user-agent-browser" "3.310.0"
     "@aws-sdk/util-user-agent-node" "3.310.0"
     "@aws-sdk/util-utf8" "3.310.0"
-    tslib "^2.5.0"
-
-"@aws-sdk/client-sts@3.315.0":
-  version "3.315.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sts/-/client-sts-3.315.0.tgz#1a8ae885f0a41d897368525f9672b475fb113612"
-  integrity sha512-e34plg6m0hScADIPiu5kCKoiJVXRLRiAuens+iwMse0oPUmrv41hdjgufwWGA/pcNkEGzMdVS88Z4khxB3LHBw==
-  dependencies:
-    "@aws-crypto/sha256-browser" "3.0.0"
-    "@aws-crypto/sha256-js" "3.0.0"
-    "@aws-sdk/config-resolver" "3.310.0"
-    "@aws-sdk/credential-provider-node" "3.315.0"
-    "@aws-sdk/fetch-http-handler" "3.310.0"
-    "@aws-sdk/hash-node" "3.310.0"
-    "@aws-sdk/invalid-dependency" "3.310.0"
-    "@aws-sdk/middleware-content-length" "3.310.0"
-    "@aws-sdk/middleware-endpoint" "3.310.0"
-    "@aws-sdk/middleware-host-header" "3.310.0"
-    "@aws-sdk/middleware-logger" "3.310.0"
-    "@aws-sdk/middleware-recursion-detection" "3.310.0"
-    "@aws-sdk/middleware-retry" "3.310.0"
-    "@aws-sdk/middleware-sdk-sts" "3.310.0"
-    "@aws-sdk/middleware-serde" "3.310.0"
-    "@aws-sdk/middleware-signing" "3.310.0"
-    "@aws-sdk/middleware-stack" "3.310.0"
-    "@aws-sdk/middleware-user-agent" "3.310.0"
-    "@aws-sdk/node-config-provider" "3.310.0"
-    "@aws-sdk/node-http-handler" "3.310.0"
-    "@aws-sdk/protocol-http" "3.310.0"
-    "@aws-sdk/smithy-client" "3.315.0"
-    "@aws-sdk/types" "3.310.0"
-    "@aws-sdk/url-parser" "3.310.0"
-    "@aws-sdk/util-base64" "3.310.0"
-    "@aws-sdk/util-body-length-browser" "3.310.0"
-    "@aws-sdk/util-body-length-node" "3.310.0"
-    "@aws-sdk/util-defaults-mode-browser" "3.315.0"
-    "@aws-sdk/util-defaults-mode-node" "3.315.0"
-    "@aws-sdk/util-endpoints" "3.310.0"
-    "@aws-sdk/util-retry" "3.310.0"
-    "@aws-sdk/util-user-agent-browser" "3.310.0"
-    "@aws-sdk/util-user-agent-node" "3.310.0"
-    "@aws-sdk/util-utf8" "3.310.0"
-    fast-xml-parser "4.1.2"
     tslib "^2.5.0"
 
 "@aws-sdk/client-sts@3.316.0":
@@ -514,21 +396,6 @@
     "@aws-sdk/url-parser" "3.310.0"
     tslib "^2.5.0"
 
-"@aws-sdk/credential-provider-ini@3.315.0":
-  version "3.315.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.315.0.tgz#0104a5067111dcd9ffd47f045f518871ed1d7665"
-  integrity sha512-TZbYNbQkNgANx3KsWmJEyBsnfUBq/XKqYYc/VQf1L4eI+GMUw2eKpNV0MTsyviViy2st7W4SiSgtsvXyeVp9xg==
-  dependencies:
-    "@aws-sdk/credential-provider-env" "3.310.0"
-    "@aws-sdk/credential-provider-imds" "3.310.0"
-    "@aws-sdk/credential-provider-process" "3.310.0"
-    "@aws-sdk/credential-provider-sso" "3.315.0"
-    "@aws-sdk/credential-provider-web-identity" "3.310.0"
-    "@aws-sdk/property-provider" "3.310.0"
-    "@aws-sdk/shared-ini-file-loader" "3.310.0"
-    "@aws-sdk/types" "3.310.0"
-    tslib "^2.5.0"
-
 "@aws-sdk/credential-provider-ini@3.316.0":
   version "3.316.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.316.0.tgz#0e5a33034a5d51e298a146fc94148ceb25002592"
@@ -538,22 +405,6 @@
     "@aws-sdk/credential-provider-imds" "3.310.0"
     "@aws-sdk/credential-provider-process" "3.310.0"
     "@aws-sdk/credential-provider-sso" "3.316.0"
-    "@aws-sdk/credential-provider-web-identity" "3.310.0"
-    "@aws-sdk/property-provider" "3.310.0"
-    "@aws-sdk/shared-ini-file-loader" "3.310.0"
-    "@aws-sdk/types" "3.310.0"
-    tslib "^2.5.0"
-
-"@aws-sdk/credential-provider-node@3.315.0":
-  version "3.315.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.315.0.tgz#13a85fd99377763b077a1bbbb82ec3e950fd50d2"
-  integrity sha512-OuzKAIg+xPAzBrb/Big5VKDpJmBhVR+N0Hfflrjj2BunQGWO7zxtkKFCz921MtP9ZunDV+UxzTpar8U5TAPtzA==
-  dependencies:
-    "@aws-sdk/credential-provider-env" "3.310.0"
-    "@aws-sdk/credential-provider-imds" "3.310.0"
-    "@aws-sdk/credential-provider-ini" "3.315.0"
-    "@aws-sdk/credential-provider-process" "3.310.0"
-    "@aws-sdk/credential-provider-sso" "3.315.0"
     "@aws-sdk/credential-provider-web-identity" "3.310.0"
     "@aws-sdk/property-provider" "3.310.0"
     "@aws-sdk/shared-ini-file-loader" "3.310.0"
@@ -583,18 +434,6 @@
   dependencies:
     "@aws-sdk/property-provider" "3.310.0"
     "@aws-sdk/shared-ini-file-loader" "3.310.0"
-    "@aws-sdk/types" "3.310.0"
-    tslib "^2.5.0"
-
-"@aws-sdk/credential-provider-sso@3.315.0":
-  version "3.315.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.315.0.tgz#d31002cbc27a80df2f5c2ae9ea5160690636e67a"
-  integrity sha512-oMDGwT67cLgLiLEj5UwAiOVo7mb0l4vi2nk+5pgPMpC3cBlAfA0y1IJe4FHp+Vz52F0nvURZZbdWhX6RgMMaqQ==
-  dependencies:
-    "@aws-sdk/client-sso" "3.315.0"
-    "@aws-sdk/property-provider" "3.310.0"
-    "@aws-sdk/shared-ini-file-loader" "3.310.0"
-    "@aws-sdk/token-providers" "3.315.0"
     "@aws-sdk/types" "3.310.0"
     tslib "^2.5.0"
 
@@ -1001,32 +840,12 @@
     "@aws-sdk/util-utf8" "3.310.0"
     tslib "^2.5.0"
 
-"@aws-sdk/smithy-client@3.315.0":
-  version "3.315.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/smithy-client/-/smithy-client-3.315.0.tgz#1233316125c939690d9dc93f4f87f624abd74d24"
-  integrity sha512-qTm0lwTh6IZMiWs3U9k2veoF6gV9yE0B9Z34yMxagOfQFQgxMih0aiH25MD25eRigjJ3sfUeZ+B0mRycmJZdkQ==
-  dependencies:
-    "@aws-sdk/middleware-stack" "3.310.0"
-    "@aws-sdk/types" "3.310.0"
-    tslib "^2.5.0"
-
 "@aws-sdk/smithy-client@3.316.0":
   version "3.316.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/smithy-client/-/smithy-client-3.316.0.tgz#8ee751d7f396179ccf52d323eb34fa7d9508aeb9"
   integrity sha512-6YXOKbRnXeS8r8RWzuL6JMBolDYM5Wa4fD/VY6x/wK78i2xErHOvqzHgyyeLI1MMw4uqyd4wRNJNWC9TMPduXw==
   dependencies:
     "@aws-sdk/middleware-stack" "3.310.0"
-    "@aws-sdk/types" "3.310.0"
-    tslib "^2.5.0"
-
-"@aws-sdk/token-providers@3.315.0":
-  version "3.315.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.315.0.tgz#fc31aefed8f5ec4108189bccf9627be9c425f757"
-  integrity sha512-EjLUQ9JLqU3eJfJyzpcVjFnuJ1MCCodZaVJmuX/a/as4TK41bKMvkVojjsU7pDSYzl+tuXE+ceivcWK4H0HQdQ==
-  dependencies:
-    "@aws-sdk/client-sso-oidc" "3.315.0"
-    "@aws-sdk/property-provider" "3.310.0"
-    "@aws-sdk/shared-ini-file-loader" "3.310.0"
     "@aws-sdk/types" "3.310.0"
     tslib "^2.5.0"
 
@@ -1101,16 +920,6 @@
   dependencies:
     tslib "^2.5.0"
 
-"@aws-sdk/util-defaults-mode-browser@3.315.0":
-  version "3.315.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.315.0.tgz#c91e489d474219da9028b13dd7d1627bb3a3a831"
-  integrity sha512-5cqNvfGos3FB/MHNl+g2fr+tPY7s3k3+96V3wOPWLOksdACth10OxPpHfboXXZDHHkR0hmyJwJcfgA4uQrUcGg==
-  dependencies:
-    "@aws-sdk/property-provider" "3.310.0"
-    "@aws-sdk/types" "3.310.0"
-    bowser "^2.11.0"
-    tslib "^2.5.0"
-
 "@aws-sdk/util-defaults-mode-browser@3.316.0":
   version "3.316.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.316.0.tgz#053d8061e51dbb8e6fd009130942c09de3ed18f2"
@@ -1119,18 +928,6 @@
     "@aws-sdk/property-provider" "3.310.0"
     "@aws-sdk/types" "3.310.0"
     bowser "^2.11.0"
-    tslib "^2.5.0"
-
-"@aws-sdk/util-defaults-mode-node@3.315.0":
-  version "3.315.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.315.0.tgz#1c9c6421ff701406818a30ee376d01a5098d2621"
-  integrity sha512-vSPIGpzh6NJIMLoh31p7CczSatN46kJdJBrHfODHaIGe4t156x+LfkkcxGQhtifqxglhL7l+fmn5D1fM5exHuA==
-  dependencies:
-    "@aws-sdk/config-resolver" "3.310.0"
-    "@aws-sdk/credential-provider-imds" "3.310.0"
-    "@aws-sdk/node-config-provider" "3.310.0"
-    "@aws-sdk/property-provider" "3.310.0"
-    "@aws-sdk/types" "3.310.0"
     tslib "^2.5.0"
 
 "@aws-sdk/util-defaults-mode-node@3.316.0":


### PR DESCRIPTION
## Description of the change

Update CoreV3 for flagship and explorations to both support tokenIdToHashSeed and version bump to 3.1.0 / 3.1.1.

Additionally, refactor out a shared `IGenArt721CoreContractExposesHashSeed` interface to be used across all contracts that conform to this, removing it from the `_Engine`-specific core contract interface (this is safe, as no reliance on said interface outside of compile-time reliance is currently used – e.g. no usage in our subgraph, etc.).
