### PR TITLE
update @artblocks/contracts version

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artblocks/contracts",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Smart contracts used by Art Blocks",
   "files": [
     "/contracts/**/*.sol",


### PR DESCRIPTION
## Description of the change

Bump artblocks contracts version to initiate new npm package release.

New release includes the following updates:
- new shared BytecodeStorage library version, and integration architecture
  - required for new e2e testing in subgraph repo
- new shared MinterFilter ABIs
