### PR TITLE
Prohibition Fork: Change most `_onlyArtist` checks to `_onlyArtistOrAdminACL` checks

### DIFF
--- a/contracts/engine/V3/forks/PROHIBITION/GenArt721CoreV3_Engine_Flex_PROHIBITION.sol
+++ b/contracts/engine/V3/forks/PROHIBITION/GenArt721CoreV3_Engine_Flex_PROHIBITION.sol
@@ -54,9 +54,7 @@ import "../../../../libs/0.8.x/Bytes32Strings.sol";
  *   and removeProjectLastScript
  * - updateProjectScriptType
  * - updateProjectAspectRatio
- * ----------------------------------------------------------------------------
- * The following functions are restricted to only the Artist or Admin ACL
- * contract of a valid project ID:
+ 
  * - proposeArtistPaymentAddressesAndSplits (Note that this has to be accepted
  *   by adminAcceptArtistAddressesAndSplits to take effect, which is restricted
  *   to the Admin ACL contract, or the artist if the core contract owner has
@@ -64,7 +62,6 @@ import "../../../../libs/0.8.x/Bytes32Strings.sol";
  *   accepted if the artist only proposes changed payee percentages without
  *   modifying any payee addresses, or is only removing payee addresses, or
  *   if the global config `autoApproveArtistSplitProposals` is set to `true`.)
- * - toggleProjectIsPaused (note the artist can still mint while paused)
  * - updateProjectSecondaryMarketRoyaltyPercentage (up to
  *   ARTIST_MAX_SECONDARY_ROYALTY_PERCENTAGE percent)
  * - updateProjectWebsite
@@ -73,14 +70,19 @@ import "../../../../libs/0.8.x/Bytes32Strings.sol";
  *   invocations)
  * - updateProjectBaseURI (controlling the base URI for tokens in the project)
  * ----------------------------------------------------------------------------
+ * The following functions are restricted to only the Artist or Admin ACL
+ * contract of a valid project ID:
+ * - toggleProjectIsPaused (note the artist can still mint while paused)
+ * ----------------------------------------------------------------------------
  * The following function is restricted to either the Admin ACL contract, or
  * the Artist address if the core contract owner has renounced ownership:
  * - adminAcceptArtistAddressesAndSplits
  * - updateProjectArtistAddress (owner ultimately controlling the project and
  *   its and-on revenue, unless owner has renounced ownership)
  * ----------------------------------------------------------------------------
- * The following function is restricted to the artist when a project is
- * unlocked, and only callable by Admin ACL contract when a project is locked:
+ * The following function is restricted to the artist or AdminACL contract when
+ * a project is unlocked, and only callable by Admin ACL contract when a project
+ * is locked:
  * - updateProjectDescription
  * ----------------------------------------------------------------------------
  * The following functions for managing external asset dependencies are restricted
