### PR TITLE
fix sdk failing tests

### DIFF
--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Build
         run: yarn run build
         working-directory: packages/sdk
+      - name: Typechain
+        run: yarn run build:typechain
+        working-directory: packages/sdk
       - name: Run Tests
         run: yarn run test
         working-directory: packages/sdk

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -32,7 +32,7 @@
     "build:docs": "jsdoc -c jsdoc.json",
     "pre-commit": "yarn lint",
     "pre-push": "yarn test",
-    "build:typechain": "typechain --target ethers-v5 --out-dir ./src/generated/contracts './artifacts/*.json' '../../node_modules/@artblocks/contracts/artifacts/**/*.json'"
+    "build:typechain": "typechain --target ethers-v5 --out-dir ./src/generated/contracts './artifacts/*.json' '../../node_modules/@artblocks/contracts/artifacts/contracts/!(*.dbg)*.json'"
   },
   "lint-staged": {
     "*.{js,ts,tsx, jsx}": [


### PR DESCRIPTION
## Description of the change

filter sdk's build:typechain to only find abi files.
