### PR TITLE
Split lib w/bytecode reduction

### DIFF
--- a/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
+++ b/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
@@ -109,9 +109,7 @@ contract GenArt721CoreV3_Engine_Flex is
     IGenArt721CoreContractExposesHashSeed
 {
     using BytecodeStorageWriterV1 for string;
-    using BytecodeStorageReaderV1 for string;
     using BytecodeStorageWriterV1 for address;
-    using BytecodeStorageReaderV1 for address;
     using Bytes32Strings for bytes32;
     uint256 constant ONE_HUNDRED = 100;
     uint256 constant ONE_MILLION = 1_000_000;
@@ -1765,7 +1763,7 @@ contract GenArt721CoreV3_Engine_Flex is
         if (_index >= project.scriptCount) {
             return "";
         }
-        return project.scriptBytecodeAddresses[_index].readFromBytecode();
+        return _readFromBytecode(project.scriptBytecodeAddresses[_index]);
     }
 
     /**
@@ -1996,7 +1994,7 @@ contract GenArt721CoreV3_Engine_Flex is
                 bytecodeAddress: _bytecodeAddress,
                 data: (_dependency.dependencyType ==
                     ExternalAssetDependencyType.ONCHAIN)
-                    ? _bytecodeAddress.readFromBytecode()
+                    ? _readFromBytecode(_bytecodeAddress)
                     : ""
             });
     }
@@ -2217,6 +2215,12 @@ contract GenArt721CoreV3_Engine_Flex is
             projectOpen ||
             (block.timestamp - projectCompletedTimestamp <
                 FOUR_WEEKS_IN_SECONDS);
+    }
+
+    function _readFromBytecode(
+        address _address
+    ) internal view returns (string memory) {
+        return BytecodeStorageReaderV1.readFromBytecode(_address);
     }
 
     // strings library from OpenZeppelin, modified for no constants

--- a/hardhat.solidity-config.ts
+++ b/hardhat.solidity-config.ts
@@ -6,7 +6,7 @@ export const solidityConfig = {
       settings: {
         optimizer: {
           enabled: true,
-          runs: 10,
+          runs: 25,
         },
       },
     },


### PR DESCRIPTION
## Description of the change

PoC of V3 Engine Flex with bytecode size reduction.

It appears that Solidity doesn't do a great job of efficiently using bytecode space when doing the following for external libraries:
- using syntax `using X for Y`
- calling a public function (on an external library) in > 1 place

In this example, all calls to public function on bytecode storage reader library are performed in a single internal helper function, and the `using X for Y` syntax is removed for the external library.

## Bytecode Impacts

The result is a net-change from `24.010 bytes` (on splitLib) to `23.909 bytes` on this branch, for `GenArt721CoreV3_Engine_Flex.sol` (possible to get down to `23.865` if we kept optimizer at 10 like it is on splitLib branch)

With respect to current `main` branch, the change is `23.878 bytes` (on main) to `23.909 bytes` on this branch, for `GenArt721CoreV3_Engine_Flex.sol`. (both have optimizer at 25)

## Alternate options

Also note that if we don't like this change for readability reasons, there are other ways to reduce bytecode to <24 kb. For example, changing variables from constants to non-constants reduces bytecode size a lot (e.g. `bytes32 constant FIELD_NEXT_PROJECT_ID = ` -> `bytes32 FIELD_NEXT_PROJECT_ID =`)
