### PR TITLE
`STORE2`-compatible reads in `BytecodeStorage`

### DIFF
--- a/contracts/libs/0.8.x/SSTORE2.sol
+++ b/contracts/libs/0.8.x/SSTORE2.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity >=0.8.0;
+
+/// @notice Read and write to persistent storage at a fraction of the cost.
+/// @author Solmate (https://github.com/transmissions11/solmate/blob/main/src/utils/SSTORE2.sol)
+/// @author Modified from 0xSequence (https://github.com/0xSequence/sstore2/blob/master/contracts/SSTORE2.sol)
+library SSTORE2 {
+    uint256 internal constant DATA_OFFSET = 1; // We skip the first byte as it's a STOP opcode to ensure the contract can't be called.
+
+    /*//////////////////////////////////////////////////////////////
+                               WRITE LOGIC
+    //////////////////////////////////////////////////////////////*/
+
+    function write(bytes memory data) internal returns (address pointer) {
+        // Prefix the bytecode with a STOP opcode to ensure it cannot be called.
+        bytes memory runtimeCode = abi.encodePacked(hex"00", data);
+
+        bytes memory creationCode = abi.encodePacked(
+            //---------------------------------------------------------------------------------------------------------------//
+            // Opcode  | Opcode + Arguments  | Description  | Stack View                                                     //
+            //---------------------------------------------------------------------------------------------------------------//
+            // 0x60    |  0x600B             | PUSH1 11     | codeOffset                                                     //
+            // 0x59    |  0x59               | MSIZE        | 0 codeOffset                                                   //
+            // 0x81    |  0x81               | DUP2         | codeOffset 0 codeOffset                                        //
+            // 0x38    |  0x38               | CODESIZE     | codeSize codeOffset 0 codeOffset                               //
+            // 0x03    |  0x03               | SUB          | (codeSize - codeOffset) 0 codeOffset                           //
+            // 0x80    |  0x80               | DUP          | (codeSize - codeOffset) (codeSize - codeOffset) 0 codeOffset   //
+            // 0x92    |  0x92               | SWAP3        | codeOffset (codeSize - codeOffset) 0 (codeSize - codeOffset)   //
+            // 0x59    |  0x59               | MSIZE        | 0 codeOffset (codeSize - codeOffset) 0 (codeSize - codeOffset) //
+            // 0x39    |  0x39               | CODECOPY     | 0 (codeSize - codeOffset)                                      //
+            // 0xf3    |  0xf3               | RETURN       |                                                                //
+            //---------------------------------------------------------------------------------------------------------------//
+            hex"60_0B_59_81_38_03_80_92_59_39_F3", // Returns all code in the contract except for the first 11 (0B in hex) bytes.
+            runtimeCode // The bytecode we want the contract to have after deployment. Capped at 1 byte less than the code size limit.
+        );
+
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Deploy a new contract with the generated creation code.
+            // We start 32 bytes into the code to avoid copying the byte length.
+            pointer := create(0, add(creationCode, 32), mload(creationCode))
+        }
+
+        require(pointer != address(0), "DEPLOYMENT_FAILED");
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                               READ LOGIC
+    //////////////////////////////////////////////////////////////*/
+
+    function read(address pointer) internal view returns (bytes memory) {
+        return
+            readBytecode(
+                pointer,
+                DATA_OFFSET,
+                pointer.code.length - DATA_OFFSET
+            );
+    }
+
+    function read(
+        address pointer,
+        uint256 start
+    ) internal view returns (bytes memory) {
+        start += DATA_OFFSET;
+
+        return readBytecode(pointer, start, pointer.code.length - start);
+    }
+
+    function read(
+        address pointer,
+        uint256 start,
+        uint256 end
+    ) internal view returns (bytes memory) {
+        start += DATA_OFFSET;
+        end += DATA_OFFSET;
+
+        require(pointer.code.length >= end, "OUT_OF_BOUNDS");
+
+        return readBytecode(pointer, start, end - start);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                          INTERNAL HELPER LOGIC
+    //////////////////////////////////////////////////////////////*/
+
+    function readBytecode(
+        address pointer,
+        uint256 start,
+        uint256 size
+    ) private view returns (bytes memory data) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Get a pointer to some free memory.
+            data := mload(0x40)
+
+            // Update the free memory pointer to prevent overriding our data.
+            // We use and(x, not(31)) as a cheaper equivalent to sub(x, mod(x, 32)).
+            // Adding 31 to size and running the result through the logic above ensures
+            // the memory pointer remains word-aligned, following the Solidity convention.
+            mstore(0x40, add(data, and(add(add(size, 32), 31), not(31))))
+
+            // Store the size of the data in the first 32 byte chunk of free memory.
+            mstore(data, size)
+
+            // Copy the code into memory right after the 32 bytes we used to store the size.
+            extcodecopy(pointer, add(data, 32), start, size)
+        }
+    }
+}