@@ -919,7 +921,7 @@ contract GenArt721CoreV3_Engine_Flex_PROHIBITION is
         uint256 _additionalPayeeSecondarySalesPercentage
     ) external {
         _onlyValidProjectId(_projectId);
-        _onlyArtist(_projectId);
+        _onlyArtistOrAdminACL(_projectId, this.proposeArtistPaymentAddressesAndSplits.selector);
         _onlyNonZeroAddress(_artistAddress);
         ProjectFinance storage projectFinance = projectIdToFinancials[
             _projectId
@@ -1195,7 +1197,7 @@ contract GenArt721CoreV3_Engine_Flex_PROHIBITION is
         uint256 _projectId,
         uint256 _secondMarketRoyalty
     ) external {
-        _onlyArtist(_projectId);
+        _onlyArtistOrAdminACL(_projectId, this.updateProjectSecondaryMarketRoyaltyPercentage.selector);
         require(
             _secondMarketRoyalty <= ARTIST_MAX_SECONDARY_ROYALTY_PERCENTAGE,
             "Over max percent"
@@ -1219,17 +1221,22 @@ contract GenArt721CoreV3_Engine_Flex_PROHIBITION is
         string memory _projectDescription
     ) external {
         // checks
-        require(
-            _projectUnlocked(_projectId)
-                ? msg.sender == projectIdToFinancials[_projectId].artistAddress
-                : adminACLAllowed(
+        if (_projectUnlocked(_projectId)) {
+            _onlyArtistOrAdminACL(
+                _projectId,
+                this.updateProjectDescription.selector
+            );
+        } else {
+            require(
+                adminACLAllowed(
                     msg.sender,
                     address(this),
                     this.updateProjectDescription.selector,
                     _projectId
                 ),
-            "Only artist when unlocked, owner when locked"
-        );
+                "Only artist when unlocked, owner when locked"
+            );
+        }
         // effects
         projects[_projectId].description = _projectDescription;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_DESCRIPTION);
@@ -1245,7 +1252,7 @@ contract GenArt721CoreV3_Engine_Flex_PROHIBITION is
         uint256 _projectId,
         string memory _projectWebsite
     ) external {
-        _onlyArtist(_projectId);
+        _onlyArtistOrAdminACL(_projectId, this.updateProjectWebsite.selector);
         projects[_projectId].website = _projectWebsite;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_WEBSITE);
     }
@@ -1279,7 +1286,7 @@ contract GenArt721CoreV3_Engine_Flex_PROHIBITION is
         uint256 _projectId,
         uint24 _maxInvocations
     ) external {
-        _onlyArtist(_projectId);
+        _onlyArtistOrAdminACL(_projectId, this.updateProjectMaxInvocations.selector);
         // CHECKS
         Project storage project = projects[_projectId];
         uint256 _invocations = project.invocations;
@@ -1452,7 +1459,7 @@ contract GenArt721CoreV3_Engine_Flex_PROHIBITION is
         uint256 _projectId,
         string memory _newBaseURI
     ) external {
-        _onlyArtist(_projectId);
+        _onlyArtistOrAdminACL(_projectId, this.updateProjectBaseURI.selector);
         _onlyNonEmptyString(_newBaseURI);
         projects[_projectId].projectBaseURI = _newBaseURI;
         emit ProjectUpdated(_projectId, FIELD_PROJECT_BASE_URI);

--- a/contracts/engine/V3/forks/PROHIBITION/V3_PROHIBTION_CHANGELOG.md
+++ b/contracts/engine/V3/forks/PROHIBITION/V3_PROHIBTION_CHANGELOG.md
@@ -7,12 +7,14 @@ _This document is intended to document and explain the differences between the P
 - Added support for delegating the ability to call specific contracts' function selectors to accounts other than `superAdmin`.
 - Added support for allowing registered/verified artists to call functions related to their projects
 
-
 ## The following changes were made in the Prohibition fork of the Core V3 Engine Flex contract:
 
 - Removes requirement for callers of `addProject` to be approved by AdminACL
 - Allows registered/verified artists in the AdminACL contract to toggle product activation for projects they own
-
-## The following changes were made in the Prohibition fork of the Minter Filter V1 contract:
-
-- Updates the call to `adminACLAllowed` to include the updated args now required.
+- Changes `_onlyArtist` (or equivalent) checks to `_onlyArtistOrAdminACL` in the following functions:
+    * `proposeArtistPaymentAddressesAndSplits`
+    * `updateProjectSecondaryMarketRoyaltyPercentage`
+    * `updateProjectDescription`
+    * `updateProjectWebsite`
+    * `updateProjectMaxInvocations`
+    * `updateProjectBaseURI`

--- a/test/core/V3/prohibition/GenArt721CoreV3_ProjectConfigure_PROHIBITION.test.ts
+++ b/test/core/V3/prohibition/GenArt721CoreV3_ProjectConfigure_PROHIBITION.test.ts
@@ -105,24 +105,31 @@ for (const coreContractName of coreContractsToTest) {
     });
 
     describe("updateProjectMaxInvocations", function () {
-      it("only allows artist to update", async function () {
+      it("only allows artist or admin to update", async function () {
         const config = await loadFixture(_beforeEach);
-        // deployer cannot update
+        // user cannot update
         await expectRevert(
           config.genArt721Core
-            .connect(config.accounts.deployer)
+            .connect(config.accounts.user)
             .updateProjectMaxInvocations(
               config.projectZero,
               config.maxInvocations - 1
             ),
-          "Only artist"
+          "Only artist or Admin ACL allowed"
         );
+        // deployer can update
+        await config.genArt721Core
+          .connect(config.accounts.deployer)
+          .updateProjectMaxInvocations(
+            config.projectZero,
+            config.maxInvocations - 1
+          );
         // artist can update
         await config.genArt721Core
           .connect(config.accounts.artist)
           .updateProjectMaxInvocations(
             config.projectZero,
-            config.maxInvocations - 1
+            config.maxInvocations - 2
           );
       });
 
@@ -277,14 +284,16 @@ for (const coreContractName of coreContractsToTest) {
 
     describe("updateProjectDescription", function () {
       const errorMessage = "Only artist when unlocked, owner when locked";
-      it("owner cannot update when unlocked", async function () {
+      it("owner can update when unlocked", async function () {
         const config = await loadFixture(_beforeEach);
-        await expectRevert(
-          config.genArt721Core
-            .connect(config.accounts.deployer)
-            .updateProjectDescription(config.projectZero, "new description"),
-          errorMessage
-        );
+        await config.genArt721Core
+          .connect(config.accounts.deployer)
+          .updateProjectDescription(config.projectZero, "new description");
+        // expect view to be updated
+        const projectDetails = await config.genArt721Core
+          .connect(config.accounts.user)
+          .projectDetails(config.projectZero);
+        expect(projectDetails.description).to.equal("new description");
       });
 
       it("artist can update when unlocked", async function () {
@@ -533,23 +542,20 @@ for (const coreContractName of coreContractsToTest) {
         this.config = config;
       });
 
-      it("only allows artist to propose updates", async function () {
+      it("only allows artist or admin to propose updates", async function () {
         // get config from beforeEach
         const config = this.config;
-        // rejects deployer as a proposer of updates
-        await expectRevert(
-          config.genArt721Core
-            .connect(config.accounts.deployer)
-            .proposeArtistPaymentAddressesAndSplits(...config.valuesToUpdateTo),
-          "Only artist"
-        );
         // rejects user as a proposer of updates
         await expectRevert(
           config.genArt721Core
             .connect(config.accounts.user)
             .proposeArtistPaymentAddressesAndSplits(...config.valuesToUpdateTo),
-          "Only artist"
+          "Only artist or Admin ACL allowed"
         );
+        // allows deployer as a proposer of updates
+        await config.genArt721Core
+          .connect(config.accounts.deployer)
+          .proposeArtistPaymentAddressesAndSplits(...config.valuesToUpdateTo);
         // allows artist to propose new values
         await config.genArt721Core
           .connect(config.accounts.artist)
@@ -998,17 +1004,14 @@ for (const coreContractName of coreContractsToTest) {
     });
 
     describe("updateProjectSecondaryMarketRoyaltyPercentage", function () {
-      it("owner can not update when unlocked", async function () {
+      it("owner can update when unlocked", async function () {
         const config = await loadFixture(_beforeEach);
-        await expectRevert(
-          config.genArt721Core
-            .connect(config.accounts.deployer)
-            .updateProjectSecondaryMarketRoyaltyPercentage(
-              config.projectZero,
-              10
-            ),
-          "Only artist"
-        );
+        await config.genArt721Core
+          .connect(config.accounts.deployer)
+          .updateProjectSecondaryMarketRoyaltyPercentage(
+            config.projectZero,
+            10
+          );
       });
 
       it("artist can update when unlocked", async function () {


### PR DESCRIPTION
## Description of the change

Changes `_onlyArtist` (or equivalent) checks to `_onlyArtistOrAdminACL` in the following functions:
    * `proposeArtistPaymentAddressesAndSplits`
    * `updateProjectSecondaryMarketRoyaltyPercentage`
    * `updateProjectDescription`
    * `updateProjectWebsite`
    * `updateProjectMaxInvocations`
    * `updateProjectBaseURI`

> reminder: Any mainnet deployments after 10 Jan 2023 should be tagged as [Releases](https://github.com/ArtBlocks/artblocks-contracts/releases) in this repository. This ensures that the deployed contract source code is easily verifiable by anyone.
