### PR TITLE
Bump Solidity compiler version

### DIFF
--- a/.openzeppelin/goerli.json
+++ b/.openzeppelin/goerli.json
@@ -16,7 +16,7 @@
       "address": "0x7F6767bB1aB8841DDc04317ac60291f799f268A6",
       "txHash": "0x0ba7e432066118ce2fdc639f3ab824ce84696838278ba29164e778c1a76ad951",
       "layout": {
-        "solcVersion": "0.8.17",
+        "solcVersion": "0.8.19",
         "storage": [
           {
             "label": "_initialized",

--- a/contracts/AdminACLV0.sol
+++ b/contracts/AdminACLV0.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 import "./interfaces/0.8.x/IAdminACLV0.sol";
 import "@openzeppelin-4.7/contracts/access/Ownable.sol";

--- a/contracts/AdminACLV0.sol
+++ b/contracts/AdminACLV0.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import "./interfaces/0.8.x/IAdminACLV0.sol";
 import "@openzeppelin-4.7/contracts/access/Ownable.sol";

--- a/contracts/AdminACLV1.sol
+++ b/contracts/AdminACLV1.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import "./interfaces/0.8.x/IAdminACLV0.sol";
 import "./GenArt721CoreV3.sol";

--- a/contracts/AdminACLV1.sol
+++ b/contracts/AdminACLV1.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 import "./interfaces/0.8.x/IAdminACLV0.sol";
 import "./GenArt721CoreV3.sol";

--- a/contracts/DependencyRegistryV0.sol
+++ b/contracts/DependencyRegistryV0.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 // Created By: Art Blocks Inc.
 

--- a/contracts/DependencyRegistryV0.sol
+++ b/contracts/DependencyRegistryV0.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 // Created By: Art Blocks Inc.
 

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 // Created By: Art Blocks Inc.
 

--- a/contracts/GenArt721CoreV3.sol
+++ b/contracts/GenArt721CoreV3.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 // Created By: Art Blocks Inc.
 

--- a/contracts/archive/minter-suite/Minters/MinterDAExp/MinterDAExpV2.sol
+++ b/contracts/archive/minter-suite/Minters/MinterDAExp/MinterDAExpV2.sol
@@ -8,7 +8,7 @@ import "../../../../interfaces/0.8.x/IFilteredMinterDAExpV0.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/math/SafeCast.sol";
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/archive/minter-suite/Minters/MinterDAExp/MinterDAExpV2.sol
+++ b/contracts/archive/minter-suite/Minters/MinterDAExp/MinterDAExpV2.sol
@@ -8,7 +8,7 @@ import "../../../../interfaces/0.8.x/IFilteredMinterDAExpV0.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/math/SafeCast.sol";
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/archive/minter-suite/Minters/MinterDAExp/MinterDAExpV3.sol
+++ b/contracts/archive/minter-suite/Minters/MinterDAExp/MinterDAExpV3.sol
@@ -8,7 +8,7 @@ import "../../../../interfaces/0.8.x/IFilteredMinterDAExpV1.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/math/SafeCast.sol";
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/archive/minter-suite/Minters/MinterDAExp/MinterDAExpV3.sol
+++ b/contracts/archive/minter-suite/Minters/MinterDAExp/MinterDAExpV3.sol
@@ -8,7 +8,7 @@ import "../../../../interfaces/0.8.x/IFilteredMinterDAExpV1.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/math/SafeCast.sol";
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/archive/minter-suite/Minters/MinterDAExpSettlement/MinterDAExpSettlementV0.sol
+++ b/contracts/archive/minter-suite/Minters/MinterDAExpSettlement/MinterDAExpSettlementV0.sol
@@ -8,7 +8,7 @@ import "../../../../interfaces/0.8.x/IFilteredMinterDAExpSettlementV0.sol";
 import "@openzeppelin-4.7/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.7/contracts/utils/math/SafeCast.sol";
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/archive/minter-suite/Minters/MinterDAExpSettlement/MinterDAExpSettlementV0.sol
+++ b/contracts/archive/minter-suite/Minters/MinterDAExpSettlement/MinterDAExpSettlementV0.sol
@@ -8,7 +8,7 @@ import "../../../../interfaces/0.8.x/IFilteredMinterDAExpSettlementV0.sol";
 import "@openzeppelin-4.7/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.7/contracts/utils/math/SafeCast.sol";
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/archive/minter-suite/Minters/MinterDAExpSettlement/MinterDAExpSettlementV1.sol
+++ b/contracts/archive/minter-suite/Minters/MinterDAExpSettlement/MinterDAExpSettlementV1.sol
@@ -9,7 +9,7 @@ import "../../../../minter-suite/Minters/MinterBase_v0_1_1.sol";
 import "@openzeppelin-4.7/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.7/contracts/utils/math/SafeCast.sol";
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/archive/minter-suite/Minters/MinterDAExpSettlement/MinterDAExpSettlementV1.sol
+++ b/contracts/archive/minter-suite/Minters/MinterDAExpSettlement/MinterDAExpSettlementV1.sol
@@ -9,7 +9,7 @@ import "../../../../minter-suite/Minters/MinterBase_v0_1_1.sol";
 import "@openzeppelin-4.7/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.7/contracts/utils/math/SafeCast.sol";
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/archive/minter-suite/Minters/MinterDALin/MinterDALinV2.sol
+++ b/contracts/archive/minter-suite/Minters/MinterDALin/MinterDALinV2.sol
@@ -8,7 +8,7 @@ import "../../../../interfaces/0.8.x/IFilteredMinterDALinV0.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/math/SafeCast.sol";
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/archive/minter-suite/Minters/MinterDALin/MinterDALinV2.sol
+++ b/contracts/archive/minter-suite/Minters/MinterDALin/MinterDALinV2.sol
@@ -8,7 +8,7 @@ import "../../../../interfaces/0.8.x/IFilteredMinterDALinV0.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/math/SafeCast.sol";
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/archive/minter-suite/Minters/MinterDALin/MinterDALinV3.sol
+++ b/contracts/archive/minter-suite/Minters/MinterDALin/MinterDALinV3.sol
@@ -8,7 +8,7 @@ import "../../../../interfaces/0.8.x/IFilteredMinterDALinV1.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/math/SafeCast.sol";
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/archive/minter-suite/Minters/MinterDALin/MinterDALinV3.sol
+++ b/contracts/archive/minter-suite/Minters/MinterDALin/MinterDALinV3.sol
@@ -8,7 +8,7 @@ import "../../../../interfaces/0.8.x/IFilteredMinterDALinV1.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/math/SafeCast.sol";
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/archive/minter-suite/Minters/MinterHolder/MinterHolderV1.sol
+++ b/contracts/archive/minter-suite/Minters/MinterHolder/MinterHolderV1.sol
@@ -11,7 +11,7 @@ import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/structs/EnumerableSet.sol";
 import "@openzeppelin-4.5/contracts/utils/structs/EnumerableMap.sol";
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/archive/minter-suite/Minters/MinterHolder/MinterHolderV1.sol
+++ b/contracts/archive/minter-suite/Minters/MinterHolder/MinterHolderV1.sol
@@ -11,7 +11,7 @@ import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/structs/EnumerableSet.sol";
 import "@openzeppelin-4.5/contracts/utils/structs/EnumerableMap.sol";
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/archive/minter-suite/Minters/MinterHolder/MinterHolderV2.sol
+++ b/contracts/archive/minter-suite/Minters/MinterHolder/MinterHolderV2.sol
@@ -11,7 +11,7 @@ import "@openzeppelin-4.5/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/structs/EnumerableSet.sol";
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/archive/minter-suite/Minters/MinterHolder/MinterHolderV2.sol
+++ b/contracts/archive/minter-suite/Minters/MinterHolder/MinterHolderV2.sol
@@ -11,7 +11,7 @@ import "@openzeppelin-4.5/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/structs/EnumerableSet.sol";
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/archive/minter-suite/Minters/MinterHolder/MinterHolderV3.sol
+++ b/contracts/archive/minter-suite/Minters/MinterHolder/MinterHolderV3.sol
@@ -11,7 +11,7 @@ import "@openzeppelin-4.5/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/structs/EnumerableSet.sol";
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/archive/minter-suite/Minters/MinterHolder/MinterHolderV3.sol
+++ b/contracts/archive/minter-suite/Minters/MinterHolder/MinterHolderV3.sol
@@ -11,7 +11,7 @@ import "@openzeppelin-4.5/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/structs/EnumerableSet.sol";
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/archive/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
+++ b/contracts/archive/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
@@ -9,7 +9,7 @@ import "@openzeppelin-4.7/contracts/utils/cryptography/MerkleProof.sol";
 import "@openzeppelin-4.7/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin-4.7/contracts/security/ReentrancyGuard.sol";
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/archive/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
+++ b/contracts/archive/minter-suite/Minters/MinterMerkle/MinterMerkleV1.sol
@@ -9,7 +9,7 @@ import "@openzeppelin-4.7/contracts/utils/cryptography/MerkleProof.sol";
 import "@openzeppelin-4.7/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin-4.7/contracts/security/ReentrancyGuard.sol";
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/archive/minter-suite/Minters/MinterMerkle/MinterMerkleV2.sol
+++ b/contracts/archive/minter-suite/Minters/MinterMerkle/MinterMerkleV2.sol
@@ -10,7 +10,7 @@ import "@openzeppelin-4.7/contracts/utils/cryptography/MerkleProof.sol";
 import "@openzeppelin-4.7/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin-4.7/contracts/security/ReentrancyGuard.sol";
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/archive/minter-suite/Minters/MinterMerkle/MinterMerkleV2.sol
+++ b/contracts/archive/minter-suite/Minters/MinterMerkle/MinterMerkleV2.sol
@@ -10,7 +10,7 @@ import "@openzeppelin-4.7/contracts/utils/cryptography/MerkleProof.sol";
 import "@openzeppelin-4.7/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin-4.7/contracts/security/ReentrancyGuard.sol";
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/archive/minter-suite/Minters/MinterMerkle/MinterMerkleV3.sol
+++ b/contracts/archive/minter-suite/Minters/MinterMerkle/MinterMerkleV3.sol
@@ -10,7 +10,7 @@ import "@openzeppelin-4.7/contracts/utils/cryptography/MerkleProof.sol";
 import "@openzeppelin-4.7/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin-4.7/contracts/security/ReentrancyGuard.sol";
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/archive/minter-suite/Minters/MinterMerkle/MinterMerkleV3.sol
+++ b/contracts/archive/minter-suite/Minters/MinterMerkle/MinterMerkleV3.sol
@@ -10,7 +10,7 @@ import "@openzeppelin-4.7/contracts/utils/cryptography/MerkleProof.sol";
 import "@openzeppelin-4.7/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin-4.7/contracts/security/ReentrancyGuard.sol";
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/archive/minter-suite/Minters/MinterMerkle/MinterMerkleV4.sol
+++ b/contracts/archive/minter-suite/Minters/MinterMerkle/MinterMerkleV4.sol
@@ -10,7 +10,7 @@ import "@openzeppelin-4.7/contracts/utils/cryptography/MerkleProof.sol";
 import "@openzeppelin-4.7/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin-4.7/contracts/security/ReentrancyGuard.sol";
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/archive/minter-suite/Minters/MinterMerkle/MinterMerkleV4.sol
+++ b/contracts/archive/minter-suite/Minters/MinterMerkle/MinterMerkleV4.sol
@@ -10,7 +10,7 @@ import "@openzeppelin-4.7/contracts/utils/cryptography/MerkleProof.sol";
 import "@openzeppelin-4.7/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin-4.7/contracts/security/ReentrancyGuard.sol";
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/archive/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
+++ b/contracts/archive/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
@@ -7,7 +7,7 @@ import "../../../../interfaces/0.8.x/IFilteredMinterV0.sol";
 
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/archive/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
+++ b/contracts/archive/minter-suite/Minters/MinterSetPrice/MinterSetPriceV2.sol
@@ -7,7 +7,7 @@ import "../../../../interfaces/0.8.x/IFilteredMinterV0.sol";
 
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/archive/minter-suite/Minters/MinterSetPrice/MinterSetPriceV3.sol
+++ b/contracts/archive/minter-suite/Minters/MinterSetPrice/MinterSetPriceV3.sol
@@ -7,7 +7,7 @@ import "../../../../interfaces/0.8.x/IFilteredMinterV2.sol";
 
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/archive/minter-suite/Minters/MinterSetPrice/MinterSetPriceV3.sol
+++ b/contracts/archive/minter-suite/Minters/MinterSetPrice/MinterSetPriceV3.sol
@@ -7,7 +7,7 @@ import "../../../../interfaces/0.8.x/IFilteredMinterV2.sol";
 
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/archive/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V2.sol
+++ b/contracts/archive/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V2.sol
@@ -8,7 +8,7 @@ import "../../../../interfaces/0.8.x/IFilteredMinterV0.sol";
 import "@openzeppelin-4.5/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/archive/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V2.sol
+++ b/contracts/archive/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V2.sol
@@ -8,7 +8,7 @@ import "../../../../interfaces/0.8.x/IFilteredMinterV0.sol";
 import "@openzeppelin-4.5/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/archive/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V3.sol
+++ b/contracts/archive/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V3.sol
@@ -8,7 +8,7 @@ import "../../../../interfaces/0.8.x/IFilteredMinterV2.sol";
 import "@openzeppelin-4.5/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/archive/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V3.sol
+++ b/contracts/archive/minter-suite/Minters/MinterSetPriceERC20/MinterSetPriceERC20V3.sol
@@ -8,7 +8,7 @@ import "../../../../interfaces/0.8.x/IFilteredMinterV2.sol";
 import "@openzeppelin-4.5/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/engine-registry/EngineRegistryV0.sol
+++ b/contracts/engine-registry/EngineRegistryV0.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 import "../interfaces/0.8.x/IEngineRegistryV0.sol";
 import "@openzeppelin-4.7/contracts/utils/introspection/ERC165.sol";

--- a/contracts/engine-registry/EngineRegistryV0.sol
+++ b/contracts/engine-registry/EngineRegistryV0.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import "../interfaces/0.8.x/IEngineRegistryV0.sol";
 import "@openzeppelin-4.7/contracts/utils/introspection/ERC165.sol";

--- a/contracts/engine-registry/future/EngineRegistryV1.sol
+++ b/contracts/engine-registry/future/EngineRegistryV1.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import "../../interfaces/0.8.x/IEngineRegistryV0.sol";
 import "@openzeppelin-4.7/contracts/utils/introspection/ERC165.sol";

--- a/contracts/engine-registry/future/EngineRegistryV1.sol
+++ b/contracts/engine-registry/future/EngineRegistryV1.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 import "../../interfaces/0.8.x/IEngineRegistryV0.sol";
 import "@openzeppelin-4.7/contracts/utils/introspection/ERC165.sol";

--- a/contracts/engine/V2/GenArt721MinterDAExp_PBAB.sol
+++ b/contracts/engine/V2/GenArt721MinterDAExp_PBAB.sol
@@ -6,7 +6,7 @@ import "../../interfaces/0.8.x/IGenArt721CoreV2_PBAB.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/math/SafeCast.sol";
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 /**
  * @title A minter contract that allows tokens to be minted with ETH.

--- a/contracts/engine/V2/GenArt721MinterDAExp_PBAB.sol
+++ b/contracts/engine/V2/GenArt721MinterDAExp_PBAB.sol
@@ -6,7 +6,7 @@ import "../../interfaces/0.8.x/IGenArt721CoreV2_PBAB.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/math/SafeCast.sol";
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 /**
  * @title A minter contract that allows tokens to be minted with ETH.

--- a/contracts/engine/V3/GenArt721CoreV3_Engine.sol
+++ b/contracts/engine/V3/GenArt721CoreV3_Engine.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 // Created By: Art Blocks Inc.
 

--- a/contracts/engine/V3/GenArt721CoreV3_Engine.sol
+++ b/contracts/engine/V3/GenArt721CoreV3_Engine.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 // Created By: Art Blocks Inc.
 

--- a/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
+++ b/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 // Created By: Art Blocks Inc.
 

--- a/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
+++ b/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 // Created By: Art Blocks Inc.
 

--- a/contracts/engine/V3/forks/GenArt721CoreV3_Engine_Flex_PROOF.sol
+++ b/contracts/engine/V3/forks/GenArt721CoreV3_Engine_Flex_PROOF.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 // Created By: Art Blocks Inc.
 

--- a/contracts/engine/V3/forks/GenArt721CoreV3_Engine_Flex_PROOF.sol
+++ b/contracts/engine/V3/forks/GenArt721CoreV3_Engine_Flex_PROOF.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 // Created By: Art Blocks Inc.
 

--- a/contracts/engine/V3/forks/PROHIBITION/AdminACLV0_PROHIBITION.sol
+++ b/contracts/engine/V3/forks/PROHIBITION/AdminACLV0_PROHIBITION.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 import "./interfaces/IAdminACLV0_PROHIBITION.sol";
 import "../../../../interfaces/0.8.x/IGenArt721CoreContractV3_Base.sol";

--- a/contracts/engine/V3/forks/PROHIBITION/AdminACLV0_PROHIBITION.sol
+++ b/contracts/engine/V3/forks/PROHIBITION/AdminACLV0_PROHIBITION.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import "./interfaces/IAdminACLV0_PROHIBITION.sol";
 import "../../../../interfaces/0.8.x/IGenArt721CoreContractV3_Base.sol";

--- a/contracts/engine/V3/forks/PROHIBITION/GenArt721CoreV3_Engine_Flex_PROHIBITION.sol
+++ b/contracts/engine/V3/forks/PROHIBITION/GenArt721CoreV3_Engine_Flex_PROHIBITION.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 // Created By: Art Blocks Inc.
 

--- a/contracts/engine/V3/forks/PROHIBITION/GenArt721CoreV3_Engine_Flex_PROHIBITION.sol
+++ b/contracts/engine/V3/forks/PROHIBITION/GenArt721CoreV3_Engine_Flex_PROHIBITION.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 // Created By: Art Blocks Inc.
 

--- a/contracts/explorations/GenArt721CoreV3_Explorations.sol
+++ b/contracts/explorations/GenArt721CoreV3_Explorations.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 // Created By: Art Blocks Inc.
 

--- a/contracts/explorations/GenArt721CoreV3_Explorations.sol
+++ b/contracts/explorations/GenArt721CoreV3_Explorations.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 // Created By: Art Blocks Inc.
 

--- a/contracts/interfaces/0.8.x/IDelegationRegistry.sol
+++ b/contracts/interfaces/0.8.x/IDelegationRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CC0-1.0
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.19;
 
 /// @dev Source: https://github.com/0xfoobar/delegation-registry/blob/main/src/IDelegationRegistry.sol
 

--- a/contracts/interfaces/0.8.x/IDependencyRegistryCompatibleV0.sol
+++ b/contracts/interfaces/0.8.x/IDependencyRegistryCompatibleV0.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Created By: Art Blocks Inc.
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.19;
 
 interface IDependencyRegistryCompatibleV0 {
     /// Dependency registry managed by Art Blocks

--- a/contracts/interfaces/0.8.x/IDependencyRegistryV0.sol
+++ b/contracts/interfaces/0.8.x/IDependencyRegistryV0.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Created By: Art Blocks Inc.
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.19;
 
 interface IDependencyRegistryV0 {
     event SupportedCoreContractAdded(address indexed _coreContractAddress);

--- a/contracts/interfaces/0.8.x/IEngineRegistryV0.sol
+++ b/contracts/interfaces/0.8.x/IEngineRegistryV0.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Created By: Art Blocks Inc.
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.19;
 
 interface IEngineRegistryV0 {
     /// ADDRESS

--- a/contracts/interfaces/0.8.x/IRandomizerPolyptychV0.sol
+++ b/contracts/interfaces/0.8.x/IRandomizerPolyptychV0.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Creatd By: Art Blocks Inc.
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import "./IRandomizerV2.sol";
 

--- a/contracts/interfaces/0.8.x/IRandomizerPolyptychV0.sol
+++ b/contracts/interfaces/0.8.x/IRandomizerPolyptychV0.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Creatd By: Art Blocks Inc.
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 import "./IRandomizerV2.sol";
 

--- a/contracts/libs/integration-refs/delegation-registry/DelegationRegistry.sol
+++ b/contracts/libs/integration-refs/delegation-registry/DelegationRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CC0-1.0
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.19;
 
 // This is a mock contract to be used in tests.
 // The source code is copied from ETH mainnet, deployed at:0x00000000000076a84fef008cdabe6409d2fe638b

--- a/contracts/minter-suite/MinterFilter/MinterFilterV1.sol
+++ b/contracts/minter-suite/MinterFilter/MinterFilterV1.sol
@@ -10,7 +10,7 @@ import "../../libs/0.8.x/Bytes32Strings.sol";
 
 import "@openzeppelin-4.5/contracts/utils/structs/EnumerableMap.sol";
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 /**
  * @title Minter filter contract that allows filtered minters to be set

--- a/contracts/minter-suite/MinterFilter/MinterFilterV1.sol
+++ b/contracts/minter-suite/MinterFilter/MinterFilterV1.sol
@@ -10,7 +10,7 @@ import "../../libs/0.8.x/Bytes32Strings.sol";
 
 import "@openzeppelin-4.5/contracts/utils/structs/EnumerableMap.sol";
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 /**
  * @title Minter filter contract that allows filtered minters to be set

--- a/contracts/minter-suite/Minters/MinterDAExpSettlementV2.sol
+++ b/contracts/minter-suite/Minters/MinterDAExpSettlementV2.sol
@@ -9,7 +9,7 @@ import "./MinterBase_v0_1_1.sol";
 import "@openzeppelin-4.7/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.7/contracts/utils/math/SafeCast.sol";
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/minter-suite/Minters/MinterDAExpSettlementV2.sol
+++ b/contracts/minter-suite/Minters/MinterDAExpSettlementV2.sol
@@ -9,7 +9,7 @@ import "./MinterBase_v0_1_1.sol";
 import "@openzeppelin-4.7/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.7/contracts/utils/math/SafeCast.sol";
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/minter-suite/Minters/MinterDAExpV4.sol
+++ b/contracts/minter-suite/Minters/MinterDAExpV4.sol
@@ -9,7 +9,7 @@ import "./MinterBase_v0_1_1.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/math/SafeCast.sol";
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/minter-suite/Minters/MinterDAExpV4.sol
+++ b/contracts/minter-suite/Minters/MinterDAExpV4.sol
@@ -9,7 +9,7 @@ import "./MinterBase_v0_1_1.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/math/SafeCast.sol";
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/minter-suite/Minters/MinterDALinV4.sol
+++ b/contracts/minter-suite/Minters/MinterDALinV4.sol
@@ -9,7 +9,7 @@ import "./MinterBase_v0_1_1.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/math/SafeCast.sol";
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/minter-suite/Minters/MinterDALinV4.sol
+++ b/contracts/minter-suite/Minters/MinterDALinV4.sol
@@ -9,7 +9,7 @@ import "./MinterBase_v0_1_1.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/math/SafeCast.sol";
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/minter-suite/Minters/MinterHolderV4.sol
+++ b/contracts/minter-suite/Minters/MinterHolderV4.sol
@@ -11,7 +11,7 @@ import "@openzeppelin-4.5/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/structs/EnumerableSet.sol";
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/minter-suite/Minters/MinterHolderV4.sol
+++ b/contracts/minter-suite/Minters/MinterHolderV4.sol
@@ -11,7 +11,7 @@ import "@openzeppelin-4.5/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/structs/EnumerableSet.sol";
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/minter-suite/Minters/MinterMerkleV5.sol
+++ b/contracts/minter-suite/Minters/MinterMerkleV5.sol
@@ -11,7 +11,7 @@ import "@openzeppelin-4.7/contracts/utils/cryptography/MerkleProof.sol";
 import "@openzeppelin-4.7/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin-4.7/contracts/security/ReentrancyGuard.sol";
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/minter-suite/Minters/MinterMerkleV5.sol
+++ b/contracts/minter-suite/Minters/MinterMerkleV5.sol
@@ -11,7 +11,7 @@ import "@openzeppelin-4.7/contracts/utils/cryptography/MerkleProof.sol";
 import "@openzeppelin-4.7/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin-4.7/contracts/security/ReentrancyGuard.sol";
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/minter-suite/Minters/MinterPolyptychV0.sol
+++ b/contracts/minter-suite/Minters/MinterPolyptychV0.sol
@@ -13,7 +13,7 @@ import "@openzeppelin-4.5/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/structs/EnumerableSet.sol";
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 /**
  * @title Core contract interface for accessing the randomizer from the minter

--- a/contracts/minter-suite/Minters/MinterPolyptychV0.sol
+++ b/contracts/minter-suite/Minters/MinterPolyptychV0.sol
@@ -13,7 +13,7 @@ import "@openzeppelin-4.5/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/structs/EnumerableSet.sol";
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 /**
  * @title Core contract interface for accessing the randomizer from the minter

--- a/contracts/minter-suite/Minters/MinterSEAV0.sol
+++ b/contracts/minter-suite/Minters/MinterSEAV0.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Created By: Art Blocks Inc.
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 import "../../interfaces/0.8.x/IGenArt721CoreContractV3_Base.sol";
 import "../../interfaces/0.8.x/IMinterFilterV0.sol";

--- a/contracts/minter-suite/Minters/MinterSEAV0.sol
+++ b/contracts/minter-suite/Minters/MinterSEAV0.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Created By: Art Blocks Inc.
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import "../../interfaces/0.8.x/IGenArt721CoreContractV3_Base.sol";
 import "../../interfaces/0.8.x/IMinterFilterV0.sol";

--- a/contracts/minter-suite/Minters/MinterSetPriceERC20V4.sol
+++ b/contracts/minter-suite/Minters/MinterSetPriceERC20V4.sol
@@ -10,7 +10,7 @@ import "./MinterBase_v0_1_1.sol";
 
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/minter-suite/Minters/MinterSetPriceERC20V4.sol
+++ b/contracts/minter-suite/Minters/MinterSetPriceERC20V4.sol
@@ -10,7 +10,7 @@ import "./MinterBase_v0_1_1.sol";
 
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH

--- a/contracts/minter-suite/Minters/MinterSetPriceV4.sol
+++ b/contracts/minter-suite/Minters/MinterSetPriceV4.sol
@@ -8,7 +8,7 @@ import "./MinterBase_v0_1_1.sol";
 
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/minter-suite/Minters/MinterSetPriceV4.sol
+++ b/contracts/minter-suite/Minters/MinterSetPriceV4.sol
@@ -8,7 +8,7 @@ import "./MinterBase_v0_1_1.sol";
 
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 /**
  * @title Filtered Minter contract that allows tokens to be minted with ETH.

--- a/contracts/mock/BytecodeV0TextCR_DMock.sol
+++ b/contracts/mock/BytecodeV0TextCR_DMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 // Created By: Art Blocks Inc.
 

--- a/contracts/mock/BytecodeV0TextCR_DMock.sol
+++ b/contracts/mock/BytecodeV0TextCR_DMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 // Created By: Art Blocks Inc.
 

--- a/contracts/mock/BytecodeV1LibCallsMock.sol
+++ b/contracts/mock/BytecodeV1LibCallsMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 // Created By: Art Blocks Inc.
 

--- a/contracts/mock/BytecodeV1LibCallsMock.sol
+++ b/contracts/mock/BytecodeV1LibCallsMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 // Created By: Art Blocks Inc.
 

--- a/contracts/mock/BytecodeV1TextCR_DMock.sol
+++ b/contracts/mock/BytecodeV1TextCR_DMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 // Created By: Art Blocks Inc.
 

--- a/contracts/mock/BytecodeV1TextCR_DMock.sol
+++ b/contracts/mock/BytecodeV1TextCR_DMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 // Created By: Art Blocks Inc.
 

--- a/contracts/mock/DeadReceiverBidderMock.sol
+++ b/contracts/mock/DeadReceiverBidderMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {DeadReceiverMock} from "./DeadReceiverMock.sol";
 

--- a/contracts/mock/DeadReceiverBidderMock.sol
+++ b/contracts/mock/DeadReceiverBidderMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 import {DeadReceiverMock} from "./DeadReceiverMock.sol";
 

--- a/contracts/mock/DeadReceiverMock.sol
+++ b/contracts/mock/DeadReceiverMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 /**
  * @notice This reverts when receiving Ether

--- a/contracts/mock/DeadReceiverMock.sol
+++ b/contracts/mock/DeadReceiverMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 /**
  * @notice This reverts when receiving Ether

--- a/contracts/mock/GasLimitReceiverBidderMock.sol
+++ b/contracts/mock/GasLimitReceiverBidderMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import {GasLimitReceiverMock} from "./GasLimitReceiverMock.sol";
 

--- a/contracts/mock/GasLimitReceiverBidderMock.sol
+++ b/contracts/mock/GasLimitReceiverBidderMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 import {GasLimitReceiverMock} from "./GasLimitReceiverMock.sol";
 

--- a/contracts/mock/GasLimitReceiverMock.sol
+++ b/contracts/mock/GasLimitReceiverMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 /**
  * @notice This uses all gas when receiving Ether, useful when testing denial

--- a/contracts/mock/GasLimitReceiverMock.sol
+++ b/contracts/mock/GasLimitReceiverMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 /**
  * @notice This uses all gas when receiving Ether, useful when testing denial

--- a/contracts/mock/GenArt721CoreV3_Engine_IncorrectCoreType.sol
+++ b/contracts/mock/GenArt721CoreV3_Engine_IncorrectCoreType.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 // Created By: Art Blocks Inc.
 

--- a/contracts/mock/GenArt721CoreV3_Engine_IncorrectCoreType.sol
+++ b/contracts/mock/GenArt721CoreV3_Engine_IncorrectCoreType.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 // Created By: Art Blocks Inc.
 

--- a/contracts/mock/MockAdminACLV0.sol
+++ b/contracts/mock/MockAdminACLV0.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import "../interfaces/0.8.x/IAdminACLV0.sol";
 import "@openzeppelin-4.7/contracts/access/Ownable.sol";

--- a/contracts/mock/MockAdminACLV0.sol
+++ b/contracts/mock/MockAdminACLV0.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 import "../interfaces/0.8.x/IAdminACLV0.sol";
 import "@openzeppelin-4.7/contracts/access/Ownable.sol";

--- a/contracts/mock/MockAdminACLV0_PROHIBITION.sol
+++ b/contracts/mock/MockAdminACLV0_PROHIBITION.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.19;
 
 import "../engine/V3/forks/PROHIBITION/interfaces/IAdminACLV0_PROHIBITION.sol";
 import "../interfaces/0.8.x/IGenArt721CoreContractV3_Base.sol";

--- a/contracts/mock/RandomizerV2_NoAssignMock.sol
+++ b/contracts/mock/RandomizerV2_NoAssignMock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Creatd By: Art Blocks Inc.
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import "../randomizer/RandomizerV2.sol";
 

--- a/contracts/mock/RandomizerV2_NoAssignMock.sol
+++ b/contracts/mock/RandomizerV2_NoAssignMock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Creatd By: Art Blocks Inc.
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 import "../randomizer/RandomizerV2.sol";
 

--- a/contracts/mock/SSTORE2Mock.sol
+++ b/contracts/mock/SSTORE2Mock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 // Created By: Art Blocks Inc.
 

--- a/contracts/mock/SSTORE2Mock.sol
+++ b/contracts/mock/SSTORE2Mock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 // Created By: Art Blocks Inc.
 

--- a/contracts/randomizer/BasicRandomizerBase_v0_0_0.sol
+++ b/contracts/randomizer/BasicRandomizerBase_v0_0_0.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Creatd By: Art Blocks Inc.
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 abstract contract RandomizerBase {
     // base class that returns

--- a/contracts/randomizer/BasicRandomizerBase_v0_0_0.sol
+++ b/contracts/randomizer/BasicRandomizerBase_v0_0_0.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Creatd By: Art Blocks Inc.
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 abstract contract RandomizerBase {
     // base class that returns

--- a/contracts/randomizer/PolyptychRandomizerV0.sol
+++ b/contracts/randomizer/PolyptychRandomizerV0.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Creatd By: Art Blocks Inc.
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 import "../interfaces/0.8.x/IGenArt721CoreContractV3_Base.sol";
 import "../interfaces/0.8.x/IRandomizerPolyptychV0.sol";

--- a/contracts/randomizer/PolyptychRandomizerV0.sol
+++ b/contracts/randomizer/PolyptychRandomizerV0.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Creatd By: Art Blocks Inc.
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import "../interfaces/0.8.x/IGenArt721CoreContractV3_Base.sol";
 import "../interfaces/0.8.x/IRandomizerPolyptychV0.sol";

--- a/contracts/randomizer/RandomizerV2.sol
+++ b/contracts/randomizer/RandomizerV2.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Creatd By: Art Blocks Inc.
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.19;
 
 import "../interfaces/0.8.x/IRandomizerV2.sol";
 import "../interfaces/0.8.x/IGenArt721CoreContractV3_Base.sol";

--- a/contracts/randomizer/RandomizerV2.sol
+++ b/contracts/randomizer/RandomizerV2.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Creatd By: Art Blocks Inc.
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.20;
 
 import "../interfaces/0.8.x/IRandomizerV2.sol";
 import "../interfaces/0.8.x/IGenArt721CoreContractV3_Base.sol";

--- a/hardhat.solidity-config.ts
+++ b/hardhat.solidity-config.ts
@@ -2,16 +2,7 @@
 export const solidityConfig = {
   compilers: [
     {
-      version: "0.8.20",
-      settings: {
-        optimizer: {
-          enabled: true,
-          runs: 25,
-        },
-      },
-    },
-    {
-      version: "0.8.17",
+      version: "0.8.19",
       settings: {
         optimizer: {
           enabled: true,

--- a/hardhat.solidity-config.ts
+++ b/hardhat.solidity-config.ts
@@ -2,6 +2,15 @@
 export const solidityConfig = {
   compilers: [
     {
+      version: "0.8.20",
+      settings: {
+        optimizer: {
+          enabled: true,
+          runs: 25,
+        },
+      },
+    },
+    {
       version: "0.8.17",
       settings: {
         optimizer: {

--- a/solidity-gotchas.md
+++ b/solidity-gotchas.md
@@ -16,7 +16,7 @@ In no particular order :)
 
 ## ABI.encodePacked
 
-When using `ABI.encodePacked` to concatenate multiple items, beware that if two sequential items are dynamic types, it is easy to craft collisions if the hash value by moving parts of one item into the other. See more details in [this section of the Solidity docs](https://docs.soliditylang.org/en/v0.8.17/abi-spec.html?highlight=abi.encodePacked#non-standard-packed-mode).
+When using `ABI.encodePacked` to concatenate multiple items, beware that if two sequential items are dynamic types, it is easy to craft collisions if the hash value by moving parts of one item into the other. See more details in [this section of the Solidity docs](https://docs.soliditylang.org/en/v0.8.19/abi-spec.html?highlight=abi.encodePacked#non-standard-packed-mode).
 
 ## Hard-Coded Addresses
 


### PR DESCRIPTION
## Description of the change

Update Solidity compiler version from `^0.8.17` to `^0.8.19`.

Note, not updating to very latest `0.8.20` currently as this is causing test breakages for an unclear reason, going to let that version cook a bit more.