### PR TITLE
Update deployment release process

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,3 @@
 ## Description of the change
 
 \<add description here\>
-
-> reminder: Any mainnet deployments after 10 Jan 2023 should be tagged as [Releases](https://github.com/ArtBlocks/artblocks-contracts/releases) in this repository. This ensures that the deployed contract source code is easily verifiable by anyone.

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -166,7 +166,7 @@ For details on the Flagship and Engine Minter Suite, see the [minter suite docum
 
 ## Contract Source Code Verification
 
-All mainnet deployments of contracts developed in this repositiory are verified on Etherscan. To protect against centralized source code verification failures (for example, if Etherscan were to dissappear), the PR history of this repository may be used to determine the commit at which a given deployment was performed, and source code verification could be submitted by anyone to a different source code verification service.
+All mainnet deployments of contracts developed in this repositiory are verified on Etherscan. To protect against centralized source code verification failures (for example, if Etherscan were to dissappear), the PR history of this repository may be used to determine the commit at which a given deployment was performed, and source code verification may be submitted by anyone to a different source code verification service. Deployment details are recorded in the `deployments/` directory.
 
 # Royalties
 

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -166,7 +166,7 @@ For details on the Flagship and Engine Minter Suite, see the [minter suite docum
 
 ## Contract Source Code Verification
 
-In an effort to ensure source code verification is easily completed by anyone, After 10, January 2023, all mainnet deployments should also have a corresponding tag+release in this GitHub repository. For deployments prior to this date, PR history may be used to determine the commit hash used for a given deployment. Currently, all mainnet deployments of contracts developed in this repositiory are verified on Etherscan.
+All mainnet deployments of contracts developed in this repositiory are verified on Etherscan. To protect against centralized source code verification failures (for example, if Etherscan were to dissappear), the PR history of this repository may be used to determine the commit at which a given deployment was performed, and source code verification could be submitted by anyone to a different source code verification service.
 
 # Royalties
 

--- a/packages/contracts/deployments/engine/README.md
+++ b/packages/contracts/deployments/engine/README.md
@@ -15,5 +15,3 @@ For V3_Engine core contracts:
   - the `DEPLOYMENTS.md` file should contain the deployment logs, as recorded by whatever deployment script was used.
   - the `DEPLOYMENT_LOGS.log` file should contain the raw deployment logs, as recorded by whatever deployment script was used.
 - Note that deployment scripts are NOT unique to each Engine partner for V3 contracts, and the `deployment-config.<environment>.ts` is intended to be sufficient to fully reproduce the deployment.
-
-All mainnet deployments that occurred after 10 Jan, 2023 should have a corresponding tag+release in the GitHub repository. This is to ensure that Art Blocks provides a well-documented contract deployment history and that the code deployed to mainnet can easily be verified by anyone.

--- a/packages/contracts/posterity/contracts/engine/README.md
+++ b/packages/contracts/posterity/contracts/engine/README.md
@@ -7,5 +7,3 @@ The code in this directory is intended to be deployed to the Ethereum blockchain
 The source code is intended to be compileable if a given directory is copied to the `/contracts/engine/` directory. However, these files will not be maintained and updated as the repository is updated over time, so imports may not work.
 
 All contracts deployed should have a corresponding deployment log in the `DEPLOYMENTS.md` file in the [`/deployments/engine/`](https://github.com/ArtBlocks/artblocks-contracts/tree/main/packages/contracts/deployments/engine) directory.
-
-All mainnet deployments that occurred after 10 Jan, 2023 should have a corresponding tag+release in the GitHub repository. This is to ensure that Art Blocks provides a well-documented contract deployment history and that the code deployed to mainnet can easily be verified by anyone.

--- a/packages/contracts/scripts/engine/V2/README.md
+++ b/packages/contracts/scripts/engine/V2/README.md
@@ -3,5 +3,3 @@
 This directory should contain all scripts used for deployment of Art Blocks Engine partner contracts. It is for archival purposes only, and is not intended to be used for development.
 
 All relevant deployment logs should be included in the `DEPLOYMENTS.md` file in the `scripts/engine/V2/<partner>` directory.
-
-All mainnet deployments that occurred after 10 Jan, 2023 should have a corresponding tag+release in the GitHub repository. This is to ensure that Art Blocks provides a well-documented contract deployment history and that the code deployed to mainnet can easily be verified by anyone.


### PR DESCRIPTION
## Description of the change

Update our documentation to reflect our current strategy of using PR history and deployment markdown files to enable source code verification in the event of etherscan failure.

Closes #473 

Note: this is separate from our new npm package release process, which will be noted in a follow-on PR.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204736689793131