### PR TITLE
Split `BytecodeStorage` into public/internal libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ erDiagram
     ADMIN_ACL ||--o{ CORE_V3_V3_FLEX : manages
     ADMIN_ACL ||--o{ MINTERFILTER : manages
     CORE_V3_V3_FLEX ||--|| MINTERFILTER : uses
+    CORE_V3_V3_FLEX }o--|| BYTECODESTORAGEREADER : uses
     MINTERFILTER ||--o{ MINTER_1 : uses
     MINTERFILTER ||--o{ MINTER_2 : uses
     MINTERFILTER ||--o{ MINTER_N : uses
@@ -140,6 +141,15 @@ The following represents the current set of flagship core contracts deployed on 
 ## Art Blocks Engine Core Contracts
 
 For deployed core contracts, see the deployment details in the `/deployments/engine/[V2|V3]/<engine-partner>/` directories. For V2 core contracts, archived source code is available in the `/posterity/engine/` directory.
+
+## BytecodeStorageReader
+
+BytecodeStorageReader (currently on V1 version) is public library for reading from storage contracts. This library is intended to be deployed as a standalone contract, and provides all _read_ functionality by being used as an externally linked library within the Art Blocks ecosystem contracts that use contract storage for writes.
+
+Given that it is an externally linked library with a shared public deployment, the deployment addresses for these shared deployments are referenced in our shared deployments `constants.ts` util (in the `BYTECODE_STORAGE_READER_LIBRARY_ADDRESSES` constant) so that they may be linked at time of deployment and are also linked here below for shared reference:
+
+- V1 `BytecodeStorageReader` (goerli): https://goerli.etherscan.io/address/0xB8B806A10d16cc80dB788552B54B3ECb4A2A3C3D#code
+- V1 `BytecodeStorageReader` (mainnet): https://etherscan.io/address/TODO#code
 
 ## Minter Suite
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ BytecodeStorageReader (currently on V1 version) is public library for reading fr
 Given that it is an externally linked library with a shared public deployment, the deployment addresses for these shared deployments are referenced in our shared deployments `constants.ts` util (in the `BYTECODE_STORAGE_READER_LIBRARY_ADDRESSES` constant) so that they may be linked at time of deployment and are also linked here below for shared reference:
 
 - V1 `BytecodeStorageReader` (goerli): https://goerli.etherscan.io/address/0xB8B806A10d16cc80dB788552B54B3ECb4A2A3C3D#code
-- V1 `BytecodeStorageReader` (mainnet): https://etherscan.io/address/TODO#code
+- V1 `BytecodeStorageReader` (mainnet): https://etherscan.io/address/0xf0585dF582A0ad119F1616FB82f3b449a98EeCd5#code
 
 ## Minter Suite
 

--- a/contracts/DependencyRegistryV0.sol
+++ b/contracts/DependencyRegistryV0.sol
@@ -831,7 +831,7 @@ contract DependencyRegistryV0 is
 
     /**
      * Helper for calling `BytecodeStorageReaderV1` external library reader method,
-     * added for gas-optimization purposes.
+     * added for bytecode size reduction purposes.
      */
     function _readFromBytecode(
         address _address

--- a/contracts/DependencyRegistryV0.sol
+++ b/contracts/DependencyRegistryV0.sol
@@ -34,7 +34,6 @@ contract DependencyRegistryV0 is
     IDependencyRegistryV0
 {
     using BytecodeStorageWriterV1 for string;
-    using BytecodeStorageWriterV1 for address;
     using Bytes32Strings for bytes32;
     using Strings for uint256;
     using EnumerableSet for EnumerableSet.Bytes32Set;

--- a/contracts/DependencyRegistryV0.sol
+++ b/contracts/DependencyRegistryV0.sol
@@ -34,9 +34,7 @@ contract DependencyRegistryV0 is
     IDependencyRegistryV0
 {
     using BytecodeStorageWriterV1 for string;
-    using BytecodeStorageReaderV1 for string;
     using BytecodeStorageWriterV1 for address;
-    using BytecodeStorageReaderV1 for address;
     using Bytes32Strings for bytes32;
     using Strings for uint256;
     using EnumerableSet for EnumerableSet.Bytes32Set;
@@ -737,7 +735,7 @@ contract DependencyRegistryV0 is
             return "";
         }
 
-        return dependency.scriptBytecodeAddresses[_index].readFromBytecode();
+        return _readFromBytecode(dependency.scriptBytecodeAddresses[_index]);
     }
 
     /**
@@ -830,5 +828,15 @@ contract DependencyRegistryV0 is
     function _transferOwnership(address newOwner) internal override {
         OwnableUpgradeable._transferOwnership(newOwner);
         adminACLContract = IAdminACLV0(newOwner);
+    }
+
+    /**
+     * Helper for calling `BytecodeStorageReaderV1` external library reader method,
+     * added for gas-optimization purposes.
+     */
+    function _readFromBytecode(
+        address _address
+    ) internal view returns (string memory) {
+        return BytecodeStorageReaderV1.readFromBytecode(_address);
     }
 }

--- a/contracts/DependencyRegistryV0.sol
+++ b/contracts/DependencyRegistryV0.sol
@@ -33,7 +33,7 @@ contract DependencyRegistryV0 is
     OwnableUpgradeable,
     IDependencyRegistryV0
 {
-    using BytecodeStorageWriterV1 for string;
+    using BytecodeStorageWriter for string;
     using Bytes32Strings for bytes32;
     using Strings for uint256;
     using EnumerableSet for EnumerableSet.Bytes32Set;
@@ -830,12 +830,12 @@ contract DependencyRegistryV0 is
     }
 
     /**
-     * Helper for calling `BytecodeStorageReaderV1` external library reader method,
+     * Helper for calling `BytecodeStorageReader` external library reader method,
      * added for bytecode size reduction purposes.
      */
     function _readFromBytecode(
         address _address
     ) internal view returns (string memory) {
-        return BytecodeStorageReaderV1.readFromBytecode(_address);
+        return BytecodeStorageReader.readFromBytecode(_address);
     }
 }

--- a/contracts/DependencyRegistryV0.sol
+++ b/contracts/DependencyRegistryV0.sol
@@ -33,8 +33,10 @@ contract DependencyRegistryV0 is
     OwnableUpgradeable,
     IDependencyRegistryV0
 {
-    using BytecodeStorage for string;
-    using BytecodeStorage for address;
+    using BytecodeStorageWriterV1 for string;
+    using BytecodeStorageReaderV1 for string;
+    using BytecodeStorageWriterV1 for address;
+    using BytecodeStorageReaderV1 for address;
     using Bytes32Strings for bytes32;
     using Strings for uint256;
     using EnumerableSet for EnumerableSet.Bytes32Set;

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -1947,7 +1947,7 @@ contract GenArt721CoreV3 is
 
     /**
      * Helper for calling `BytecodeStorageReaderV1` external library reader method,
-     * added for gas-optimization purposes.
+     * added for bytecode size reduction purposes.
      */
     function _readFromBytecode(
         address _address

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -94,9 +94,7 @@ contract GenArt721CoreV3 is
     IGenArt721CoreContractExposesHashSeed
 {
     using BytecodeStorageWriterV1 for string;
-    using BytecodeStorageReaderV1 for string;
     using BytecodeStorageWriterV1 for address;
-    using BytecodeStorageReaderV1 for address;
     using Bytes32Strings for bytes32;
     using Strings for uint256;
     uint256 constant ONE_HUNDRED = 100;
@@ -1495,7 +1493,7 @@ contract GenArt721CoreV3 is
         if (_index >= project.scriptCount) {
             return "";
         }
-        return project.scriptBytecodeAddresses[_index].readFromBytecode();
+        return _readFromBytecode(project.scriptBytecodeAddresses[_index]);
     }
 
     /**
@@ -1946,5 +1944,15 @@ contract GenArt721CoreV3 is
             projectOpen ||
             (block.timestamp - projectCompletedTimestamp <
                 FOUR_WEEKS_IN_SECONDS);
+    }
+
+    /**
+     * Helper for calling `BytecodeStorageReaderV1` external library reader method,
+     * added for gas-optimization purposes.
+     */
+    function _readFromBytecode(
+        address _address
+    ) internal view returns (string memory) {
+        return BytecodeStorageReaderV1.readFromBytecode(_address);
     }
 }

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -94,7 +94,6 @@ contract GenArt721CoreV3 is
     IGenArt721CoreContractExposesHashSeed
 {
     using BytecodeStorageWriterV1 for string;
-    using BytecodeStorageWriterV1 for address;
     using Bytes32Strings for bytes32;
     using Strings for uint256;
     uint256 constant ONE_HUNDRED = 100;

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -93,8 +93,10 @@ contract GenArt721CoreV3 is
     IGenArt721CoreContractV3,
     IGenArt721CoreContractExposesHashSeed
 {
-    using BytecodeStorage for string;
-    using BytecodeStorage for address;
+    using BytecodeStorageWriterV1 for string;
+    using BytecodeStorageReaderV1 for string;
+    using BytecodeStorageWriterV1 for address;
+    using BytecodeStorageReaderV1 for address;
     using Bytes32Strings for bytes32;
     using Strings for uint256;
     uint256 constant ONE_HUNDRED = 100;

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -93,7 +93,7 @@ contract GenArt721CoreV3 is
     IGenArt721CoreContractV3,
     IGenArt721CoreContractExposesHashSeed
 {
-    using BytecodeStorageWriterV1 for string;
+    using BytecodeStorageWriter for string;
     using Bytes32Strings for bytes32;
     using Strings for uint256;
     uint256 constant ONE_HUNDRED = 100;
@@ -1946,12 +1946,12 @@ contract GenArt721CoreV3 is
     }
 
     /**
-     * Helper for calling `BytecodeStorageReaderV1` external library reader method,
+     * Helper for calling `BytecodeStorageReader` external library reader method,
      * added for bytecode size reduction purposes.
      */
     function _readFromBytecode(
         address _address
     ) internal view returns (string memory) {
-        return BytecodeStorageReaderV1.readFromBytecode(_address);
+        return BytecodeStorageReader.readFromBytecode(_address);
     }
 }

--- a/contracts/engine/V3/GenArt721CoreV3_Engine.sol
+++ b/contracts/engine/V3/GenArt721CoreV3_Engine.sol
@@ -100,8 +100,10 @@ contract GenArt721CoreV3_Engine is
     IGenArt721CoreContractV3_Engine,
     IGenArt721CoreContractExposesHashSeed
 {
-    using BytecodeStorage for string;
-    using BytecodeStorage for address;
+    using BytecodeStorageWriterV1 for string;
+    using BytecodeStorageReaderV1 for string;
+    using BytecodeStorageWriterV1 for address;
+    using BytecodeStorageReaderV1 for address;
     using Bytes32Strings for bytes32;
     using Strings for uint256;
     using Strings for address;

--- a/contracts/engine/V3/GenArt721CoreV3_Engine.sol
+++ b/contracts/engine/V3/GenArt721CoreV3_Engine.sol
@@ -1998,7 +1998,7 @@ contract GenArt721CoreV3_Engine is
 
     /**
      * Helper for calling `BytecodeStorageReaderV1` external library reader method,
-     * added for gas-optimization purposes.
+     * added for bytecode size reduction purposes.
      */
     function _readFromBytecode(
         address _address

--- a/contracts/engine/V3/GenArt721CoreV3_Engine.sol
+++ b/contracts/engine/V3/GenArt721CoreV3_Engine.sol
@@ -101,9 +101,7 @@ contract GenArt721CoreV3_Engine is
     IGenArt721CoreContractExposesHashSeed
 {
     using BytecodeStorageWriterV1 for string;
-    using BytecodeStorageReaderV1 for string;
     using BytecodeStorageWriterV1 for address;
-    using BytecodeStorageReaderV1 for address;
     using Bytes32Strings for bytes32;
     using Strings for uint256;
     using Strings for address;
@@ -1579,7 +1577,7 @@ contract GenArt721CoreV3_Engine is
         if (_index >= project.scriptCount) {
             return "";
         }
-        return project.scriptBytecodeAddresses[_index].readFromBytecode();
+        return _readFromBytecode(project.scriptBytecodeAddresses[_index]);
     }
 
     /**
@@ -1997,5 +1995,15 @@ contract GenArt721CoreV3_Engine is
             projectOpen ||
             (block.timestamp - projectCompletedTimestamp <
                 FOUR_WEEKS_IN_SECONDS);
+    }
+
+    /**
+     * Helper for calling `BytecodeStorageReaderV1` external library reader method,
+     * added for gas-optimization purposes.
+     */
+    function _readFromBytecode(
+        address _address
+    ) internal view returns (string memory) {
+        return BytecodeStorageReaderV1.readFromBytecode(_address);
     }
 }

--- a/contracts/engine/V3/GenArt721CoreV3_Engine.sol
+++ b/contracts/engine/V3/GenArt721CoreV3_Engine.sol
@@ -100,7 +100,7 @@ contract GenArt721CoreV3_Engine is
     IGenArt721CoreContractV3_Engine,
     IGenArt721CoreContractExposesHashSeed
 {
-    using BytecodeStorageWriterV1 for string;
+    using BytecodeStorageWriter for string;
     using Bytes32Strings for bytes32;
     using Strings for uint256;
     using Strings for address;
@@ -1997,12 +1997,12 @@ contract GenArt721CoreV3_Engine is
     }
 
     /**
-     * Helper for calling `BytecodeStorageReaderV1` external library reader method,
+     * Helper for calling `BytecodeStorageReader` external library reader method,
      * added for bytecode size reduction purposes.
      */
     function _readFromBytecode(
         address _address
     ) internal view returns (string memory) {
-        return BytecodeStorageReaderV1.readFromBytecode(_address);
+        return BytecodeStorageReader.readFromBytecode(_address);
     }
 }

--- a/contracts/engine/V3/GenArt721CoreV3_Engine.sol
+++ b/contracts/engine/V3/GenArt721CoreV3_Engine.sol
@@ -101,7 +101,6 @@ contract GenArt721CoreV3_Engine is
     IGenArt721CoreContractExposesHashSeed
 {
     using BytecodeStorageWriterV1 for string;
-    using BytecodeStorageWriterV1 for address;
     using Bytes32Strings for bytes32;
     using Strings for uint256;
     using Strings for address;

--- a/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
+++ b/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
@@ -108,8 +108,10 @@ contract GenArt721CoreV3_Engine_Flex is
     IGenArt721CoreContractV3_Engine_Flex,
     IGenArt721CoreContractExposesHashSeed
 {
-    using BytecodeStorage for string;
-    using BytecodeStorage for address;
+    using BytecodeStorageWriterV1 for string;
+    using BytecodeStorageReaderV1 for string;
+    using BytecodeStorageWriterV1 for address;
+    using BytecodeStorageReaderV1 for address;
     using Bytes32Strings for bytes32;
     uint256 constant ONE_HUNDRED = 100;
     uint256 constant ONE_MILLION = 1_000_000;

--- a/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
+++ b/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
@@ -2217,6 +2217,10 @@ contract GenArt721CoreV3_Engine_Flex is
                 FOUR_WEEKS_IN_SECONDS);
     }
 
+    /**
+     * Helper for calling `BytecodeStorageReaderV1` external library reader method,
+     * added for gas-optimization purposes.
+     */
     function _readFromBytecode(
         address _address
     ) internal view returns (string memory) {

--- a/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
+++ b/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
@@ -108,7 +108,7 @@ contract GenArt721CoreV3_Engine_Flex is
     IGenArt721CoreContractV3_Engine_Flex,
     IGenArt721CoreContractExposesHashSeed
 {
-    using BytecodeStorageWriterV1 for string;
+    using BytecodeStorageWriter for string;
     using Bytes32Strings for bytes32;
     uint256 constant ONE_HUNDRED = 100;
     uint256 constant ONE_MILLION = 1_000_000;
@@ -2217,13 +2217,13 @@ contract GenArt721CoreV3_Engine_Flex is
     }
 
     /**
-     * Helper for calling `BytecodeStorageReaderV1` external library reader method,
+     * Helper for calling `BytecodeStorageReader` external library reader method,
      * added for bytecode size reduction purposes.
      */
     function _readFromBytecode(
         address _address
     ) internal view returns (string memory) {
-        return BytecodeStorageReaderV1.readFromBytecode(_address);
+        return BytecodeStorageReader.readFromBytecode(_address);
     }
 
     // strings library from OpenZeppelin, modified for no constants

--- a/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
+++ b/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
@@ -109,7 +109,6 @@ contract GenArt721CoreV3_Engine_Flex is
     IGenArt721CoreContractExposesHashSeed
 {
     using BytecodeStorageWriterV1 for string;
-    using BytecodeStorageWriterV1 for address;
     using Bytes32Strings for bytes32;
     uint256 constant ONE_HUNDRED = 100;
     uint256 constant ONE_MILLION = 1_000_000;

--- a/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
+++ b/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
@@ -2218,7 +2218,7 @@ contract GenArt721CoreV3_Engine_Flex is
 
     /**
      * Helper for calling `BytecodeStorageReaderV1` external library reader method,
-     * added for gas-optimization purposes.
+     * added for bytecode size reduction purposes.
      */
     function _readFromBytecode(
         address _address

--- a/contracts/engine/V3/forks/GenArt721CoreV3_Engine_Flex_PROOF.sol
+++ b/contracts/engine/V3/forks/GenArt721CoreV3_Engine_Flex_PROOF.sol
@@ -107,8 +107,10 @@ contract GenArt721CoreV3_Engine_Flex_PROOF is
     IManifold,
     IGenArt721CoreContractV3_Engine_Flex
 {
-    using BytecodeStorage for string;
-    using BytecodeStorage for address;
+    using BytecodeStorageWriterV1 for string;
+    using BytecodeStorageReaderV1 for string;
+    using BytecodeStorageWriterV1 for address;
+    using BytecodeStorageReaderV1 for address;
     using Bytes32Strings for bytes32;
 
     uint256 constant ONE_HUNDRED = 100;

--- a/contracts/engine/V3/forks/GenArt721CoreV3_Engine_Flex_PROOF.sol
+++ b/contracts/engine/V3/forks/GenArt721CoreV3_Engine_Flex_PROOF.sol
@@ -2228,7 +2228,7 @@ contract GenArt721CoreV3_Engine_Flex_PROOF is
 
     /**
      * Helper for calling `BytecodeStorageReaderV1` external library reader method,
-     * added for gas-optimization purposes.
+     * added for bytecode size reduction purposes.
      */
     function _readFromBytecode(
         address _address

--- a/contracts/engine/V3/forks/GenArt721CoreV3_Engine_Flex_PROOF.sol
+++ b/contracts/engine/V3/forks/GenArt721CoreV3_Engine_Flex_PROOF.sol
@@ -107,7 +107,7 @@ contract GenArt721CoreV3_Engine_Flex_PROOF is
     IManifold,
     IGenArt721CoreContractV3_Engine_Flex
 {
-    using BytecodeStorageWriterV1 for string;
+    using BytecodeStorageWriter for string;
     using Bytes32Strings for bytes32;
 
     uint256 constant ONE_HUNDRED = 100;
@@ -2227,13 +2227,13 @@ contract GenArt721CoreV3_Engine_Flex_PROOF is
     }
 
     /**
-     * Helper for calling `BytecodeStorageReaderV1` external library reader method,
+     * Helper for calling `BytecodeStorageReader` external library reader method,
      * added for bytecode size reduction purposes.
      */
     function _readFromBytecode(
         address _address
     ) internal view returns (string memory) {
-        return BytecodeStorageReaderV1.readFromBytecode(_address);
+        return BytecodeStorageReader.readFromBytecode(_address);
     }
 
     // strings library from OpenZeppelin, modified for no constants

--- a/contracts/engine/V3/forks/GenArt721CoreV3_Engine_Flex_PROOF.sol
+++ b/contracts/engine/V3/forks/GenArt721CoreV3_Engine_Flex_PROOF.sol
@@ -108,9 +108,7 @@ contract GenArt721CoreV3_Engine_Flex_PROOF is
     IGenArt721CoreContractV3_Engine_Flex
 {
     using BytecodeStorageWriterV1 for string;
-    using BytecodeStorageReaderV1 for string;
     using BytecodeStorageWriterV1 for address;
-    using BytecodeStorageReaderV1 for address;
     using Bytes32Strings for bytes32;
 
     uint256 constant ONE_HUNDRED = 100;
@@ -1775,7 +1773,7 @@ contract GenArt721CoreV3_Engine_Flex_PROOF is
         if (_index >= project.scriptCount) {
             return "";
         }
-        return project.scriptBytecodeAddresses[_index].readFromBytecode();
+        return _readFromBytecode(project.scriptBytecodeAddresses[_index]);
     }
 
     /**
@@ -2006,7 +2004,7 @@ contract GenArt721CoreV3_Engine_Flex_PROOF is
                 bytecodeAddress: _bytecodeAddress,
                 data: (_dependency.dependencyType ==
                     ExternalAssetDependencyType.ONCHAIN)
-                    ? _bytecodeAddress.readFromBytecode()
+                    ? _readFromBytecode(_bytecodeAddress)
                     : ""
             });
     }
@@ -2227,6 +2225,16 @@ contract GenArt721CoreV3_Engine_Flex_PROOF is
             projectOpen ||
             (block.timestamp - projectCompletedTimestamp <
                 FOUR_WEEKS_IN_SECONDS);
+    }
+
+    /**
+     * Helper for calling `BytecodeStorageReaderV1` external library reader method,
+     * added for gas-optimization purposes.
+     */
+    function _readFromBytecode(
+        address _address
+    ) internal view returns (string memory) {
+        return BytecodeStorageReaderV1.readFromBytecode(_address);
     }
 
     // strings library from OpenZeppelin, modified for no constants

--- a/contracts/engine/V3/forks/GenArt721CoreV3_Engine_Flex_PROOF.sol
+++ b/contracts/engine/V3/forks/GenArt721CoreV3_Engine_Flex_PROOF.sol
@@ -108,7 +108,6 @@ contract GenArt721CoreV3_Engine_Flex_PROOF is
     IGenArt721CoreContractV3_Engine_Flex
 {
     using BytecodeStorageWriterV1 for string;
-    using BytecodeStorageWriterV1 for address;
     using Bytes32Strings for bytes32;
 
     uint256 constant ONE_HUNDRED = 100;

--- a/contracts/engine/V3/forks/PROHIBITION/GenArt721CoreV3_Engine_Flex_PROHIBITION.sol
+++ b/contracts/engine/V3/forks/PROHIBITION/GenArt721CoreV3_Engine_Flex_PROHIBITION.sol
@@ -109,7 +109,6 @@ contract GenArt721CoreV3_Engine_Flex_PROHIBITION is
     IGenArt721CoreContractV3_Engine_Flex_PROHIBITION
 {
     using BytecodeStorageWriterV1 for string;
-    using BytecodeStorageWriterV1 for address;
     using Bytes32Strings for bytes32;
     uint256 constant ONE_HUNDRED = 100;
     uint256 constant ONE_MILLION = 1_000_000;

--- a/contracts/engine/V3/forks/PROHIBITION/GenArt721CoreV3_Engine_Flex_PROHIBITION.sol
+++ b/contracts/engine/V3/forks/PROHIBITION/GenArt721CoreV3_Engine_Flex_PROHIBITION.sol
@@ -2277,7 +2277,7 @@ contract GenArt721CoreV3_Engine_Flex_PROHIBITION is
 
     /**
      * Helper for calling `BytecodeStorageReaderV1` external library reader method,
-     * added for gas-optimization purposes.
+     * added for bytecode size reduction purposes.
      */
     function _readFromBytecode(
         address _address

--- a/contracts/engine/V3/forks/PROHIBITION/GenArt721CoreV3_Engine_Flex_PROHIBITION.sol
+++ b/contracts/engine/V3/forks/PROHIBITION/GenArt721CoreV3_Engine_Flex_PROHIBITION.sol
@@ -108,7 +108,7 @@ contract GenArt721CoreV3_Engine_Flex_PROHIBITION is
     IManifold,
     IGenArt721CoreContractV3_Engine_Flex_PROHIBITION
 {
-    using BytecodeStorageWriterV1 for string;
+    using BytecodeStorageWriter for string;
     using Bytes32Strings for bytes32;
     uint256 constant ONE_HUNDRED = 100;
     uint256 constant ONE_MILLION = 1_000_000;
@@ -2276,13 +2276,13 @@ contract GenArt721CoreV3_Engine_Flex_PROHIBITION is
     }
 
     /**
-     * Helper for calling `BytecodeStorageReaderV1` external library reader method,
+     * Helper for calling `BytecodeStorageReader` external library reader method,
      * added for bytecode size reduction purposes.
      */
     function _readFromBytecode(
         address _address
     ) internal view returns (string memory) {
-        return BytecodeStorageReaderV1.readFromBytecode(_address);
+        return BytecodeStorageReader.readFromBytecode(_address);
     }
 
     // strings library from OpenZeppelin, modified for no constants

--- a/contracts/engine/V3/forks/PROHIBITION/GenArt721CoreV3_Engine_Flex_PROHIBITION.sol
+++ b/contracts/engine/V3/forks/PROHIBITION/GenArt721CoreV3_Engine_Flex_PROHIBITION.sol
@@ -108,8 +108,10 @@ contract GenArt721CoreV3_Engine_Flex_PROHIBITION is
     IManifold,
     IGenArt721CoreContractV3_Engine_Flex_PROHIBITION
 {
-    using BytecodeStorage for string;
-    using BytecodeStorage for address;
+    using BytecodeStorageWriterV1 for string;
+    using BytecodeStorageReaderV1 for string;
+    using BytecodeStorageWriterV1 for address;
+    using BytecodeStorageReaderV1 for address;
     using Bytes32Strings for bytes32;
     uint256 constant ONE_HUNDRED = 100;
     uint256 constant ONE_MILLION = 1_000_000;

--- a/contracts/engine/V3/forks/PROHIBITION/GenArt721CoreV3_Engine_Flex_PROHIBITION.sol
+++ b/contracts/engine/V3/forks/PROHIBITION/GenArt721CoreV3_Engine_Flex_PROHIBITION.sol
@@ -109,9 +109,7 @@ contract GenArt721CoreV3_Engine_Flex_PROHIBITION is
     IGenArt721CoreContractV3_Engine_Flex_PROHIBITION
 {
     using BytecodeStorageWriterV1 for string;
-    using BytecodeStorageReaderV1 for string;
     using BytecodeStorageWriterV1 for address;
-    using BytecodeStorageReaderV1 for address;
     using Bytes32Strings for bytes32;
     uint256 constant ONE_HUNDRED = 100;
     uint256 constant ONE_MILLION = 1_000_000;
@@ -1783,7 +1781,7 @@ contract GenArt721CoreV3_Engine_Flex_PROHIBITION is
         if (_index >= project.scriptCount) {
             return "";
         }
-        return project.scriptBytecodeAddresses[_index].readFromBytecode();
+        return _readFromBytecode(project.scriptBytecodeAddresses[_index]);
     }
 
     /**
@@ -2014,7 +2012,7 @@ contract GenArt721CoreV3_Engine_Flex_PROHIBITION is
                 bytecodeAddress: _bytecodeAddress,
                 data: (_dependency.dependencyType ==
                     ExternalAssetDependencyType.ONCHAIN)
-                    ? _bytecodeAddress.readFromBytecode()
+                    ? _readFromBytecode(_bytecodeAddress)
                     : ""
             });
     }
@@ -2276,6 +2274,16 @@ contract GenArt721CoreV3_Engine_Flex_PROHIBITION is
             projectOpen ||
             (block.timestamp - projectCompletedTimestamp <
                 FOUR_WEEKS_IN_SECONDS);
+    }
+
+    /**
+     * Helper for calling `BytecodeStorageReaderV1` external library reader method,
+     * added for gas-optimization purposes.
+     */
+    function _readFromBytecode(
+        address _address
+    ) internal view returns (string memory) {
+        return BytecodeStorageReaderV1.readFromBytecode(_address);
     }
 
     // strings library from OpenZeppelin, modified for no constants

--- a/contracts/explorations/GenArt721CoreV3_Explorations.sol
+++ b/contracts/explorations/GenArt721CoreV3_Explorations.sol
@@ -93,7 +93,6 @@ contract GenArt721CoreV3_Explorations is
     IGenArt721CoreContractExposesHashSeed
 {
     using BytecodeStorageWriterV1 for string;
-    using BytecodeStorageWriterV1 for address;
     using Bytes32Strings for bytes32;
     using Strings for uint256;
     using Strings for address;

--- a/contracts/explorations/GenArt721CoreV3_Explorations.sol
+++ b/contracts/explorations/GenArt721CoreV3_Explorations.sol
@@ -1953,7 +1953,7 @@ contract GenArt721CoreV3_Explorations is
 
     /**
      * Helper for calling `BytecodeStorageReaderV1` external library reader method,
-     * added for gas-optimization purposes.
+     * added for bytecode size reduction purposes.
      */
     function _readFromBytecode(
         address _address

--- a/contracts/explorations/GenArt721CoreV3_Explorations.sol
+++ b/contracts/explorations/GenArt721CoreV3_Explorations.sol
@@ -92,7 +92,7 @@ contract GenArt721CoreV3_Explorations is
     IGenArt721CoreContractV3,
     IGenArt721CoreContractExposesHashSeed
 {
-    using BytecodeStorageWriterV1 for string;
+    using BytecodeStorageWriter for string;
     using Bytes32Strings for bytes32;
     using Strings for uint256;
     using Strings for address;
@@ -1952,12 +1952,12 @@ contract GenArt721CoreV3_Explorations is
     }
 
     /**
-     * Helper for calling `BytecodeStorageReaderV1` external library reader method,
+     * Helper for calling `BytecodeStorageReader` external library reader method,
      * added for bytecode size reduction purposes.
      */
     function _readFromBytecode(
         address _address
     ) internal view returns (string memory) {
-        return BytecodeStorageReaderV1.readFromBytecode(_address);
+        return BytecodeStorageReader.readFromBytecode(_address);
     }
 }

--- a/contracts/explorations/GenArt721CoreV3_Explorations.sol
+++ b/contracts/explorations/GenArt721CoreV3_Explorations.sol
@@ -93,9 +93,7 @@ contract GenArt721CoreV3_Explorations is
     IGenArt721CoreContractExposesHashSeed
 {
     using BytecodeStorageWriterV1 for string;
-    using BytecodeStorageReaderV1 for string;
     using BytecodeStorageWriterV1 for address;
-    using BytecodeStorageReaderV1 for address;
     using Bytes32Strings for bytes32;
     using Strings for uint256;
     using Strings for address;
@@ -1501,7 +1499,7 @@ contract GenArt721CoreV3_Explorations is
         if (_index >= project.scriptCount) {
             return "";
         }
-        return project.scriptBytecodeAddresses[_index].readFromBytecode();
+        return _readFromBytecode(project.scriptBytecodeAddresses[_index]);
     }
 
     /**
@@ -1952,5 +1950,15 @@ contract GenArt721CoreV3_Explorations is
             projectOpen ||
             (block.timestamp - projectCompletedTimestamp <
                 FOUR_WEEKS_IN_SECONDS);
+    }
+
+    /**
+     * Helper for calling `BytecodeStorageReaderV1` external library reader method,
+     * added for gas-optimization purposes.
+     */
+    function _readFromBytecode(
+        address _address
+    ) internal view returns (string memory) {
+        return BytecodeStorageReaderV1.readFromBytecode(_address);
     }
 }

--- a/contracts/explorations/GenArt721CoreV3_Explorations.sol
+++ b/contracts/explorations/GenArt721CoreV3_Explorations.sol
@@ -92,8 +92,10 @@ contract GenArt721CoreV3_Explorations is
     IGenArt721CoreContractV3,
     IGenArt721CoreContractExposesHashSeed
 {
-    using BytecodeStorage for string;
-    using BytecodeStorage for address;
+    using BytecodeStorageWriterV1 for string;
+    using BytecodeStorageReaderV1 for string;
+    using BytecodeStorageWriterV1 for address;
+    using BytecodeStorageReaderV1 for address;
     using Bytes32Strings for bytes32;
     using Strings for uint256;
     using Strings for address;

--- a/contracts/libs/0.8.x/BytecodeStorageV1.sol
+++ b/contracts/libs/0.8.x/BytecodeStorageV1.sol
@@ -45,6 +45,23 @@ pragma solidity ^0.8.0;
  *         standalone contract, and provides all _read_ functionality.
  */
 library BytecodeStorageReaderV1 {
+    // Define the set of known valid version strings that may be stored in the deployed storage contract bytecode
+    // note: These are all intentionally exactly 32-bytes and are null-terminated. Null-termination is used due
+    //       to this being the standard expected formatting in common web3 tooling such as ethers.js. Please see
+    //       the following for additional context: https://docs.ethers.org/v5/api/utils/strings/#Bytes32String
+    // Used for storage contracts that were deployed by an unknown source
+    bytes32 public constant UNKNOWN_VERSION_STRING =
+        "UNKNOWN_VERSION_STRING_________ ";
+    // Pre-dates versioning string, so this doesn't actually exist in any deployed contracts,
+    // but is useful for backwards-compatible semantics with original version of this library
+    bytes32 public constant V0_VERSION_STRING =
+        "BytecodeStorage_V0.0.0_________ ";
+    // The first versioned storage contract, deployed by an updated version of this library
+    bytes32 public constant V1_VERSION_STRING =
+        "BytecodeStorage_V1.0.0_________ ";
+    // The current version of this library.
+    bytes32 public constant CURRENT_VERSION = V1_VERSION_STRING;
+
     //---------------------------------------------------------------------------------------------------------------//
     // Starting Index | Size | Ending Index | Description                                                            //
     //---------------------------------------------------------------------------------------------------------------//
@@ -73,24 +90,6 @@ library BytecodeStorageReaderV1 {
     // concat(invalid opcode, version, deployer-address, data)
     uint256 private constant V1_ADDRESS_OFFSET = ADDRESS_OFFSET;
     uint256 private constant V1_DATA_OFFSET = DATA_OFFSET;
-
-    // Define the set of known valid version strings that may be stored in the deployed storage contract bytecode
-    // note: These are all intentionally exactly 32-bytes and are null-terminated. Null-termination is used due
-    //       to this being the standard expected formatting in common web3 tooling such as ethers.js. Please see
-    //       the following for additional context: https://docs.ethers.org/v5/api/utils/strings/#Bytes32String
-    // Used for storage contracts that were deployed by an unknown source
-    bytes32 private constant UNKNOWN_VERSION_STRING =
-        "UNKNOWN_VERSION_STRING_________ ";
-    // Pre-dates versioning string, so this doesn't actually exist in any deployed contracts,
-    // but is useful for backwards-compatible semantics with original version of this library
-    bytes32 private constant V0_VERSION_STRING =
-        "BytecodeStorage_V0.0.0_________ ";
-    // The first versioned storage contract, deployed by an updated version of this library
-    bytes32 private constant V1_VERSION_STRING =
-        "BytecodeStorage_V1.0.0_________ ";
-
-    // Provide a public getter for the version of this library.
-    bytes32 public constant CURRENT_VERSION = V1_VERSION_STRING;
 
     /*//////////////////////////////////////////////////////////////
                                READ LOGIC

--- a/contracts/libs/0.8.x/BytecodeStorageV1.sol
+++ b/contracts/libs/0.8.x/BytecodeStorageV1.sol
@@ -44,7 +44,7 @@ pragma solidity ^0.8.0;
  * @notice The public library for reading from storage contracts. This library is intended to be deployed as a
  *         standalone contract, and provides all _read_ functionality.
  */
-library BytecodeStorageReaderV1 {
+library BytecodeStorageReader {
     // Define the set of known valid version strings that may be stored in the deployed storage contract bytecode
     // note: These are all intentionally exactly 32-bytes and are null-terminated. Null-termination is used due
     //       to this being the standard expected formatting in common web3 tooling such as ethers.js. Please see
@@ -329,7 +329,7 @@ library BytecodeStorageReaderV1 {
  * @notice The internal library for writing to storage contracts. This library is intended to be deployed
  *         within library client contracts that use this library to perform _write_ operations on storage.
  */
-library BytecodeStorageWriterV1 {
+library BytecodeStorageWriter {
     /*//////////////////////////////////////////////////////////////
                            WRITE LOGIC
     //////////////////////////////////////////////////////////////*/
@@ -375,7 +375,7 @@ library BytecodeStorageWriterV1 {
             // c.) store the version string, which is already represented as a 32-byte value
             //---------------------------------------------------------------------------------------------------------------//
             // (32 bytes)
-            BytecodeStorageReaderV1.CURRENT_VERSION,
+            BytecodeStorageReader.CURRENT_VERSION,
             //---------------------------------------------------------------------------------------------------------------//
             // d.) store the deploying-contract's address with 0-padding to fit a 20-byte address into a 32-byte slot
             //---------------------------------------------------------------------------------------------------------------//

--- a/contracts/libs/0.8.x/BytecodeStorageV1.sol
+++ b/contracts/libs/0.8.x/BytecodeStorageV1.sol
@@ -56,37 +56,37 @@ library BytecodeStorageReaderV1 {
     // Define the offset for where the "meta bytes" end, and the "data bytes" begin. Note that this is a manually
     // calculated value, and must be updated if the above table is changed. It is expected that tests will fail
     // loudly if these values are not updated in-step with eachother.
-    uint256 internal constant VERSION_OFFSET = 1;
-    uint256 internal constant ADDRESS_OFFSET = 33;
-    uint256 internal constant DATA_OFFSET = 65;
+    uint256 private constant VERSION_OFFSET = 1;
+    uint256 private constant ADDRESS_OFFSET = 33;
+    uint256 private constant DATA_OFFSET = 65;
 
     // Define the set of known *historic* offset values for where the "meta bytes" end, and the "data bytes" begin.
     // SSTORE2 deployed storage contracts take the general format of:
     // concat(0x00, data)
     // note: this is true for both variants of the SSTORE2 library
-    uint256 internal constant SSTORE2_DATA_OFFSET = 1;
+    uint256 private constant SSTORE2_DATA_OFFSET = 1;
     // V0 deployed storage contracts take the general format of:
     // concat(gated-cleanup-logic, deployer-address, data)
-    uint256 internal constant V0_ADDRESS_OFFSET = 72;
-    uint256 internal constant V0_DATA_OFFSET = 104;
+    uint256 private constant V0_ADDRESS_OFFSET = 72;
+    uint256 private constant V0_DATA_OFFSET = 104;
     // V1 deployed storage contracts take the general format of:
     // concat(invalid opcode, version, deployer-address, data)
-    uint256 internal constant V1_ADDRESS_OFFSET = ADDRESS_OFFSET;
-    uint256 internal constant V1_DATA_OFFSET = DATA_OFFSET;
+    uint256 private constant V1_ADDRESS_OFFSET = ADDRESS_OFFSET;
+    uint256 private constant V1_DATA_OFFSET = DATA_OFFSET;
 
     // Define the set of known valid version strings that may be stored in the deployed storage contract bytecode
     // note: These are all intentionally exactly 32-bytes and are null-terminated. Null-termination is used due
     //       to this being the standard expected formatting in common web3 tooling such as ethers.js. Please see
     //       the following for additional context: https://docs.ethers.org/v5/api/utils/strings/#Bytes32String
     // Used for storage contracts that were deployed by an unknown source
-    bytes32 internal constant UNKNOWN_VERSION_STRING =
+    bytes32 private constant UNKNOWN_VERSION_STRING =
         "UNKNOWN_VERSION_STRING_________ ";
     // Pre-dates versioning string, so this doesn't actually exist in any deployed contracts,
     // but is useful for backwards-compatible semantics with original version of this library
-    bytes32 internal constant V0_VERSION_STRING =
+    bytes32 private constant V0_VERSION_STRING =
         "BytecodeStorage_V0.0.0_________ ";
     // The first versioned storage contract, deployed by an updated version of this library
-    bytes32 internal constant V1_VERSION_STRING =
+    bytes32 private constant V1_VERSION_STRING =
         "BytecodeStorage_V1.0.0_________ ";
 
     // Provide a public getter for the version of this library.

--- a/contracts/libs/0.8.x/BytecodeStorageV1.sol
+++ b/contracts/libs/0.8.x/BytecodeStorageV1.sol
@@ -5,13 +5,13 @@ pragma solidity ^0.8.0;
 
 /**
  * @title Art Blocks Script Storage Library
- * @notice Utilize contract bytecode as persistant storage for large chunks of script string data.
+ * @notice Utilize contract bytecode as persistent storage for large chunks of script string data.
  *         This library is intended to have an external deployed copy that is released in the future,
  *         and, as such, has been designed to support both updated V1 (versioned, with purging removed)
  *         reads as well as backwards-compatible reads for both a) the unversioned "V0" storage contracts
  *         which were deployed by the original version of this libary and b) contracts that were deployed
  *         using one of the SSTORE2 implementations referenced below.
- *         For these pre-V1 storage contracts (which themselves did not have any explict versioning semantics)
+ *         For these pre-V1 storage contracts (which themselves did not have any explicit versioning semantics)
  *         backwards-compatible reads are optimistic, and only expected to work for contracts actually
  *         deployed by the original version of this library – and may fail ungracefully if attempted to be
  *         used to read from other contracts.

--- a/contracts/mock/BytecodeV1TextCR_DMock.sol
+++ b/contracts/mock/BytecodeV1TextCR_DMock.sol
@@ -22,8 +22,10 @@ import "../libs/0.8.x/BytecodeStorageV1.sol";
  *         supported by the underlying library.
  */
 contract BytecodeV1TextCR_DMock {
-    using BytecodeStorage for string;
-    using BytecodeStorage for address;
+    using BytecodeStorageWriterV1 for string;
+    using BytecodeStorageReaderV1 for string;
+    using BytecodeStorageWriterV1 for address;
+    using BytecodeStorageReaderV1 for address;
 
     // monotonically increasing slot counter and associated slot-storage mapping
     uint256 public nextTextSlotId = 0;

--- a/contracts/mock/BytecodeV1TextCR_DMock.sol
+++ b/contracts/mock/BytecodeV1TextCR_DMock.sol
@@ -23,9 +23,7 @@ import "../libs/0.8.x/BytecodeStorageV1.sol";
  */
 contract BytecodeV1TextCR_DMock {
     using BytecodeStorageWriterV1 for string;
-    using BytecodeStorageReaderV1 for string;
     using BytecodeStorageWriterV1 for address;
-    using BytecodeStorageReaderV1 for address;
 
     // monotonically increasing slot counter and associated slot-storage mapping
     uint256 public nextTextSlotId = 0;
@@ -79,7 +77,10 @@ contract BytecodeV1TextCR_DMock {
      *      the underlying BytecodeStorage lib to throw errors where applicable.
      */
     function readText(uint256 _textSlotId) public view returns (string memory) {
-        return storedTextBytecodeAddresses[_textSlotId].readFromBytecode();
+        return
+            BytecodeStorageReaderV1.readFromBytecode(
+                storedTextBytecodeAddresses[_textSlotId]
+            );
     }
 
     /**
@@ -110,7 +111,7 @@ contract BytecodeV1TextCR_DMock {
     function readTextAtAddress(
         address _bytecodeAddress
     ) public view returns (string memory) {
-        return _bytecodeAddress.readFromBytecode();
+        return BytecodeStorageReaderV1.readFromBytecode(_bytecodeAddress);
     }
 
     /**
@@ -128,7 +129,13 @@ contract BytecodeV1TextCR_DMock {
         address _bytecodeAddress,
         uint256 _offset
     ) public view returns (string memory) {
-        return string(_bytecodeAddress.readBytesFromBytecode(_offset));
+        return
+            string(
+                BytecodeStorageReaderV1.readBytesFromBytecode(
+                    _bytecodeAddress,
+                    _offset
+                )
+            );
     }
 
     /**
@@ -143,7 +150,12 @@ contract BytecodeV1TextCR_DMock {
     function readSSTORE2TextAtAddress(
         address _bytecodeAddress
     ) public view returns (string memory) {
-        return string(_bytecodeAddress.readBytesFromSSTORE2Bytecode());
+        return
+            string(
+                BytecodeStorageReaderV1.readBytesFromSSTORE2Bytecode(
+                    _bytecodeAddress
+                )
+            );
     }
 
     /**
@@ -158,7 +170,10 @@ contract BytecodeV1TextCR_DMock {
     function readAuthorForTextAtAddress(
         address _bytecodeAddress
     ) public view returns (address) {
-        return _bytecodeAddress.getWriterAddressForBytecode();
+        return
+            BytecodeStorageReaderV1.getWriterAddressForBytecode(
+                _bytecodeAddress
+            );
     }
 
     /**
@@ -173,7 +188,10 @@ contract BytecodeV1TextCR_DMock {
     function readLibraryVersionForTextAtAddress(
         address _bytecodeAddress
     ) public view returns (bytes32) {
-        return _bytecodeAddress.getLibraryVersionForBytecode();
+        return
+            BytecodeStorageReaderV1.getLibraryVersionForBytecode(
+                _bytecodeAddress
+            );
     }
 
     /**

--- a/contracts/mock/BytecodeV1TextCR_DMock.sol
+++ b/contracts/mock/BytecodeV1TextCR_DMock.sol
@@ -23,7 +23,6 @@ import "../libs/0.8.x/BytecodeStorageV1.sol";
  */
 contract BytecodeV1TextCR_DMock {
     using BytecodeStorageWriterV1 for string;
-    using BytecodeStorageWriterV1 for address;
 
     // monotonically increasing slot counter and associated slot-storage mapping
     uint256 public nextTextSlotId = 0;

--- a/contracts/mock/BytecodeV1TextCR_DMock.sol
+++ b/contracts/mock/BytecodeV1TextCR_DMock.sol
@@ -22,7 +22,7 @@ import "../libs/0.8.x/BytecodeStorageV1.sol";
  *         supported by the underlying library.
  */
 contract BytecodeV1TextCR_DMock {
-    using BytecodeStorageWriterV1 for string;
+    using BytecodeStorageWriter for string;
 
     // monotonically increasing slot counter and associated slot-storage mapping
     uint256 public nextTextSlotId = 0;
@@ -77,7 +77,7 @@ contract BytecodeV1TextCR_DMock {
      */
     function readText(uint256 _textSlotId) public view returns (string memory) {
         return
-            BytecodeStorageReaderV1.readFromBytecode(
+            BytecodeStorageReader.readFromBytecode(
                 storedTextBytecodeAddresses[_textSlotId]
             );
     }
@@ -110,7 +110,7 @@ contract BytecodeV1TextCR_DMock {
     function readTextAtAddress(
         address _bytecodeAddress
     ) public view returns (string memory) {
-        return BytecodeStorageReaderV1.readFromBytecode(_bytecodeAddress);
+        return BytecodeStorageReader.readFromBytecode(_bytecodeAddress);
     }
 
     /**
@@ -130,7 +130,7 @@ contract BytecodeV1TextCR_DMock {
     ) public view returns (string memory) {
         return
             string(
-                BytecodeStorageReaderV1.readBytesFromBytecode(
+                BytecodeStorageReader.readBytesFromBytecode(
                     _bytecodeAddress,
                     _offset
                 )
@@ -151,7 +151,7 @@ contract BytecodeV1TextCR_DMock {
     ) public view returns (string memory) {
         return
             string(
-                BytecodeStorageReaderV1.readBytesFromSSTORE2Bytecode(
+                BytecodeStorageReader.readBytesFromSSTORE2Bytecode(
                     _bytecodeAddress
                 )
             );
@@ -170,9 +170,7 @@ contract BytecodeV1TextCR_DMock {
         address _bytecodeAddress
     ) public view returns (address) {
         return
-            BytecodeStorageReaderV1.getWriterAddressForBytecode(
-                _bytecodeAddress
-            );
+            BytecodeStorageReader.getWriterAddressForBytecode(_bytecodeAddress);
     }
 
     /**
@@ -188,7 +186,7 @@ contract BytecodeV1TextCR_DMock {
         address _bytecodeAddress
     ) public view returns (bytes32) {
         return
-            BytecodeStorageReaderV1.getLibraryVersionForBytecode(
+            BytecodeStorageReader.getLibraryVersionForBytecode(
                 _bytecodeAddress
             );
     }

--- a/contracts/mock/GenArt721CoreV3_Engine_IncorrectCoreType.sol
+++ b/contracts/mock/GenArt721CoreV3_Engine_IncorrectCoreType.sol
@@ -31,7 +31,6 @@ contract GenArt721CoreV3_Engine_IncorrectCoreType is
     // INTERFACE CONFORMANCE INTENTIONALLY OMITTED TO ENABLE MOCKING BUGGED CONTRACT
 {
     using BytecodeStorageWriterV1 for string;
-    using BytecodeStorageWriterV1 for address;
     using Bytes32Strings for bytes32;
     using Strings for uint256;
     using Strings for address;

--- a/contracts/mock/GenArt721CoreV3_Engine_IncorrectCoreType.sol
+++ b/contracts/mock/GenArt721CoreV3_Engine_IncorrectCoreType.sol
@@ -1956,7 +1956,7 @@ contract GenArt721CoreV3_Engine_IncorrectCoreType is
 
     /**
      * Helper for calling `BytecodeStorageReaderV1` external library reader method,
-     * added for gas-optimization purposes.
+     * added for bytecode size reduction purposes.
      */
     function _readFromBytecode(
         address _address

--- a/contracts/mock/GenArt721CoreV3_Engine_IncorrectCoreType.sol
+++ b/contracts/mock/GenArt721CoreV3_Engine_IncorrectCoreType.sol
@@ -30,7 +30,7 @@ contract GenArt721CoreV3_Engine_IncorrectCoreType is
     IManifold
     // INTERFACE CONFORMANCE INTENTIONALLY OMITTED TO ENABLE MOCKING BUGGED CONTRACT
 {
-    using BytecodeStorageWriterV1 for string;
+    using BytecodeStorageWriter for string;
     using Bytes32Strings for bytes32;
     using Strings for uint256;
     using Strings for address;
@@ -1955,12 +1955,12 @@ contract GenArt721CoreV3_Engine_IncorrectCoreType is
     }
 
     /**
-     * Helper for calling `BytecodeStorageReaderV1` external library reader method,
+     * Helper for calling `BytecodeStorageReader` external library reader method,
      * added for bytecode size reduction purposes.
      */
     function _readFromBytecode(
         address _address
     ) internal view returns (string memory) {
-        return BytecodeStorageReaderV1.readFromBytecode(_address);
+        return BytecodeStorageReader.readFromBytecode(_address);
     }
 }

--- a/contracts/mock/GenArt721CoreV3_Engine_IncorrectCoreType.sol
+++ b/contracts/mock/GenArt721CoreV3_Engine_IncorrectCoreType.sol
@@ -30,8 +30,10 @@ contract GenArt721CoreV3_Engine_IncorrectCoreType is
     IManifold
     // INTERFACE CONFORMANCE INTENTIONALLY OMITTED TO ENABLE MOCKING BUGGED CONTRACT
 {
-    using BytecodeStorage for string;
-    using BytecodeStorage for address;
+    using BytecodeStorageWriterV1 for string;
+    using BytecodeStorageReaderV1 for string;
+    using BytecodeStorageWriterV1 for address;
+    using BytecodeStorageReaderV1 for address;
     using Bytes32Strings for bytes32;
     using Strings for uint256;
     using Strings for address;

--- a/contracts/mock/GenArt721CoreV3_Engine_IncorrectCoreType.sol
+++ b/contracts/mock/GenArt721CoreV3_Engine_IncorrectCoreType.sol
@@ -31,9 +31,7 @@ contract GenArt721CoreV3_Engine_IncorrectCoreType is
     // INTERFACE CONFORMANCE INTENTIONALLY OMITTED TO ENABLE MOCKING BUGGED CONTRACT
 {
     using BytecodeStorageWriterV1 for string;
-    using BytecodeStorageReaderV1 for string;
     using BytecodeStorageWriterV1 for address;
-    using BytecodeStorageReaderV1 for address;
     using Bytes32Strings for bytes32;
     using Strings for uint256;
     using Strings for address;
@@ -1560,7 +1558,7 @@ contract GenArt721CoreV3_Engine_IncorrectCoreType is
         if (_index >= project.scriptCount) {
             return "";
         }
-        return project.scriptBytecodeAddresses[_index].readFromBytecode();
+        return _readFromBytecode(project.scriptBytecodeAddresses[_index]);
     }
 
     /**
@@ -1955,5 +1953,15 @@ contract GenArt721CoreV3_Engine_IncorrectCoreType is
             projectOpen ||
             (block.timestamp - projectCompletedTimestamp <
                 FOUR_WEEKS_IN_SECONDS);
+    }
+
+    /**
+     * Helper for calling `BytecodeStorageReaderV1` external library reader method,
+     * added for gas-optimization purposes.
+     */
+    function _readFromBytecode(
+        address _address
+    ) internal view returns (string memory) {
+        return BytecodeStorageReaderV1.readFromBytecode(_address);
     }
 }

--- a/deployments/engine/V3/internal-testing/staging-v3-react-demo-2/DEPLOYMENTS.md
+++ b/deployments/engine/V3/internal-testing/staging-v3-react-demo-2/DEPLOYMENTS.md
@@ -1,0 +1,42 @@
+
+# Deployment
+
+Date: 2023-05-04T19:39:28.024Z
+
+## **Network:** goerli
+
+## **Environment:** staging
+
+**Deployment Input File:** `deployments/engine/V3/internal-testing/staging-v3-react-demo-2/deployment-config.staging.ts`
+
+**GenArt721CoreV3_Engine:** https://goerli.etherscan.io/address/0xFb2480C9c02F3222d1299330976DACEB98009800#code
+
+**AdminACLV1:** https://goerli.etherscan.io/address/0xeA28d75dd6e3108000E4d0E1411A58b872248024#code
+
+**Engine Registry:** https://goerli.etherscan.io/address/0xEa698596b6009A622C3eD00dD5a8b5d1CAE4fC36#code
+
+**MinterFilterV1:** https://goerli.etherscan.io/address/0x682A5aB4d364a5CB5Ee372F6F5727C91431B8F10#code
+
+**Minters:**
+
+**MinterSetPriceV4:** https://goerli.etherscan.io/address/0xE4aF88B3E9a3045537339Fc05fd5F211fBFD92Df#code
+
+
+
+**Metadata**
+
+- **Starting Project Id:** 0
+- **Token Name:** V3 Engine Demo External Reader Lib
+- **Token Ticker:** DEMO
+- **Auto Approve Artist Split Proposals:** true
+- **Render Provider Address, Primary Sales:** deployer
+- **Platform Provider Address, Primary Sales:** deployer
+
+**Other**
+
+- **Add initial project?:** true
+- **Add initial token?:** true
+- **Image Bucket:** v3-engine-demo-external-reader-lib-goerli
+
+---
+

--- a/deployments/engine/V3/internal-testing/staging-v3-react-demo-2/DEPLOYMENT_LOGS.log
+++ b/deployments/engine/V3/internal-testing/staging-v3-react-demo-2/DEPLOYMENT_LOGS.log
@@ -1,0 +1,66 @@
+----------------------------------------
+[INFO] Datetime of deployment: 2023-05-04T19:33:15.886Z
+[INFO] Deployment configuration file: /Users/jakerockland/Code/artblocks-contracts/deployments/engine/V3/internal-testing/staging-v3-react-demo-2/deployment-config.staging.ts
+[INFO] Deploying to network: goerli
+[INFO] Deploying to environment: staging
+[INFO] New Admin ACL AdminACLV1 deployed at address: 0xeA28d75dd6e3108000E4d0E1411A58b872248024
+[INFO] Randomizer BasicRandomizerV2 deployed at g0x399fa387324E4588047BBe1598e3691AB94c7e5C
+[INFO] Core GenArt721CoreV3_Engine deployed at 0xFb2480C9c02F3222d1299330976DACEB98009800
+[INFO] Minter Filter MinterFilterV1 deployed at 0x682A5aB4d364a5CB5Ee372F6F5727C91431B8F10
+[INFO] MinterSetPriceV4 deployed at 0xE4aF88B3E9a3045537339Fc05fd5F211fBFD92Df
+[INFO] Assigned randomizer to core and renounced ownership of randomizer
+[INFO] Updated the Minter Filter on the Core contract to 0x682A5aB4d364a5CB5Ee372F6F5727C91431B8F10.
+[INFO] Allowlisted minter MinterSetPriceV4 at 0xE4aF88B3E9a3045537339Fc05fd5F211fBFD92Df on minter filter.
+[INFO] Added V3 Engine Demo External Reader Lib project 0 placeholder on V3 Engine Demo External Reader Lib contract, artist is 0xB8559AF91377e5BaB052A4E9a5088cB65a9a4d63.
+[INFO] Configured set price minter (0xE4aF88B3E9a3045537339Fc05fd5F211fBFD92Df) for project 0.
+[INFO] Configured minter price project 0.
+[INFO] Minted token 0 for project 0.
+[INFO] Skipping transfer of superAdmin role on adminACL.
+[INFO] Verifying core contract contract deployment...
+Nothing to compile
+Successfully submitted source code for contract
+contracts/engine/V3/GenArt721CoreV3_Engine.sol:GenArt721CoreV3_Engine at 0xFb2480C9c02F3222d1299330976DACEB98009800
+for verification on the block explorer. Waiting for verification result...
+
+Successfully verified contract GenArt721CoreV3_Engine on Etherscan.
+https://goerli.etherscan.io/address/0xFb2480C9c02F3222d1299330976DACEB98009800#code
+[INFO] Core contract verified on Etherscan at 0xFb2480C9c02F3222d1299330976DACEB98009800}
+[INFO] Verifying AdminACL contract deployment...
+Compiled 209 Solidity files successfully
+Successfully submitted source code for contract
+contracts/AdminACLV1.sol:AdminACLV1 at 0xeA28d75dd6e3108000E4d0E1411A58b872248024
+for verification on the block explorer. Waiting for verification result...
+
+Successfully verified contract AdminACLV1 on Etherscan.
+https://goerli.etherscan.io/address/0xeA28d75dd6e3108000E4d0E1411A58b872248024#code
+[INFO] AdminACL contract verified on Etherscan at 0xeA28d75dd6e3108000E4d0E1411A58b872248024}
+[INFO] Verifying MinterFilter contract deployment...
+The contract 0x682A5aB4d364a5CB5Ee372F6F5727C91431B8F10 has already been verified
+[INFO] MinterFilter contract verified on Etherscan at 0x682A5aB4d364a5CB5Ee372F6F5727C91431B8F10}
+[INFO] Verifying MinterSetPriceV4 contract deployment...
+The contract 0xE4aF88B3E9a3045537339Fc05fd5F211fBFD92Df has already been verified
+[INFO] MinterSetPriceV4 contract verified on Etherscan at 0xE4aF88B3E9a3045537339Fc05fd5F211fBFD92Df}
+Created s3 bucket for https://v3-engine-demo-external-reader-lib-goerli.s3.amazonaws.com
+[INFO] Created image bucket v3-engine-demo-external-reader-lib-goerli
+[INFO] Deployment details written to /Users/jakerockland/Code/artblocks-contracts/deployments/engine/V3/internal-testing/staging-v3-react-demo-2/DEPLOYMENTS.md
+Upserting 1 contract...
+Contracts metadata upsert input:
+{
+  "address": "0xfb2480c9c02f3222d1299330976daceb98009800",
+  "name": "V3 Engine Demo External Reader Lib",
+  "bucket_name": "v3-engine-demo-external-reader-lib-goerli",
+  "default_vertical_name": "fullyonchain"
+}
+Successfully upserted 1 contract
+Upserting 1 project...
+Projects metadata upsert input:
+{
+  "id": "0xfb2480c9c02f3222d1299330976daceb98009800-0",
+  "contract_address": "0xfb2480c9c02f3222d1299330976daceb98009800",
+  "project_id": "0",
+  "artist_address": "0xb8559af91377e5bab052a4e9a5088cb65a9a4d63",
+  "vertical_name": "fullyonchain"
+}
+Successfully upserted 1 project
+[ACTION] provider primary and secondary sales payment addresses remain as deployer addresses: 0xB8559AF91377e5BaB052A4E9a5088cB65a9a4d63. Update later as needed.
+[ACTION] AdminACL's superAdmin address is 0xB8559AF91377e5BaB052A4E9a5088cB65a9a4d63, don't forget to update if requred.

--- a/deployments/engine/V3/internal-testing/staging-v3-react-demo-2/deployment-config.staging.ts
+++ b/deployments/engine/V3/internal-testing/staging-v3-react-demo-2/deployment-config.staging.ts
@@ -1,0 +1,50 @@
+// This file is used to configure the deployment of the Engine Partner contracts
+// It is intended to be imported by the generic deployer by running `deploy:mainnet:v3-engine`, `deploy:staging:v3-engine` or `deploy:dev:v3-engine`.
+export const deployDetailsArray = [
+  {
+    network: "goerli",
+    // environment is only used for metadata purposes, and is not used in the deployment process
+    // Please set to "dev", "staging", or "mainnet", as appropriate
+    environment: "staging",
+    // if you want to use an existing admin ACL, set the address here (otherwise set as undefined to deploy a new one)
+    existingAdminACL: undefined,
+    // the following can be undefined if you are using an existing admin ACL, otherwise define the Admin ACL contract name
+    // if deploying a new AdminACL
+    adminACLContractName: "AdminACLV1",
+    // See the `KNOWN_ENGINE_REGISTRIES` object in `/scripts/engine/V3/constants.ts` for the correct registry address for
+    // the intended network and the corresponding deployer wallet addresses
+    // @dev if you neeed a new engine registry, use the `/scripts/engine/V3/engine-registry-deployer.ts` script
+    engineRegistryAddress: "0xEa698596b6009A622C3eD00dD5a8b5d1CAE4fC36",
+    randomizerContractName: "BasicRandomizerV2",
+    genArt721CoreContractName: "GenArt721CoreV3_Engine",
+    tokenName: "V3 Engine Demo External Reader Lib",
+    tokenTicker: "DEMO",
+    startingProjectId: 0,
+    autoApproveArtistSplitProposals: true,
+    renderProviderAddress: "deployer", // use either "0x..." or special "deployer" which sets the render provider to the deployer
+    platformProviderAddress: "deployer", // use either "0x..." or special "deployer" which sets the render provider to the deployer
+    // minter suite
+    minterFilterContractName: "MinterFilterV1",
+    minters: [
+      // include any of the most recent minter contracts the engine partner wishes to use
+      // @dev ensure the minter contracts here are the latest versions
+      "MinterSetPriceV4",
+    ],
+    // set to true if you want to add an initial project to the core contract
+    addInitialProject: true,
+    // set to true if you want to add an initial token to the initial project
+    // (this will only work if you have set addInitialProject to true, and requires a MinterSetPriceV[4-9])
+    addInitialToken: true,
+    // set to true if you want to transfer the superAdmin role to a different address
+    doTransferSuperAdmin: false,
+    // set to the address you want to transfer the superAdmin role to
+    // (this will only work if you have set doTransferSuperAdmin to true, can be undefined if you are not transferring)
+    newSuperAdminAddress: undefined, // use either "0x..." or undefined if not transferring
+    // optionally define this to set default vertical name for the contract after deployment.
+    // if not defined, the default vertical name will be "unassigned".
+    // common values include `fullyonchain`, `flex`, or partnerships like `artblocksxpace`.
+    // also note that if you desire to create a new veritcal, you will need to add the vertical name to the
+    // `project_verticals` table in the database before running this deploy script.
+    defaultVerticalName: "fullyonchain",
+  },
+];

--- a/hardhat.solidity-config.ts
+++ b/hardhat.solidity-config.ts
@@ -2,11 +2,11 @@
 export const solidityConfig = {
   compilers: [
     {
-      version: "0.5.17",
+      version: "0.8.17",
       settings: {
         optimizer: {
           enabled: true,
-          runs: 100,
+          runs: 10,
         },
       },
     },
@@ -20,11 +20,11 @@ export const solidityConfig = {
       },
     },
     {
-      version: "0.8.17",
+      version: "0.5.17",
       settings: {
         optimizer: {
           enabled: true,
-          runs: 10,
+          runs: 100,
         },
       },
     },

--- a/hardhat.solidity-config.ts
+++ b/hardhat.solidity-config.ts
@@ -24,7 +24,7 @@ export const solidityConfig = {
       settings: {
         optimizer: {
           enabled: true,
-          runs: 25,
+          runs: 10,
         },
       },
     },

--- a/scripts/bytecode-storage/bytecode-storage-deployer-goerli.ts
+++ b/scripts/bytecode-storage/bytecode-storage-deployer-goerli.ts
@@ -1,0 +1,70 @@
+// This file can be used to deploy new copies of the shared
+// public BytecodeStorageReader library, which is intended to
+// be used as an externally linked library.
+// SPDX-License-Identifier: LGPL-3.0-only
+// Created By: Art Blocks Inc.
+import hre from "hardhat";
+import { ethers } from "hardhat";
+import { tryVerify } from "../util/verification";
+
+/**
+ * This file can be used to deploy new copies of the shared
+ * public BytecodeStorageReader library, which is intended to
+ * be used as an externally linked library.
+ */
+//////////////////////////////////////////////////////////////////////////////
+// CONFIG BEGINS HERE
+//////////////////////////////////////////////////////////////////////////////
+const intendedNetwork = "goerli"; // "goerli" or "mainnet"
+const libraryContractName = "BytecodeStorageReader";
+//////////////////////////////////////////////////////////////////////////////
+// CONFIG ENDS HERE
+//////////////////////////////////////////////////////////////////////////////
+async function main() {
+  const [deployer] = await ethers.getSigners();
+  const network = await ethers.provider.getNetwork();
+  const networkName = network.name == "homestead" ? "mainnet" : network.name;
+  if (networkName != intendedNetwork) {
+    throw new Error(
+      `[ERROR] This script is intended to be run on ${intendedNetwork} only`
+    );
+  }
+  //////////////////////////////////////////////////////////////////////////////
+  // DEPLOYMENT BEGINS HERE
+  //////////////////////////////////////////////////////////////////////////////
+
+  // Deploy library
+  const libraryFactory = await ethers.getContractFactory(
+    libraryContractName
+  );
+  const library = await libraryFactory.deploy();
+  await library.deployed();
+  const libraryAddress = library.address;
+  console.log(`[INFO] ${intendedNetwork} ${libraryContractName} deployed at: ${libraryAddress}`);
+
+  //////////////////////////////////////////////////////////////////////////////
+  // DEPLOYMENT ENDS HERE
+  //////////////////////////////////////////////////////////////////////////////
+
+  //////////////////////////////////////////////////////////////////////////////
+  // VERIFICATION BEGINS HERE
+  //////////////////////////////////////////////////////////////////////////////
+
+  // Output instructions for manual Etherscan verification.
+  await tryVerify(libraryContractName, libraryAddress, [], networkName);
+
+  console.log(
+    `[INFO] Deployment complete! Please record deployment details in the top-level README of this repo.`
+  );
+
+  //////////////////////////////////////////////////////////////////////////////
+  // VERIFICATION ENDS HERE
+  //////////////////////////////////////////////////////////////////////////////
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/bytecode-storage/bytecode-storage-deployer-goerli.ts
+++ b/scripts/bytecode-storage/bytecode-storage-deployer-goerli.ts
@@ -34,13 +34,13 @@ async function main() {
   //////////////////////////////////////////////////////////////////////////////
 
   // Deploy library
-  const libraryFactory = await ethers.getContractFactory(
-    libraryContractName
-  );
+  const libraryFactory = await ethers.getContractFactory(libraryContractName);
   const library = await libraryFactory.deploy();
   await library.deployed();
   const libraryAddress = library.address;
-  console.log(`[INFO] ${intendedNetwork} ${libraryContractName} deployed at: ${libraryAddress}`);
+  console.log(
+    `[INFO] ${intendedNetwork} ${libraryContractName} deployed at: ${libraryAddress}`
+  );
 
   //////////////////////////////////////////////////////////////////////////////
   // DEPLOYMENT ENDS HERE

--- a/scripts/bytecode-storage/bytecode-storage-deployer-mainnet.ts
+++ b/scripts/bytecode-storage/bytecode-storage-deployer-mainnet.ts
@@ -1,0 +1,70 @@
+// This file can be used to deploy new copies of the shared
+// public BytecodeStorageReader library, which is intended to
+// be used as an externally linked library.
+// SPDX-License-Identifier: LGPL-3.0-only
+// Created By: Art Blocks Inc.
+import hre from "hardhat";
+import { ethers } from "hardhat";
+import { tryVerify } from "../util/verification";
+
+/**
+ * This file can be used to deploy new copies of the shared
+ * public BytecodeStorageReader library, which is intended to
+ * be used as an externally linked library.
+ */
+//////////////////////////////////////////////////////////////////////////////
+// CONFIG BEGINS HERE
+//////////////////////////////////////////////////////////////////////////////
+const intendedNetwork = "mainnet"; // "goerli" or "mainnet"
+const libraryContractName = "BytecodeStorageReader";
+//////////////////////////////////////////////////////////////////////////////
+// CONFIG ENDS HERE
+//////////////////////////////////////////////////////////////////////////////
+async function main() {
+  const [deployer] = await ethers.getSigners();
+  const network = await ethers.provider.getNetwork();
+  const networkName = network.name == "homestead" ? "mainnet" : network.name;
+  if (networkName != intendedNetwork) {
+    throw new Error(
+      `[ERROR] This script is intended to be run on ${intendedNetwork} only`
+    );
+  }
+  //////////////////////////////////////////////////////////////////////////////
+  // DEPLOYMENT BEGINS HERE
+  //////////////////////////////////////////////////////////////////////////////
+
+  // Deploy library
+  const libraryFactory = await ethers.getContractFactory(
+    libraryContractName
+  );
+  const library = await libraryFactory.deploy();
+  await library.deployed();
+  const libraryAddress = library.address;
+  console.log(`[INFO] ${intendedNetwork} ${libraryContractName} deployed at: ${libraryAddress}`);
+
+  //////////////////////////////////////////////////////////////////////////////
+  // DEPLOYMENT ENDS HERE
+  //////////////////////////////////////////////////////////////////////////////
+
+  //////////////////////////////////////////////////////////////////////////////
+  // VERIFICATION BEGINS HERE
+  //////////////////////////////////////////////////////////////////////////////
+
+  // Output instructions for manual Etherscan verification.
+  await tryVerify(libraryContractName, libraryAddress, [], networkName);
+
+  console.log(
+    `[INFO] Deployment complete! Please record deployment details in the top-level README of this repo.`
+  );
+
+  //////////////////////////////////////////////////////////////////////////////
+  // VERIFICATION ENDS HERE
+  //////////////////////////////////////////////////////////////////////////////
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/bytecode-storage/bytecode-storage-deployer-mainnet.ts
+++ b/scripts/bytecode-storage/bytecode-storage-deployer-mainnet.ts
@@ -34,13 +34,13 @@ async function main() {
   //////////////////////////////////////////////////////////////////////////////
 
   // Deploy library
-  const libraryFactory = await ethers.getContractFactory(
-    libraryContractName
-  );
+  const libraryFactory = await ethers.getContractFactory(libraryContractName);
   const library = await libraryFactory.deploy();
   await library.deployed();
   const libraryAddress = library.address;
-  console.log(`[INFO] ${intendedNetwork} ${libraryContractName} deployed at: ${libraryAddress}`);
+  console.log(
+    `[INFO] ${intendedNetwork} ${libraryContractName} deployed at: ${libraryAddress}`
+  );
 
   //////////////////////////////////////////////////////////////////////////////
   // DEPLOYMENT ENDS HERE

--- a/scripts/engine/V3/generic-engine-deployer.ts
+++ b/scripts/engine/V3/generic-engine-deployer.ts
@@ -214,9 +214,11 @@ async function main() {
 
     // Deploy Core contract
     // Ensure that BytecodeStorageReader library is linked in the process
-    const bytecodeStorageLibraryAddress = BYTECODE_STORAGE_READER_LIBRARY_ADDRESSES[networkName];
+    const bytecodeStorageLibraryAddress =
+      BYTECODE_STORAGE_READER_LIBRARY_ADDRESSES[networkName];
     const genArt721CoreFactory = await ethers.getContractFactory(
-      deployDetails.genArt721CoreContractName, {
+      deployDetails.genArt721CoreContractName,
+      {
         libraries: {
           BytecodeStorageReader: bytecodeStorageLibraryAddress,
         },

--- a/scripts/engine/V3/generic-engine-deployer.ts
+++ b/scripts/engine/V3/generic-engine-deployer.ts
@@ -159,6 +159,15 @@ async function main() {
         `[ERROR] The default vertical cannot be flex if not using a flex engine`
       );
     }
+
+    // verify that there is a valid bytecode storage reader library address for the network
+    const bytecodeStorageLibraryAddress =
+      BYTECODE_STORAGE_READER_LIBRARY_ADDRESSES[networkName];
+    if (!bytecodeStorageLibraryAddress) {
+      throw new Error(
+        `[ERROR] No bytecode storage reader library address configured for network ${networkName}`
+      );
+    }
     //////////////////////////////////////////////////////////////////////////////
     // INPUT VALIDATION ENDS HERE
     //////////////////////////////////////////////////////////////////////////////
@@ -208,14 +217,12 @@ async function main() {
     await randomizer.deployed();
     const randomizerAddress = randomizer.address;
     console.log(
-      `[INFO] Randomizer ${deployDetails.randomizerContractName} deployed at g${randomizerAddress}`
+      `[INFO] Randomizer ${deployDetails.randomizerContractName} deployed at ${randomizerAddress}`
     );
     await delay(EXTRA_DELAY_BETWEEN_TX);
 
     // Deploy Core contract
     // Ensure that BytecodeStorageReader library is linked in the process
-    const bytecodeStorageLibraryAddress =
-      BYTECODE_STORAGE_READER_LIBRARY_ADDRESSES[networkName];
     const genArt721CoreFactory = await ethers.getContractFactory(
       deployDetails.genArt721CoreContractName,
       {
@@ -575,6 +582,7 @@ ${deployedMinterNames
 - **Platform Provider Address, Primary Sales:** ${
       deployDetails.platformProviderAddress
     }
+- **BytecodeStorageReader Library:** ${bytecodeStorageLibraryAddress}
 
 **Other**
 

--- a/scripts/engine/V3/generic-engine-deployer.ts
+++ b/scripts/engine/V3/generic-engine-deployer.ts
@@ -18,6 +18,7 @@ import {
 
 import {
   DELEGATION_REGISTRY_ADDRESSES,
+  BYTECODE_STORAGE_READER_LIBRARY_ADDRESSES,
   KNOWN_ENGINE_REGISTRIES,
   EXTRA_DELAY_BETWEEN_TX,
 } from "../../util/constants";
@@ -207,13 +208,19 @@ async function main() {
     await randomizer.deployed();
     const randomizerAddress = randomizer.address;
     console.log(
-      `[INFO] Randomizer ${deployDetails.randomizerContractName} deployed at ${randomizerAddress}`
+      `[INFO] Randomizer ${deployDetails.randomizerContractName} deployed at g${randomizerAddress}`
     );
     await delay(EXTRA_DELAY_BETWEEN_TX);
 
     // Deploy Core contract
+    // Ensure that BytecodeStorageReader library is linked in the process
+    const bytecodeStorageLibraryAddress = BYTECODE_STORAGE_READER_LIBRARY_ADDRESSES[networkName];
     const genArt721CoreFactory = await ethers.getContractFactory(
-      deployDetails.genArt721CoreContractName
+      deployDetails.genArt721CoreContractName, {
+        libraries: {
+          BytecodeStorageReader: bytecodeStorageLibraryAddress,
+        },
+      }
     );
     const tokenName = deployDetails.tokenName;
     const tokenTicker = deployDetails.tokenTicker;

--- a/scripts/util/constants.ts
+++ b/scripts/util/constants.ts
@@ -11,7 +11,7 @@ export const DELEGATION_REGISTRY_ADDRESSES = {
 
 // BytecodeStorageReader library addresses on supported networks
 export const BYTECODE_STORAGE_READER_LIBRARY_ADDRESSES = {
-  // note: same address for goerli and mainnet
+  // note: _different_ address for goerli and mainnet
   goerli: "0xB8B806A10d16cc80dB788552B54B3ECb4A2A3C3D",
   mainnet: "0xf0585dF582A0ad119F1616FB82f3b449a98EeCd5",
 };

--- a/scripts/util/constants.ts
+++ b/scripts/util/constants.ts
@@ -9,6 +9,13 @@ export const DELEGATION_REGISTRY_ADDRESSES = {
   mainnet: "0x00000000000076A84feF008CDAbe6409d2FE638B",
 };
 
+// BytecodeStorageReader library addresses on supported networks
+export const BYTECODE_STORAGE_READER_LIBRARY_ADDRESSES = {
+  // note: same address for goerli and mainnet
+  goerli: "0xB8B806A10d16cc80dB788552B54B3ECb4A2A3C3D",
+  mainnet: "0xf0585dF582A0ad119F1616FB82f3b449a98EeCd5",
+};
+
 // known V3 engine registry contracts, and their deployers
 // format is [network]: { [registry address]: [deployer address] }
 export const KNOWN_ENGINE_REGISTRIES = {

--- a/test/core/V3/GenArt721CoreV3_AdminACLRequests.test.ts
+++ b/test/core/V3/GenArt721CoreV3_AdminACLRequests.test.ts
@@ -75,12 +75,6 @@ for (const coreContractName of coreContractsToTest) {
       };
       config = await assignDefaultConstants(config);
 
-      // get core contract interface for signature hash retrieval
-      const artblocksFactory = await ethers.getContractFactory(
-        coreContractName
-      );
-      config.coreInterface = artblocksFactory.interface;
-
       // deploy and configure minter filter and minter
       ({
         genArt721Core: config.genArt721Core,
@@ -93,7 +87,9 @@ for (const coreContractName of coreContractsToTest) {
         "MinterFilterV1",
         true
       ));
-
+      
+      // get core contract interface for signature hash retrieval
+      config.coreInterface = config.genArt721Core.interface;
       config.minter = await deployAndGet(config, "MinterSetPriceV2", [
         config.genArt721Core.address,
         config.minterFilter.address,

--- a/test/core/V3/GenArt721CoreV3_AdminACLRequests.test.ts
+++ b/test/core/V3/GenArt721CoreV3_AdminACLRequests.test.ts
@@ -87,7 +87,7 @@ for (const coreContractName of coreContractsToTest) {
         "MinterFilterV1",
         true
       ));
-      
+
       // get core contract interface for signature hash retrieval
       config.coreInterface = config.genArt721Core.interface;
       config.minter = await deployAndGet(config, "MinterSetPriceV2", [

--- a/test/core/V3/GenArt721CoreV3_Events.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Events.test.ts
@@ -109,11 +109,14 @@ for (const coreContractName of coreContractsToTest) {
           .deploy(/* no args for library ever */);
 
         // Deploy actual contract (with library linked)
-        const coreContractFactory = await ethers.getContractFactory(coreContractName, {
-          libraries: {
-            BytecodeStorageReaderV1: library.address,
-          },
-        });
+        const coreContractFactory = await ethers.getContractFactory(
+          coreContractName,
+          {
+            libraries: {
+              BytecodeStorageReaderV1: library.address,
+            },
+          }
+        );
         // it is OK that config construction addresses aren't particularly valid
         // addresses for the purposes of config test
         let tx;
@@ -124,17 +127,19 @@ for (const coreContractName of coreContractsToTest) {
           const engineRegistry = await engineRegistryFactory
             .connect(config.accounts.deployer)
             .deploy();
-          tx = await coreContractFactory.connect(config.accounts.deployer).deploy(
-            "name",
-            "symbol",
-            config.accounts.additional.address,
-            config.accounts.additional.address,
-            config.accounts.additional.address,
-            config.accounts.additional.address,
-            365,
-            false,
-            engineRegistry.address // Note: important to use a real engine registry
-          );
+          tx = await coreContractFactory
+            .connect(config.accounts.deployer)
+            .deploy(
+              "name",
+              "symbol",
+              config.accounts.additional.address,
+              config.accounts.additional.address,
+              config.accounts.additional.address,
+              config.accounts.additional.address,
+              365,
+              false,
+              engineRegistry.address // Note: important to use a real engine registry
+            );
           const receipt = await tx.deployTransaction.wait();
           const registrationLog = receipt.logs[receipt.logs.length - 1];
           // expect "ContractRegistered" event as log 0

--- a/test/core/V3/GenArt721CoreV3_Events.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Events.test.ts
@@ -102,7 +102,7 @@ for (const coreContractName of coreContractsToTest) {
         // Note that for testing purposes, we deploy a new version of the library,
         // but in production we would use the same library deployment for all contracts
         const libraryFactory = await ethers.getContractFactory(
-          "BytecodeStorageReaderV1"
+          "BytecodeStorageReader"
         );
         const library = await libraryFactory
           .connect(config.accounts.deployer)
@@ -113,7 +113,7 @@ for (const coreContractName of coreContractsToTest) {
           coreContractName,
           {
             libraries: {
-              BytecodeStorageReaderV1: library.address,
+              BytecodeStorageReader: library.address,
             },
           }
         );

--- a/test/core/V3/GenArt721CoreV3_Integration.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Integration.test.ts
@@ -440,7 +440,7 @@ for (const coreContractName of coreContractsToTest) {
           const engineRegistry = await engineRegistryFactory
             .connect(config.accounts.deployer)
             .deploy();
-          differentGenArt721Core = await deployAndGet(
+          differentGenArt721Core = await deployWithStorageLibraryAndGet(
             config,
             coreContractName,
             [
@@ -456,7 +456,7 @@ for (const coreContractName of coreContractsToTest) {
             ]
           );
         } else {
-          differentGenArt721Core = await deployAndGet(
+          differentGenArt721Core = await deployWithStorageLibraryAndGet(
             config,
             coreContractName,
             [

--- a/test/core/V3/GenArt721CoreV3_Integration.test.ts
+++ b/test/core/V3/GenArt721CoreV3_Integration.test.ts
@@ -16,6 +16,7 @@ import {
   getAccounts,
   assignDefaultConstants,
   deployAndGet,
+  deployWithStorageLibraryAndGet,
   deployCoreWithMinterFilter,
   mintProjectUntilRemaining,
   advanceEVMByTime,
@@ -389,7 +390,7 @@ for (const coreContractName of coreContractsToTest) {
           const engineRegistry = await engineRegistryFactory
             .connect(config.accounts.deployer)
             .deploy();
-          differentGenArt721Core = await deployAndGet(
+          differentGenArt721Core = await deployWithStorageLibraryAndGet(
             config,
             coreContractName,
             [
@@ -405,7 +406,7 @@ for (const coreContractName of coreContractsToTest) {
             ]
           );
         } else {
-          differentGenArt721Core = await deployAndGet(
+          differentGenArt721Core = await deployWithStorageLibraryAndGet(
             config,
             coreContractName,
             [

--- a/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
+++ b/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
@@ -1424,17 +1424,21 @@ for (const coreContractName of coreContractsToTest) {
           []
         );
         // set `autoApproveArtistSplitProposals` to true
-        config.genArt721Core = await deployWithStorageLibraryAndGet(config, coreContractName, [
-          config.name, // _tokenName
-          config.symbol, // _tokenSymbol
-          config.accounts.deployer.address, // _renderProviderAddress
-          config.accounts.additional.address, // _platformProviderAddress
-          config.randomizer.address, // _randomizerContract
-          config.adminACL.address, // _adminACLContract
-          0, // _startingProjectId
-          true, // _autoApproveArtistSplitProposals
-          config.engineRegistry.address, // _engineRegistryContract
-        ]);
+        config.genArt721Core = await deployWithStorageLibraryAndGet(
+          config,
+          coreContractName,
+          [
+            config.name, // _tokenName
+            config.symbol, // _tokenSymbol
+            config.accounts.deployer.address, // _renderProviderAddress
+            config.accounts.additional.address, // _platformProviderAddress
+            config.randomizer.address, // _randomizerContract
+            config.adminACL.address, // _adminACLContract
+            0, // _startingProjectId
+            true, // _autoApproveArtistSplitProposals
+            config.engineRegistry.address, // _engineRegistryContract
+          ]
+        );
         // assign core contract for randomizer to use
         config.randomizer
           .connect(config.accounts.deployer)

--- a/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
+++ b/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
@@ -18,6 +18,7 @@ import {
   deployCoreWithMinterFilter,
   mintProjectUntilRemaining,
   advanceEVMByTime,
+  deployWithStorageLibraryAndGet,
 } from "../../util/common";
 import { FOUR_WEEKS } from "../../util/constants";
 import {
@@ -1423,7 +1424,7 @@ for (const coreContractName of coreContractsToTest) {
           []
         );
         // set `autoApproveArtistSplitProposals` to true
-        config.genArt721Core = await deployAndGet(config, coreContractName, [
+        config.genArt721Core = await deployWithStorageLibraryAndGet(config, coreContractName, [
           config.name, // _tokenName
           config.symbol, // _tokenSymbol
           config.accounts.deployer.address, // _renderProviderAddress

--- a/test/core/V3/prohibition/GenArt721CoreV3_AdminACLRequests_PROHIBITION.test.ts
+++ b/test/core/V3/prohibition/GenArt721CoreV3_AdminACLRequests_PROHIBITION.test.ts
@@ -72,12 +72,6 @@ for (const coreContractName of coreContractsToTest) {
       };
       config = await assignDefaultConstants(config);
 
-      // get core contract interface for signature hash retrieval
-      const artblocksFactory = await ethers.getContractFactory(
-        coreContractName
-      );
-      config.coreInterface = artblocksFactory.interface;
-
       // deploy and configure minter filter and minter
       ({
         genArt721Core: config.genArt721Core,
@@ -90,6 +84,8 @@ for (const coreContractName of coreContractsToTest) {
         "MinterFilterV1",
         true
       ));
+      // get core contract interface for signature hash retrieval
+      config.coreInterface = config.genArt721Core.interface;
 
       config.minter = await deployAndGet(config, "MinterSetPriceV2", [
         config.genArt721Core.address,

--- a/test/core/V3/prohibition/GenArt721CoreV3_Events_PROHIBITION.test.ts
+++ b/test/core/V3/prohibition/GenArt721CoreV3_Events_PROHIBITION.test.ts
@@ -99,7 +99,7 @@ for (const coreContractName of coreContractsToTest) {
         // Note that for testing purposes, we deploy a new version of the library,
         // but in production we would use the same library deployment for all contracts
         const libraryFactory = await ethers.getContractFactory(
-          "BytecodeStorageReaderV1"
+          "BytecodeStorageReader"
         );
         const library = await libraryFactory
           .connect(config.accounts.deployer)
@@ -110,7 +110,7 @@ for (const coreContractName of coreContractsToTest) {
           coreContractName,
           {
             libraries: {
-              BytecodeStorageReaderV1: library.address,
+              BytecodeStorageReader: library.address,
             },
           }
         );

--- a/test/core/V3/prohibition/GenArt721CoreV3_Events_PROHIBITION.test.ts
+++ b/test/core/V3/prohibition/GenArt721CoreV3_Events_PROHIBITION.test.ts
@@ -106,11 +106,14 @@ for (const coreContractName of coreContractsToTest) {
           .deploy(/* no args for library ever */);
 
         // Deploy actual contract (with library linked)
-        const coreContractFactory = await ethers.getContractFactory(coreContractName, {
-          libraries: {
-            BytecodeStorageReaderV1: library.address,
-          },
-        });
+        const coreContractFactory = await ethers.getContractFactory(
+          coreContractName,
+          {
+            libraries: {
+              BytecodeStorageReaderV1: library.address,
+            },
+          }
+        );
         // it is OK that config construction addresses aren't particularly valid
         // addresses for the purposes of config test
         let tx;
@@ -121,17 +124,19 @@ for (const coreContractName of coreContractsToTest) {
           const engineRegistry = await engineRegistryFactory
             .connect(config.accounts.deployer)
             .deploy();
-          tx = await coreContractFactory.connect(config.accounts.deployer).deploy(
-            "name",
-            "symbol",
-            config.accounts.additional.address,
-            config.accounts.additional.address,
-            config.accounts.additional.address,
-            config.accounts.additional.address,
-            365,
-            false,
-            engineRegistry.address // Note: important to use a real engine registry
-          );
+          tx = await coreContractFactory
+            .connect(config.accounts.deployer)
+            .deploy(
+              "name",
+              "symbol",
+              config.accounts.additional.address,
+              config.accounts.additional.address,
+              config.accounts.additional.address,
+              config.accounts.additional.address,
+              365,
+              false,
+              engineRegistry.address // Note: important to use a real engine registry
+            );
           const receipt = await tx.deployTransaction.wait();
           const registrationLog = receipt.logs[receipt.logs.length - 1];
           // expect "ContractRegistered" event as log 0

--- a/test/core/V3/prohibition/GenArt721CoreV3_Events_PROHIBITION.test.ts
+++ b/test/core/V3/prohibition/GenArt721CoreV3_Events_PROHIBITION.test.ts
@@ -95,10 +95,22 @@ for (const coreContractName of coreContractsToTest) {
     describe("PlatformUpdated", function () {
       it("deployment events (nextProjectId, etc.)", async function () {
         const config = await loadFixture(_beforeEach);
-        // typical expect event helper doesn't work for deploy event
-        const contractFactory = await ethers.getContractFactory(
-          coreContractName
+
+        // Note that for testing purposes, we deploy a new version of the library,
+        // but in production we would use the same library deployment for all contracts
+        const libraryFactory = await ethers.getContractFactory(
+          "BytecodeStorageReaderV1"
         );
+        const library = await libraryFactory
+          .connect(config.accounts.deployer)
+          .deploy(/* no args for library ever */);
+
+        // Deploy actual contract (with library linked)
+        const coreContractFactory = await ethers.getContractFactory(coreContractName, {
+          libraries: {
+            BytecodeStorageReaderV1: library.address,
+          },
+        });
         // it is OK that config construction addresses aren't particularly valid
         // addresses for the purposes of config test
         let tx;
@@ -109,7 +121,7 @@ for (const coreContractName of coreContractsToTest) {
           const engineRegistry = await engineRegistryFactory
             .connect(config.accounts.deployer)
             .deploy();
-          tx = await contractFactory.connect(config.accounts.deployer).deploy(
+          tx = await coreContractFactory.connect(config.accounts.deployer).deploy(
             "name",
             "symbol",
             config.accounts.additional.address,
@@ -149,7 +161,7 @@ for (const coreContractName of coreContractsToTest) {
             ethers.utils.formatBytes32String("nextProjectId")
           );
         } else {
-          tx = await contractFactory
+          tx = await coreContractFactory
             .connect(config.accounts.deployer)
             .deploy(
               "name",

--- a/test/core/V3/prohibition/GenArt721CoreV3_Integration_PROHIBITION.test.ts
+++ b/test/core/V3/prohibition/GenArt721CoreV3_Integration_PROHIBITION.test.ts
@@ -16,6 +16,7 @@ import {
   getAccounts,
   assignDefaultConstants,
   deployAndGet,
+  deployWithStorageLibraryAndGet,
   deployCoreWithMinterFilter,
   mintProjectUntilRemaining,
   advanceEVMByTime,
@@ -491,7 +492,7 @@ for (const coreContractName of coreContractsToTest) {
           const engineRegistry = await engineRegistryFactory
             .connect(config.accounts.deployer)
             .deploy();
-          differentGenArt721Core = await deployAndGet(
+          differentGenArt721Core = await deployWithStorageLibraryAndGet(
             config,
             coreContractName,
             [
@@ -507,7 +508,7 @@ for (const coreContractName of coreContractsToTest) {
             ]
           );
         } else {
-          differentGenArt721Core = await deployAndGet(
+          differentGenArt721Core = await deployWithStorageLibraryAndGet(
             config,
             coreContractName,
             [

--- a/test/core/V3/prohibition/GenArt721CoreV3_Integration_PROHIBITION.test.ts
+++ b/test/core/V3/prohibition/GenArt721CoreV3_Integration_PROHIBITION.test.ts
@@ -442,7 +442,7 @@ for (const coreContractName of coreContractsToTest) {
           const engineRegistry = await engineRegistryFactory
             .connect(config.accounts.deployer)
             .deploy();
-          differentGenArt721Core = await deployAndGet(
+          differentGenArt721Core = await deployWithStorageLibraryAndGet(
             config,
             coreContractName,
             [
@@ -458,7 +458,7 @@ for (const coreContractName of coreContractsToTest) {
             ]
           );
         } else {
-          differentGenArt721Core = await deployAndGet(
+          differentGenArt721Core = await deployWithStorageLibraryAndGet(
             config,
             coreContractName,
             [

--- a/test/core/V3/prohibition/GenArt721CoreV3_ProjectConfigure_PROHIBITION.test.ts
+++ b/test/core/V3/prohibition/GenArt721CoreV3_ProjectConfigure_PROHIBITION.test.ts
@@ -18,6 +18,7 @@ import {
   deployCoreWithMinterFilter,
   mintProjectUntilRemaining,
   advanceEVMByTime,
+  deployWithStorageLibraryAndGet,
 } from "../../../util/common";
 import { FOUR_WEEKS } from "../../../util/constants";
 import {
@@ -1420,7 +1421,7 @@ for (const coreContractName of coreContractsToTest) {
           []
         );
         // set `autoApproveArtistSplitProposals` to true
-        config.genArt721Core = await deployAndGet(config, coreContractName, [
+        config.genArt721Core = await deployWithStorageLibraryAndGet(config, coreContractName, [
           config.name, // _tokenName
           config.symbol, // _tokenSymbol
           config.accounts.deployer.address, // _renderProviderAddress

--- a/test/core/V3/prohibition/GenArt721CoreV3_ProjectConfigure_PROHIBITION.test.ts
+++ b/test/core/V3/prohibition/GenArt721CoreV3_ProjectConfigure_PROHIBITION.test.ts
@@ -1421,17 +1421,21 @@ for (const coreContractName of coreContractsToTest) {
           []
         );
         // set `autoApproveArtistSplitProposals` to true
-        config.genArt721Core = await deployWithStorageLibraryAndGet(config, coreContractName, [
-          config.name, // _tokenName
-          config.symbol, // _tokenSymbol
-          config.accounts.deployer.address, // _renderProviderAddress
-          config.accounts.additional.address, // _platformProviderAddress
-          config.randomizer.address, // _randomizerContract
-          config.adminACL.address, // _adminACLContract
-          0, // _startingProjectId
-          true, // _autoApproveArtistSplitProposals
-          config.engineRegistry.address, // _engineRegistryContract
-        ]);
+        config.genArt721Core = await deployWithStorageLibraryAndGet(
+          config,
+          coreContractName,
+          [
+            config.name, // _tokenName
+            config.symbol, // _tokenSymbol
+            config.accounts.deployer.address, // _renderProviderAddress
+            config.accounts.additional.address, // _platformProviderAddress
+            config.randomizer.address, // _randomizerContract
+            config.adminACL.address, // _adminACLContract
+            0, // _startingProjectId
+            true, // _autoApproveArtistSplitProposals
+            config.engineRegistry.address, // _engineRegistryContract
+          ]
+        );
         // assign core contract for randomizer to use
         config.randomizer
           .connect(config.accounts.deployer)

--- a/test/dependency-registry/DependencyRegistryV0.test.ts
+++ b/test/dependency-registry/DependencyRegistryV0.test.ts
@@ -15,6 +15,7 @@ import {
   getAccounts,
   assignDefaultConstants,
   deployAndGet,
+  deployWithStorageLibraryAndGet,
   deployCoreWithMinterFilter,
 } from "../util/common";
 
@@ -68,7 +69,7 @@ describe(`DependencyRegistryV0`, async function () {
       config.minterFilter.address,
     ]);
 
-    config.dependencyRegistry = await deployAndGet(
+    config.dependencyRegistry = await deployWithStorageLibraryAndGet(
       config,
       "DependencyRegistryV0"
     );

--- a/test/libs/BytecodeStorageV0_BytecodeTextCR_DMock.test.ts
+++ b/test/libs/BytecodeStorageV0_BytecodeTextCR_DMock.test.ts
@@ -12,12 +12,15 @@ import { Contract } from "ethers";
 import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 
+import { BytecodeV0TextCR_DMock } from "../../scripts/contracts";
+
 import {
   T_Config,
   getAccounts,
   deployAndGet,
   assignDefaultConstants,
 } from "../util/common";
+
 import {
   SQUIGGLE_SCRIPT,
   SKULPTUUR_SCRIPT_APPROX,
@@ -25,6 +28,10 @@ import {
   GREATER_THAN_CONTRACT_SIZE_LIMIT_SCRIPT,
   MULTI_BYTE_UTF_EIGHT_SCRIPT,
 } from "../util/example-scripts";
+
+interface BytecodeStorageV0TestConfig extends T_Config {
+  bytecodeV0TextCR_DMock?: BytecodeV0TextCR_DMock;
+}
 
 /**
  * Tests for BytecodeStorageV0 by way of testing the BytecodeV0TextCR_DMock.
@@ -36,7 +43,7 @@ describe("BytecodeStorageV0 + BytecodeV0TextCR_DMock Library Tests", async funct
   // Helper that validates a Create and subsequent Read operation, ensuring
   // that bytes-in == bytes-out for a given input string.
   async function validateCreateAndRead(
-    config: T_Config,
+    config: BytecodeStorageV0TestConfig,
     targetText: string,
     bytecodeV0TextCR_DMock: Contract,
     deployer: SignerWithAddress
@@ -52,7 +59,7 @@ describe("BytecodeStorageV0 + BytecodeV0TextCR_DMock Library Tests", async funct
   // Helper that retrieves the address of the most recently deployed contract
   // containing bytecode for storage.
   async function getLatestTextDeploymentAddress(
-    config: T_Config,
+    config: BytecodeStorageV0TestConfig,
     bytecodeV0TextCR_DMock: Contract
   ) {
     const nextTextSlotId = await bytecodeV0TextCR_DMock.nextTextSlotId();
@@ -64,7 +71,7 @@ describe("BytecodeStorageV0 + BytecodeV0TextCR_DMock Library Tests", async funct
   }
 
   async function _beforeEach() {
-    let config: T_Config = {
+    let config: BytecodeStorageV0TestConfig = {
       accounts: await getAccounts(),
     };
     config = await assignDefaultConstants(config);

--- a/test/libs/BytecodeStorageV1_BackwardsCompatibleReads.test.ts
+++ b/test/libs/BytecodeStorageV1_BackwardsCompatibleReads.test.ts
@@ -23,6 +23,7 @@ import {
   T_Config,
   getAccounts,
   deployAndGet,
+  deployWithStorageLibraryAndGet,
   assignDefaultConstants,
 } from "../util/common";
 
@@ -162,7 +163,7 @@ describe("BytecodeStorageV1 Backwards Compatible Reads Tests", async function ()
     };
     config = await assignDefaultConstants(config);
     // deploy the V1 library mock
-    config.bytecodeV1TextCR_DMock = await deployAndGet(
+    config.bytecodeV1TextCR_DMock = await deployWithStorageLibraryAndGet(
       config,
       "BytecodeV1TextCR_DMock",
       [] // no deployment args

--- a/test/libs/BytecodeStorageV1_BytecodeTextCR_DMock.test.ts
+++ b/test/libs/BytecodeStorageV1_BytecodeTextCR_DMock.test.ts
@@ -12,12 +12,15 @@ import { Contract } from "ethers";
 import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 
+import { BytecodeV1TextCR_DMock } from "../../scripts/contracts";
+
 import {
   T_Config,
   getAccounts,
-  deployAndGet,
+  deployWithStorageLibraryAndGet,
   assignDefaultConstants,
 } from "../util/common";
+
 import {
   SQUIGGLE_SCRIPT,
   SKULPTUUR_SCRIPT_APPROX,
@@ -25,6 +28,10 @@ import {
   GREATER_THAN_CONTRACT_SIZE_LIMIT_SCRIPT,
   MULTI_BYTE_UTF_EIGHT_SCRIPT,
 } from "../util/example-scripts";
+
+interface BytecodeStorageV1TestConfig extends T_Config {
+  bytecodeV1TextCR_DMock?: BytecodeV1TextCR_DMock;
+}
 
 /**
  * Tests for BytecodeStorageV1 by way of testing the BytecodeV1TextCR_DMock.
@@ -36,7 +43,7 @@ describe("BytecodeStorageV1 + BytecodeV1TextCR_DMock Library Tests", async funct
   // Helper that validates a Create and subsequent Read operation, ensuring
   // that bytes-in == bytes-out for a given input string.
   async function validateCreateAndRead(
-    config: T_Config,
+    config: BytecodeStorageV1TestConfig,
     targetText: string,
     bytecodeV1TextCR_DMock: Contract,
     deployer: SignerWithAddress
@@ -52,7 +59,7 @@ describe("BytecodeStorageV1 + BytecodeV1TextCR_DMock Library Tests", async funct
   // Helper that retrieves the address of the most recently deployed contract
   // containing bytecode for storage.
   async function getLatestTextDeploymentAddress(
-    config: T_Config,
+    config: BytecodeStorageV1TestConfig,
     bytecodeV1TextCR_DMock: Contract
   ) {
     const nextTextSlotId = await bytecodeV1TextCR_DMock.nextTextSlotId();
@@ -64,12 +71,12 @@ describe("BytecodeStorageV1 + BytecodeV1TextCR_DMock Library Tests", async funct
   }
 
   async function _beforeEach() {
-    let config: T_Config = {
+    let config: BytecodeStorageV1TestConfig = {
       accounts: await getAccounts(),
     };
     config = await assignDefaultConstants(config);
     // deploy the library mock
-    config.bytecodeV1TextCR_DMock = await deployAndGet(
+    config.bytecodeV1TextCR_DMock = await deployWithStorageLibraryAndGet(
       config,
       "BytecodeV1TextCR_DMock",
       [] // no deployment args
@@ -181,11 +188,12 @@ describe("BytecodeStorageV1 + BytecodeV1TextCR_DMock Library Tests", async funct
       );
 
       // deploy a second instance of the library mock
-      const additionalBytecodeV1TextCR_DMock = await deployAndGet(
-        config,
-        "BytecodeV1TextCR_DMock",
-        [] // no deployment args
-      );
+      const additionalBytecodeV1TextCR_DMock =
+        await deployWithStorageLibraryAndGet(
+          config,
+          "BytecodeV1TextCR_DMock",
+          [] // no deployment args
+        );
       const text = await additionalBytecodeV1TextCR_DMock.readTextAtAddress(
         textBytecodeAddress
       );
@@ -261,11 +269,12 @@ describe("BytecodeStorageV1 + BytecodeV1TextCR_DMock Library Tests", async funct
       );
 
       // deploy a second instance of the library mock
-      const additionalBytecodeV1TextCR_DMock = await deployAndGet(
-        config,
-        "BytecodeV1TextCR_DMock",
-        [] // no deployment args
-      );
+      const additionalBytecodeV1TextCR_DMock =
+        await deployWithStorageLibraryAndGet(
+          config,
+          "BytecodeV1TextCR_DMock",
+          [] // no deployment args
+        );
       const textAuthorAddress =
         await additionalBytecodeV1TextCR_DMock.readAuthorForTextAtAddress(
           textBytecodeAddress

--- a/test/minter-suite-minters/Minter.common.ts
+++ b/test/minter-suite-minters/Minter.common.ts
@@ -3,7 +3,7 @@ import { constants, expectRevert } from "@openzeppelin/test-helpers";
 import { expect } from "chai";
 import { ethers } from "hardhat";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
-import { T_Config } from "../util/common";
+import { T_Config, deployWithStorageLibraryAndGet } from "../util/common";
 
 /**
  * These tests are intended to check common Minter functionality
@@ -20,19 +20,18 @@ export const Minter_Common = async (_beforeEach: () => Promise<T_Config>) => {
 
     it("reverts when given incorrect minter filter and core addresses", async function () {
       const config = await loadFixture(_beforeEach);
-      const artblocksFactory = await ethers.getContractFactory(
-        "GenArt721CoreV3"
-      );
       const adminACL = await config.genArt721Core.owner();
-      const token2 = await artblocksFactory
-        .connect(config.accounts.deployer)
-        .deploy(
+      const token2 = await deployWithStorageLibraryAndGet(
+        config,
+        "GenArt721CoreV3",
+        [
           config.name,
           config.symbol,
           config.randomizer.address,
           adminACL,
           0
-        );
+        ]
+      )
 
       const minterFilterFactory = await ethers.getContractFactory(
         "MinterFilterV1"

--- a/test/minter-suite-minters/Minter.common.ts
+++ b/test/minter-suite-minters/Minter.common.ts
@@ -24,14 +24,8 @@ export const Minter_Common = async (_beforeEach: () => Promise<T_Config>) => {
       const token2 = await deployWithStorageLibraryAndGet(
         config,
         "GenArt721CoreV3",
-        [
-          config.name,
-          config.symbol,
-          config.randomizer.address,
-          adminACL,
-          0
-        ]
-      )
+        [config.name, config.symbol, config.randomizer.address, adminACL, 0]
+      );
 
       const minterFilterFactory = await ethers.getContractFactory(
         "MinterFilterV1"

--- a/test/util/common.ts
+++ b/test/util/common.ts
@@ -147,7 +147,7 @@ export async function deployWithStorageLibraryAndGet(
   // Note that for testing purposes, we deploy a new version of the library,
   // but in production we would use the same library deployment for all contracts
   const libraryFactory = await ethers.getContractFactory(
-    "BytecodeStorageReaderV1"
+    "BytecodeStorageReader"
   );
   const library = await libraryFactory
     .connect(config.accounts.deployer)
@@ -158,7 +158,7 @@ export async function deployWithStorageLibraryAndGet(
     coreContractName,
     {
       libraries: {
-        BytecodeStorageReaderV1: library.address,
+        BytecodeStorageReader: library.address,
       },
     }
   );

--- a/test/util/common.ts
+++ b/test/util/common.ts
@@ -154,11 +154,14 @@ export async function deployWithStorageLibraryAndGet(
     .deploy(/* no args for library ever */);
 
   // Deploy actual contract (with library linked)
-  const coreContractFactory = await ethers.getContractFactory(coreContractName, {
-    libraries: {
-      BytecodeStorageReaderV1: library.address,
-    },
-  });
+  const coreContractFactory = await ethers.getContractFactory(
+    coreContractName,
+    {
+      libraries: {
+        BytecodeStorageReaderV1: library.address,
+      },
+    }
+  );
   return await coreContractFactory
     .connect(config.accounts.deployer)
     .deploy(...deployArgs);

--- a/test/util/common.ts
+++ b/test/util/common.ts
@@ -154,12 +154,12 @@ export async function deployWithStorageLibraryAndGet(
     .deploy(/* no args for library ever */);
 
   // Deploy actual contract (with library linked)
-  const contractFactory = await ethers.getContractFactory(coreContractName, {
+  const coreContractFactory = await ethers.getContractFactory(coreContractName, {
     libraries: {
       BytecodeStorageReaderV1: library.address,
     },
   });
-  return await contractFactory
+  return await coreContractFactory
     .connect(config.accounts.deployer)
     .deploy(...deployArgs);
 }

--- a/test/util/common.ts
+++ b/test/util/common.ts
@@ -137,6 +137,31 @@ export async function deployAndGet(
     .deploy(...deployArgs);
 }
 
+// utility function to simplify code when deploying any contract from factory
+// that requires the bytecode storage library
+export async function deployWithStorageLibraryAndGet(
+  config: T_Config,
+  coreContractName: string,
+  deployArgs?: any[]
+): Promise<Contract> {
+  // note that for testing purposes, we deploy a new version of the library,
+  // but in production we would use the same library deployment for all contracts
+  const libraryFactory = await ethers.getContractFactory(
+    "BytecodeStorageReaderV1"
+  );
+  const library = await libraryFactory
+    .connect(config.accounts.deployer)
+    .deploy(...deployArgs);
+  const contractFactory = await ethers.getContractFactory(coreContractName, {
+    libraries: {
+      BytecodeStorageReaderV1: library.address,
+    },
+  });
+  return await contractFactory
+    .connect(config.accounts.deployer)
+    .deploy(...deployArgs);
+}
+
 // utility function to deploy basic randomizer, core, and MinterFilter
 // works for core versions V0, V1, V2_PRTNR, V3
 export async function deployCoreWithMinterFilter(

--- a/test/util/common.ts
+++ b/test/util/common.ts
@@ -144,14 +144,16 @@ export async function deployWithStorageLibraryAndGet(
   coreContractName: string,
   deployArgs?: any[]
 ): Promise<Contract> {
-  // note that for testing purposes, we deploy a new version of the library,
+  // Note that for testing purposes, we deploy a new version of the library,
   // but in production we would use the same library deployment for all contracts
   const libraryFactory = await ethers.getContractFactory(
     "BytecodeStorageReaderV1"
   );
   const library = await libraryFactory
     .connect(config.accounts.deployer)
-    .deploy(...deployArgs);
+    .deploy(/* no args for library ever */);
+
+  // Deploy actual contract (with library linked)
   const contractFactory = await ethers.getContractFactory(coreContractName, {
     libraries: {
       BytecodeStorageReaderV1: library.address,
@@ -228,13 +230,17 @@ export async function deployCoreWithMinterFilter(
       ? _adminACLContractName
       : adminACLContractName;
     adminACL = await deployAndGet(config, adminACLContractName, []);
-    genArt721Core = await deployAndGet(config, coreContractName, [
-      config.name,
-      config.symbol,
-      randomizer.address,
-      adminACL.address,
-      0, // _startingProjectId
-    ]);
+    genArt721Core = await deployWithStorageLibraryAndGet(
+      config,
+      coreContractName,
+      [
+        config.name,
+        config.symbol,
+        randomizer.address,
+        adminACL.address,
+        0, // _startingProjectId
+      ]
+    );
     // assign core contract for randomizer to use
     randomizer
       .connect(config.accounts.deployer)
@@ -272,17 +278,21 @@ export async function deployCoreWithMinterFilter(
     engineRegistry = await deployAndGet(config, "EngineRegistryV0", []);
     // Note: in the common tests, set `autoApproveArtistSplitProposals` to false, which
     //       mirrors the approval-flow behavior of the other (non-Engine) V3 contracts
-    genArt721Core = await deployAndGet(config, coreContractName, [
-      config.name, // _tokenName
-      config.symbol, // _tokenSymbol
-      config.accounts.deployer.address, // _renderProviderAddress
-      config.accounts.additional.address, // _platformProviderAddress
-      randomizer.address, // _randomizerContract
-      adminACL.address, // _adminACLContract
-      0, // _startingProjectId
-      false, // _autoApproveArtistSplitProposals
-      engineRegistry.address, // _engineRegistryContract
-    ]);
+    genArt721Core = await deployWithStorageLibraryAndGet(
+      config,
+      coreContractName,
+      [
+        config.name, // _tokenName
+        config.symbol, // _tokenSymbol
+        config.accounts.deployer.address, // _renderProviderAddress
+        config.accounts.additional.address, // _platformProviderAddress
+        randomizer.address, // _randomizerContract
+        adminACL.address, // _adminACLContract
+        0, // _startingProjectId
+        false, // _autoApproveArtistSplitProposals
+        engineRegistry.address, // _engineRegistryContract
+      ]
+    );
     // assign core contract for randomizer to use
     randomizer
       .connect(config.accounts.deployer)


### PR DESCRIPTION
## Description of the change

This PR builds on top of #668 and #670 to actualize the architecture discussed in https://github.com/ArtBlocks/artblocks-contracts/issues/422#issuecomment-1523789750 of a split public shared external reader library and an internal writer library.

This PR is intended to be atomically merged into `main` at the same time as #668 and #670 and is thus marked as "do not merge" until all three have been through review and are ready to merge. Because of this, we are *not* bumping the versions of the client CoreV3 contracts using this library with this changeset, as they are already version-bumped in #668.

~Note: that this PR is still marked as a WIP as we have not yet made the necessary changes to the deployment script of this PR, as that will be a "phase 2" update to this changeset after I have gotten an initial LGTM from reviewers on the overall architecture and code structure here.~

Our shared deployer script has been added, and deployment using this library linking approach has been validated end-to-end on goerli, with shared deployments of the library being deployed on both goerli and mainnet. 

Pending the final approval of this PR, I will merge this as well as #668 and #670 into main, and we can consider the V1 version of this new `BytecodeStorage` library as released!! (closes #660).