### PR TITLE
Nits on minter filter V2 styling, included functions

### DIFF
--- a/packages/contracts/contracts/interfaces/0.8.x/IMinterFilterV1.sol
+++ b/packages/contracts/contracts/interfaces/0.8.x/IMinterFilterV1.sol
@@ -24,35 +24,35 @@ interface IMinterFilterV1 {
     event Deployed();
 
     /**
-     * @notice Globally approved minter `_minter`.
+     * @notice Globally approved minter `minter`.
      */
-    event MinterApprovedGlobally(address indexed _minter, string _minterType);
+    event MinterApprovedGlobally(address indexed minter, string minterType);
 
     /**
-     * @notice Globally revoked minter `_minter`.
+     * @notice Globally revoked minter `minter`.
      * @dev contract owner may still approve this minter on a per-contract
      * basis.
      */
-    event MinterRevokedGlobally(address indexed _minter);
+    event MinterRevokedGlobally(address indexed minter);
 
     /**
-     * @notice Approved minter `_minter` on core contract
-     * `_coreContract`.
+     * @notice Approved minter `minter` on core contract
+     * `coreContract`.
      */
     event MinterApprovedForContract(
-        address indexed _coreContract,
-        address indexed _minter,
-        string _minterType
+        address indexed coreContract,
+        address indexed minter,
+        string minterType
     );
 
     /**
-     * @notice Globally revoked minter `_minter`.
+     * @notice Revoked minter `minter` on core contract `coreContract`.
      * @dev minter filter owner may still globally approve this minter for all
      * contracts.
      */
     event MinterRevokedForContract(
-        address indexed _coreContract,
-        address indexed _minter
+        address indexed coreContract,
+        address indexed minter
     );
 
     /**
@@ -63,7 +63,7 @@ interface IMinterFilterV1 {
         uint256 indexed projectId,
         address indexed coreContract,
         address indexed minter,
-        string _minterType
+        string minterType
     );
 
     /**

--- a/packages/contracts/contracts/interfaces/0.8.x/IMinterFilterV1.sol
+++ b/packages/contracts/contracts/interfaces/0.8.x/IMinterFilterV1.sol
@@ -106,6 +106,8 @@ interface IMinterFilterV1 {
 
     function updateCoreRegistry(address _coreRegistry) external;
 
+    function minterFilterType() external pure returns (string memory);
+
     function getMinterForProject(
         uint256 _projectId,
         address _coreContract
@@ -130,6 +132,23 @@ interface IMinterFilterV1 {
 
     /// The current admin ACL contract
     function adminACLContract() external view returns (IAdminACLV0);
+
+    /// The quantity of projects on a core contract that have assigned minters
+    function getNumProjectsOnContractWithMinters(
+        address _coreContract
+    ) external view returns (uint256);
+
+    function getProjectAndMinterInfoOnContractAt(
+        address _coreContract,
+        uint256 _index
+    )
+        external
+        view
+        returns (
+            uint256 projectId,
+            address minterAddress,
+            string memory minterType
+        );
 
     /**
      * Owner of contract.

--- a/packages/contracts/contracts/minter-suite/MinterFilter/MinterFilterV2.sol
+++ b/packages/contracts/contracts/minter-suite/MinterFilter/MinterFilterV2.sol
@@ -304,11 +304,11 @@ contract MinterFilterV2 is Ownable, IMinterFilterV1 {
             contractApprovedMinters[_coreContract].add(_minter),
             "Minter already approved"
         );
-        emit MinterApprovedForContract(
-            _coreContract,
-            _minter,
-            IFilteredMinterV0(_minter).minterType()
-        );
+        emit MinterApprovedForContract({
+            coreContract: _coreContract,
+            minter: _minter,
+            minterType: IFilteredMinterV0(_minter).minterType()
+        });
     }
 
     /**
@@ -338,7 +338,10 @@ contract MinterFilterV2 is Ownable, IMinterFilterV1 {
             contractApprovedMinters[_coreContract].remove(_minter),
             "Only previously approved minter"
         );
-        emit MinterRevokedForContract(_coreContract, _minter);
+        emit MinterRevokedForContract({
+            coreContract: _coreContract,
+            minter: _minter
+        });
     }
 
     /**
@@ -383,12 +386,12 @@ contract MinterFilterV2 is Ownable, IMinterFilterV1 {
         // assign new minter
         numProjectsUsingMinter[_minter]++;
         minterForProject[_coreContract].set(_projectId, _minter);
-        emit ProjectMinterRegistered(
-            _projectId,
-            _coreContract,
-            _minter,
-            IFilteredMinterV0(_minter).minterType()
-        );
+        emit ProjectMinterRegistered({
+            projectId: _projectId,
+            coreContract: _coreContract,
+            minter: _minter,
+            minterType: IFilteredMinterV0(_minter).minterType()
+        });
     }
 
     /**


### PR DESCRIPTION
## Description of the change

Update Minter Filter V2 with minor updates on styling, as well as what functions are included.

Updates include:
- style: underscore is removed from event parameters in the new interface
- style: named parameters are used when sending events with adjacent parameters of the same type
- interface: a few functions used by the new subgraph handlers are included in the IMinterFilterV1 interface.

Getting this in before writing new subgraph handlers.