--- a/contracts/mock/BytecodeV1TextCR_DMock.sol
+++ b/contracts/mock/BytecodeV1TextCR_DMock.sol
@@ -112,6 +112,24 @@ contract BytecodeV1TextCR_DMock {
     }
 
     /**
+     * @notice Allows additional read introspection, to read a chunk of text,
+     *         from chain-state that lives at a given deployed address with an
+     *         explicitly provided `_offset`.
+     * @param _bytecodeAddress address from which to read text content.
+     * @param _offset Offset to read from in contract bytecode,
+     *                explicitly provided (not calculated)
+     * @return string Content read from contract bytecode at the given address.
+     * @dev Intentionally do not perform input validation, instead allowing
+     *      the underlying BytecodeStorage lib to throw errors where applicable.
+     */
+    function forceReadTextAtAddress(
+        address _bytecodeAddress,
+        uint256 _offset
+    ) public view returns (string memory) {
+        return _bytecodeAddress.forceReadFromBytecode(_offset);
+    }
+
+    /**
      * @notice Allows introspection of who deployed a given contracts-as-storage
      *         contract, based on a provided `_bytecodeAddress`.
      * @param _bytecodeAddress address for which to read the author address.

--- a/contracts/mock/BytecodeV1TextCR_DMock.sol
+++ b/contracts/mock/BytecodeV1TextCR_DMock.sol
@@ -126,7 +126,22 @@ contract BytecodeV1TextCR_DMock {
         address _bytecodeAddress,
         uint256 _offset
     ) public view returns (string memory) {
-        return _bytecodeAddress.forceReadFromBytecode(_offset);
+        return string(_bytecodeAddress.readBytesFromBytecode(_offset));
+    }
+
+    /**
+     * @notice Allows additional read introspection, to read a chunk of text,
+     *         from chain-state that lives at a given deployed address that
+     *         was written with SSTORE2.
+     * @param _bytecodeAddress address from which to read text content.
+     * @return string Content read from contract bytecode at the given address.
+     * @dev Intentionally do not perform input validation, instead allowing
+     *      the underlying BytecodeStorage lib to throw errors where applicable.
+     */
+    function readSSTORE2TextAtAddress(
+        address _bytecodeAddress
+    ) public view returns (string memory) {
+        return string(_bytecodeAddress.readBytesFromSSTORE2Bytecode());
     }
 
     /**

--- a/contracts/mock/SSTORE2Mock.sol
+++ b/contracts/mock/SSTORE2Mock.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity 0.8.17;
+
+// Created By: Art Blocks Inc.
+
+import "../libs/0.8.x/SSTORE2.sol";
+
+/**
+ * @title Art Blocks SSTORE2Mock.
+ * @author Art Blocks Inc.
+ * @notice This contract serves as a mock client of the SSTORE2 library
+ *         to allow for more testing of this library in the context of
+ *         backwards-compatible reads with the Art Blocks BytecodeStorage library
+ * @dev For the purposes of our backwards-compatibility testing, the two different
+ *      variations of the SSTORE2 library are functionally equivalent, so we just test
+ *      against the one that is more widely tracked on Github for simplicity, but the
+ *      same tests could be run against the other variation of the library as well
+ *      and would be expected to "just work" given both use the same data offset of
+ *      a single 0x00 "stop byte".
+ */
+contract SSTORE2Mock {
+    using SSTORE2 for bytes;
+    using SSTORE2 for address;
+
+    // monotonically increasing slot counter and associated slot-storage mapping
+    uint256 public nextTextSlotId = 0;
+    mapping(uint256 => address) public storedTextBytecodeAddresses;
+
+    // save deployer address to support basic ACL checks for non-read operations
+    address public deployerAddress;
+
+    modifier onlyDeployer() {
+        require(msg.sender == deployerAddress, "Only deployer");
+        _;
+    }
+
+    /**
+     * @notice Initializes contract.
+     */
+    constructor() {
+        deployerAddress = msg.sender;
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                     Create + Read
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @notice "Create": Adds a chunk of text to be stored to chain-state.
+     * @param _text Text to be created in chain-state.
+     * @return uint256 Slot that the written bytecode contract address was
+     *         stored in.
+     * @dev Intentionally do not perform input validation, instead allowing
+     *      the underlying BytecodeStorage lib to throw errors where applicable.
+     */
+    function createText(
+        string memory _text
+    ) external onlyDeployer returns (uint256) {
+        // store text in contract bytecode
+        storedTextBytecodeAddresses[nextTextSlotId] = bytes(_text).write();
+        // record written slot before incrementing
+        uint256 textSlotId = nextTextSlotId;
+        nextTextSlotId++;
+        return textSlotId;
+    }
+
+    /**
+     * @notice "Read": Reads chunk of text currently in the provided slot, from
+     *                 chain-state.
+     * @param _textSlotId Slot (associated with this contract) for which to
+     *                   read text content.
+     * @return string Content read from contract bytecode in the given slot.
+     * @dev Intentionally do not perform input validation, instead allowing
+     *      the underlying BytecodeStorage lib to throw errors where applicable.
+     */
+    function readText(uint256 _textSlotId) public view returns (string memory) {
+        return string(storedTextBytecodeAddresses[_textSlotId].read());
+    }
+
+    /**
+     * @notice Allows additional read introspection, to read a chunk of text,
+     *         from chain-state that lives at a given deployed address.
+     * @param _bytecodeAddress address from which to read text content.
+     * @return string Content read from contract bytecode at the given address.
+     * @dev Intentionally do not perform input validation, instead allowing
+     *      the underlying BytecodeStorage lib to throw errors where applicable.
+     */
+    function readTextAtAddress(
+        address _bytecodeAddress
+    ) public view returns (string memory) {
+        return string(_bytecodeAddress.read());
+    }
+}

--- a/test/libs/BytecodeStorageV1_BackwardsCompatibleReadsMock.test.ts
+++ b/test/libs/BytecodeStorageV1_BackwardsCompatibleReadsMock.test.ts
@@ -33,6 +33,33 @@ import {
  *       library under test here, BytecodeStorage.
  */
 describe("BytecodeStorageV1 Backwards Compatible Reads Tests", async function () {
+  // Helper that validates a write from the SSTORE2 library is readable
+  // from the V1 library, for a given string.
+  async function validateReadInterop_SSTORE2_V1(
+    config: T_Config,
+    targetText: string,
+    sstore2Mock: Contract,
+    bytecodeV1TextCR_DMock: Contract,
+    deployer: SignerWithAddress
+  ) {
+    // Upload the target text via the V0 library.
+    const createTextTX = await sstore2Mock
+      .connect(deployer)
+      .createText(targetText);
+
+    // Retrieve the address of the written target text from the V0 library.
+    const textBytecodeAddress = getLatestTextDeploymentAddressSSTORE2(
+      config,
+      config.sstore2Mock
+    );
+
+    // Validate that V1 read of V0 written text is same as original text.
+    const text = await bytecodeV1TextCR_DMock.readTextAtAddress(
+      textBytecodeAddress
+    );
+    expect(text).to.equal(targetText);
+  }
+
   // Helper that validates a write from the V0 library is readable
   // from the V1 library, for a given string.
   async function validateReadInterop_V0_V1(
@@ -58,6 +85,21 @@ describe("BytecodeStorageV1 Backwards Compatible Reads Tests", async function ()
       textBytecodeAddress
     );
     expect(text).to.equal(targetText);
+  }
+
+  // Helper that retrieves the address of the most recently deployed contract
+  // containing bytecode for storage, from the SSTORE2 library.
+  async function getLatestTextDeploymentAddressSSTORE2(
+    config: T_Config,
+    sstore2Mock: Contract
+  ) {
+    const nextTextSlotId = await sstore2Mock.nextTextSlotId();
+    // decrement from `nextTextSlotId` to get last updated slot
+    const textSlotId = nextTextSlotId - 1;
+    const textBytecodeAddress = await sstore2Mock.storedTextBytecodeAddresses(
+      textSlotId
+    );
+    return textBytecodeAddress;
   }
 
   // Helper that retrieves the address of the most recently deployed contract
@@ -93,16 +135,22 @@ describe("BytecodeStorageV1 Backwards Compatible Reads Tests", async function ()
       accounts: await getAccounts(),
     };
     config = await assignDefaultConstants(config);
-    // deploy the library mock
+    // deploy the V1 library mock
     config.bytecodeV1TextCR_DMock = await deployAndGet(
       config,
       "BytecodeV1TextCR_DMock",
       [] // no deployment args
     );
-    // deploy the library mock
+    // deploy the V0 library mock
     config.bytecodeV0TextCR_DMock = await deployAndGet(
       config,
       "BytecodeV0TextCR_DMock",
+      [] // no deployment args
+    );
+    // deploy the SSTORE2 library mock
+    config.sstore2Mock = await deployAndGet(
+      config,
+      "SSTORE2Mock",
       [] // no deployment args
     );
     return config;
@@ -111,20 +159,36 @@ describe("BytecodeStorageV1 Backwards Compatible Reads Tests", async function ()
   describe("validate readFromBytecode backwards-compatible interoperability", function () {
     it("validates interop for a single-byte script", async function () {
       const config = await loadFixture(_beforeEach);
+      let testString = "0";
       await validateReadInterop_V0_V1(
         config,
-        "0",
+        testString,
         config.bytecodeV0TextCR_DMock,
+        config.bytecodeV1TextCR_DMock,
+        config.accounts.deployer
+      );
+      await validateReadInterop_SSTORE2_V1(
+        config,
+        testString,
+        config.sstore2Mock,
         config.bytecodeV1TextCR_DMock,
         config.accounts.deployer
       );
     });
     it("validates interop for an short script < 32 bytes", async function () {
       const config = await loadFixture(_beforeEach);
+      let testString = "console.log(hello world)";
       await validateReadInterop_V0_V1(
         config,
-        "console.log(hello world)",
+        testString,
         config.bytecodeV0TextCR_DMock,
+        config.bytecodeV1TextCR_DMock,
+        config.accounts.deployer
+      );
+      await validateReadInterop_SSTORE2_V1(
+        config,
+        testString,
+        config.sstore2Mock,
         config.bytecodeV1TextCR_DMock,
         config.accounts.deployer
       );
@@ -138,6 +202,13 @@ describe("BytecodeStorageV1 Backwards Compatible Reads Tests", async function ()
         config.bytecodeV1TextCR_DMock,
         config.accounts.deployer
       );
+      await validateReadInterop_SSTORE2_V1(
+        config,
+        SQUIGGLE_SCRIPT,
+        config.sstore2Mock,
+        config.bytecodeV1TextCR_DMock,
+        config.accounts.deployer
+      );
     });
     it("validates interop for different script", async function () {
       const config = await loadFixture(_beforeEach);
@@ -148,6 +219,13 @@ describe("BytecodeStorageV1 Backwards Compatible Reads Tests", async function ()
         config.bytecodeV1TextCR_DMock,
         config.accounts.deployer
       );
+      await validateReadInterop_SSTORE2_V1(
+        config,
+        SKULPTUUR_SCRIPT_APPROX,
+        config.sstore2Mock,
+        config.bytecodeV1TextCR_DMock,
+        config.accounts.deployer
+      );
     });
     it("validates interop for misc. UTF-8 script", async function () {
       const config = await loadFixture(_beforeEach);
@@ -155,6 +233,13 @@ describe("BytecodeStorageV1 Backwards Compatible Reads Tests", async function ()
         config,
         MULTI_BYTE_UTF_EIGHT_SCRIPT,
         config.bytecodeV0TextCR_DMock,
+        config.bytecodeV1TextCR_DMock,
+        config.accounts.deployer
+      );
+      await validateReadInterop_SSTORE2_V1(
+        config,
+        MULTI_BYTE_UTF_EIGHT_SCRIPT,
+        config.sstore2Mock,
         config.bytecodeV1TextCR_DMock,
         config.accounts.deployer
       );
@@ -185,6 +270,25 @@ describe("BytecodeStorageV1 Backwards Compatible Reads Tests", async function ()
         .resolvedAddress;
       expect(textAuthorAddressV1).to.equal(resolvedMockAddress);
       expect(textAuthorAddressV1).to.equal(textAuthorAddressV0);
+    });
+
+    it("getWriterAddressForBytecode is not supported for SSTORE2", async function () {
+      const config = await loadFixture(_beforeEach);
+      await config.sstore2Mock
+        .connect(config.accounts.deployer)
+        .createText("zip zipppity zoooop zop");
+      const textBytecodeAddress = getLatestTextDeploymentAddressSSTORE2(
+        config,
+        config.sstore2Mock
+      );
+
+      // validate read with V1 library
+      await expectRevert(
+        config.bytecodeV1TextCR_DMock.readAuthorForTextAtAddress(
+          textBytecodeAddress
+        ),
+        "ContractAsStorage: Unsupported Version"
+      );
     });
   });
 

--- a/test/libs/BytecodeStorageV1_BackwardsCompatibleReadsMock.test.ts
+++ b/test/libs/BytecodeStorageV1_BackwardsCompatibleReadsMock.test.ts
@@ -42,22 +42,29 @@ describe("BytecodeStorageV1 Backwards Compatible Reads Tests", async function ()
     bytecodeV1TextCR_DMock: Contract,
     deployer: SignerWithAddress
   ) {
-    // Upload the target text via the V0 library.
+    // Upload the target text via the SSTORE2 library.
     const createTextTX = await sstore2Mock
       .connect(deployer)
       .createText(targetText);
 
-    // Retrieve the address of the written target text from the V0 library.
+    // Retrieve the address of the written target text from the SSTORE2 library.
     const textBytecodeAddress = getLatestTextDeploymentAddressSSTORE2(
       config,
       config.sstore2Mock
     );
 
-    // Validate that V1 read of V0 written text is same as original text.
+    // Validate that V1 read of SSTORE2 written text is same as original text.
     const text = await bytecodeV1TextCR_DMock.readTextAtAddress(
       textBytecodeAddress
     );
     expect(text).to.equal(targetText);
+    // Validate that read is the same when using manually provided read-offsets.
+    const textManualOffset =
+      await bytecodeV1TextCR_DMock.forceReadTextAtAddress(
+        textBytecodeAddress,
+        1 // for SSTORE2, expected data offset is `1`
+      );
+    expect(textManualOffset).to.equal(targetText);
   }
 
   // Helper that validates a write from the V0 library is readable
@@ -85,6 +92,13 @@ describe("BytecodeStorageV1 Backwards Compatible Reads Tests", async function ()
       textBytecodeAddress
     );
     expect(text).to.equal(targetText);
+    // Validate that read is the same when using manually provided read-offsets.
+    const textManualOffset =
+      await bytecodeV1TextCR_DMock.forceReadTextAtAddress(
+        textBytecodeAddress,
+        104 // for V0, expected data offset is `104`
+      );
+    expect(textManualOffset).to.equal(targetText);
   }
 
   // Helper that retrieves the address of the most recently deployed contract

--- a/test/libs/BytecodeStorageV1_BackwardsCompatibleReadsMock.test.ts
+++ b/test/libs/BytecodeStorageV1_BackwardsCompatibleReadsMock.test.ts
@@ -54,7 +54,7 @@ describe("BytecodeStorageV1 Backwards Compatible Reads Tests", async function ()
     );
 
     // Validate that V1 read of SSTORE2 written text is same as original text.
-    const text = await bytecodeV1TextCR_DMock.readTextAtAddress(
+    const text = await bytecodeV1TextCR_DMock.readSSTORE2TextAtAddress(
       textBytecodeAddress
     );
     expect(text).to.equal(targetText);
@@ -309,13 +309,20 @@ describe("BytecodeStorageV1 Backwards Compatible Reads Tests", async function ()
   describe("validate getLibraryVersionForBytecode works across versions", function () {
     it("read unknown contract from V1 library", async function () {
       const config = await loadFixture(_beforeEach);
+      await config.sstore2Mock
+        .connect(config.accounts.deployer)
+        .createText("zip zipppity zoooop zop");
+      const textBytecodeAddress = getLatestTextDeploymentAddressSSTORE2(
+        config,
+        config.sstore2Mock
+      );
 
-      // read the mock contract itself (it _is_ an unknown storage contract)
-      // from the V1 library, to validate unknown-reads
+      // read SSTORE2 version from V1 library
       const textLibraryVersionV1 =
         await config.bytecodeV1TextCR_DMock.readLibraryVersionForTextAtAddress(
-          config.bytecodeV1TextCR_DMock.address
+          textBytecodeAddress
         );
+
       // hard-coded expected value
       let textLibraryVersionV1UTF8 =
         ethers.utils.toUtf8String(textLibraryVersionV1);


### PR DESCRIPTION
## Description of the change

Staging this up for separate review, but if approved before #670 will merge directly into that branch, otherwise should be merged in very close conjunction with #670 in support of #660.

This PR updates the `BytecodeStorage` library to provide backwards-compatible reads that are compatible with `SSTORE2` as an additional read option as well as explicit-offset bytes reads, in advance of plans to split off reads into a shared external public utility library (which will live in-companion to the embedded internal library for writes).

For additional context, please see: 
- #670 
- #668 
- #660 
- #422 
