### PR TITLE
Revert "Bump hardhat from 2.15.0 to 2.16.0"

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -63,7 +63,7 @@
     "eslint-config-custom": "*",
     "ethereum-waffle": "^4.0.10",
     "ethers": "^5.7.2",
-    "hardhat": "^2.16.0",
+    "hardhat": "^2.15.0",
     "hardhat-contract-sizer": "^2.10.0",
     "hardhat-docgen": "^1.3.0",
     "hardhat-gas-reporter": "^1.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11166,10 +11166,10 @@ hardhat-gas-reporter@^1.0.9:
     eth-gas-reporter "^0.2.25"
     sha1 "^1.1.1"
 
-hardhat@^2.16.0:
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.16.0.tgz#c5611d433416b31f6ce92f733b1f1b5236ad6230"
-  integrity sha512-7VQEJPQRAZdtrYUZaU9GgCpP3MBNy/pTdscARNJQMWKj5C+R7V32G5uIZKIqZ4QiqXa6CBfxxe+G+ahxUbHZHA==
+hardhat@^2.15.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.15.0.tgz#0cacb2b44c4c4651aa8ab649fef12804848b0267"
+  integrity sha512-cC9tM/N10YaES04zPOp7yR13iX3YibqaNmi0//Ep40Nt9ELIJx3kFpQmucur0PAIfXYpGnw5RuXHNLkxpnVHEw==
   dependencies:
     "@ethersproject/abi" "^5.1.2"
     "@metamask/eth-sig-util" "^4.0.0"
@@ -11210,6 +11210,7 @@ hardhat@^2.16.0:
     mnemonist "^0.38.0"
     mocha "^10.0.0"
     p-map "^4.0.0"
+    qs "^6.7.0"
     raw-body "^2.4.1"
     resolve "1.17.0"
     semver "^6.3.0"
@@ -15362,7 +15363,7 @@ q@^1.2.0:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==
 
-qs@6.11.0, qs@^6.4.0:
+qs@6.11.0, qs@^6.4.0, qs@^6.7.0:
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
   integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==


### PR DESCRIPTION
Reverts ArtBlocks/artblocks-contracts#813.

It appears that the latest solidity-coverage is not yet compatible with the latest version of hardhat. I think it is preferable to roll back this change and wait on a fix, and revisit this in a polish week, as upgrading to the latest release of `solidity-coverage` does not fix the incompatibility (and the latest hardhat version came out 16 hours ago).

If this is merged, we should follow with an Asana polish task to ensure it does not get dropped.