### PR TITLE
Use auth lib

### DIFF
--- a/packages/contracts/contracts/libs/v0.8.x/AuthLib.sol
+++ b/packages/contracts/contracts/libs/v0.8.x/AuthLib.sol
@@ -17,8 +17,10 @@ import "../../interfaces/v0.8.x/IMinterFilterV1.sol";
 library AuthLib {
     /**
      * function to restrict access to only AdminACL allowed calls, where
-     * AdminACL is the admin of this minter's MinterFilter.
-     * @param _minterFilterAddress address of the minter filter contract
+     * AdminACL is the admin of an IMinterFilterV1.
+     * Reverts if not allowed.
+     * @param _minterFilterAddress address of the minter filter to be checked,
+     * should implement IMinterFilterV1
      * @param _sender address of the caller
      * @param _contract address of the contract being called
      * @param _selector selector of the function being called
@@ -40,26 +42,11 @@ library AuthLib {
         );
     }
 
-    // function to restrict access to only the artist of a project
-    function onlyArtist(
-        uint256 _projectId,
-        address _coreContract,
-        address _sender
-    ) internal view {
-        require(
-            _senderIsArtist({
-                _projectId: _projectId,
-                _coreContract: _coreContract,
-                _sender: _sender
-            }),
-            "Only Artist"
-        );
-    }
-
     /**
-     * function to restrict access to only AdminACL allowed calls, where
+     * Function to restrict access to only AdminACL allowed calls, where
      * AdminACL is the admin of a core contract at `_coreContract`.
-     * @param _coreContract address of the minter filter contract
+     * Reverts if not allowed.
+     * @param _coreContract address of the core contract to be checked
      * @param _sender address of the caller
      * @param _contract address of the contract being called
      * @param _selector selector of the function being called
@@ -82,11 +69,36 @@ library AuthLib {
     }
 
     /**
+     * @notice Throws if `_sender` is any account other than the artist of the
+     * specified project `_projectId` on core contract `_coreContract`.
+     * Requirements: `msg.sender` must be the artist associated with
+     * `_projectId` on `_coreContract`.
+     * @param _projectId The ID of the project being checked.
+     * @param _coreContract The address of the GenArt721CoreContractV3_Base
+     * contract.
+     * @param _sender Wallet to check. Typically, the address of the caller.
+     */
+    function onlyArtist(
+        uint256 _projectId,
+        address _coreContract,
+        address _sender
+    ) internal view {
+        require(
+            _senderIsArtist({
+                _projectId: _projectId,
+                _coreContract: _coreContract,
+                _sender: _sender
+            }),
+            "Only Artist"
+        );
+    }
+
+    /**
      * function to restrict access to only the artist of a project, or AdminACL
      * allowed calls, where AdminACL is the admin of a core contract at
      * `_coreContract`.
      * @param _projectId id of the project
-     * @param _coreContract address of the minter filter contract
+     * @param _coreContract address of the core contract to be checked
      * @param _sender address of the caller
      * @param _contract address of the contract being called
      * @param _selector selector of the function being called
@@ -118,17 +130,39 @@ library AuthLib {
     // Private functions used internally by this library
     // ------------------------------------------------------------------------
 
-    function _senderIsArtist(
-        uint256 _projectId,
-        address _coreContract,
-        address _sender
-    ) private view returns (bool senderIsArtist) {
+    /**
+     * Private function that returns if minter filter contract's AdminACL
+     * allows `_sender` to call function with selector `_selector` on contract
+     * `_contract`.
+     * @param _minterFilterAddress address of the minter filter to be checked.
+     * Should implement IMinterFilterV1.
+     * @param _sender address of the caller
+     * @param _contract address of the contract being called
+     * @param _selector selector of the function being called
+     */
+    function _minterFilterAdminACLAllowed(
+        address _minterFilterAddress,
+        address _sender,
+        address _contract,
+        bytes4 _selector
+    ) private returns (bool) {
         return
-            _sender ==
-            IGenArt721CoreContractV3_Base(_coreContract)
-                .projectIdToArtistAddress(_projectId);
+            IMinterFilterV1(_minterFilterAddress).adminACLAllowed({
+                _sender: _sender,
+                _contract: _contract,
+                _selector: _selector
+            });
     }
 
+    /**
+     * Private function that returns if core contract's AdminACL allows
+     * `_sender` to call function with selector `_selector` on contract
+     * `_contract`.
+     * @param _coreContract address of the core contract to be checked
+     * @param _sender address of the caller
+     * @param _contract address of the contract being called
+     * @param _selector selector of the function being called
+     */
     function _coreAdminACLAllowed(
         address _coreContract,
         address _sender,
@@ -143,17 +177,21 @@ library AuthLib {
             });
     }
 
-    function _minterFilterAdminACLAllowed(
-        address _minterFilterAddress,
-        address _sender,
-        address _contract,
-        bytes4 _selector
-    ) private returns (bool) {
+    /**
+     * Private function that returns if `_sender` is the artist of `_projectId`
+     * on `_coreContract`.
+     * @param _projectId project ID to check
+     * @param _coreContract core contract to check
+     * @param _sender wallet to check
+     */
+    function _senderIsArtist(
+        uint256 _projectId,
+        address _coreContract,
+        address _sender
+    ) private view returns (bool senderIsArtist) {
         return
-            IMinterFilterV1(_minterFilterAddress).adminACLAllowed({
-                _sender: _sender,
-                _contract: _contract,
-                _selector: _selector
-            });
+            _sender ==
+            IGenArt721CoreContractV3_Base(_coreContract)
+                .projectIdToArtistAddress(_projectId);
     }
 }

--- a/packages/contracts/contracts/minter-suite/Minters/MinterSEAV1.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterSEAV1.sol
@@ -174,9 +174,9 @@ contract MinterSEAV1 is ReentrancyGuard, ISharedMinterV0, ISharedMinterSEAV0 {
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     // MODIFIERS
-    // @dev we use internal functions instead of modifiers to reduce contract
-    // bytecode size
-    // @dev contract uses AuthLib for additional modifier-like functions
+    // @dev contract uses modifier-like internal functions instead of modifiers
+    // to reduce contract bytecode size
+    // @dev contract uses AuthLib for some modifier-like functions
 
     // function to require that a value is non-zero
     function _onlyNonZero(uint256 _value) internal pure {

--- a/packages/contracts/contracts/minter-suite/Minters/MinterSetPriceERC20V5.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterSetPriceERC20V5.sol
@@ -6,6 +6,7 @@ import "../../interfaces/v0.8.x/IDelegationRegistry.sol";
 import "../../interfaces/v0.8.x/ISharedMinterV0.sol";
 import "../../interfaces/v0.8.x/IMinterFilterV1.sol";
 
+import "../../libs/v0.8.x/AuthLib.sol";
 import "../../libs/v0.8.x/minter-libs/SplitFundsLib.sol";
 import "../../libs/v0.8.x/minter-libs/MaxInvocationsLib.sol";
 
@@ -84,22 +85,13 @@ contract MinterSetPriceERC20V5 is ReentrancyGuard, ISharedMinterV0 {
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     // MODIFIERS
-    /**
-     * @dev Throws if called by any account other than the artist of the specified project.
-     * Requirements: `msg.sender` must be the artist associated with `_projectId`.
-     * @param _projectId The ID of the project being checked.
-     * @param _coreContract The address of the GenArt721CoreContractV3_Base contract.
-     */
-    function _onlyArtist(
-        uint256 _projectId,
-        address _coreContract
-    ) internal view {
-        require(
-            msg.sender ==
-                IGenArt721CoreContractV3_Base(_coreContract)
-                    .projectIdToArtistAddress(_projectId),
-            "Only Artist"
-        );
+    // @dev contract uses modifier-like internal functions instead of modifiers
+    // to reduce contract bytecode size
+    // @dev contract uses AuthLib for some modifier-like functions
+
+    // function to require that a value is non-zero
+    function _onlyNonZero(uint256 _value) internal pure {
+        require(_value != 0, "Only non-zero");
     }
 
     /**
@@ -130,7 +122,11 @@ contract MinterSetPriceERC20V5 is ReentrancyGuard, ISharedMinterV0 {
         address _coreContract,
         uint24 _maxInvocations
     ) external {
-        _onlyArtist(_projectId, _coreContract);
+        AuthLib.onlyArtist({
+            _projectId: _projectId,
+            _coreContract: _coreContract,
+            _sender: msg.sender
+        });
         MaxInvocationsLib.manuallyLimitProjectMaxInvocations(
             _projectId,
             _coreContract,
@@ -158,7 +154,11 @@ contract MinterSetPriceERC20V5 is ReentrancyGuard, ISharedMinterV0 {
         address _coreContract,
         uint248 _pricePerTokenInWei
     ) external {
-        _onlyArtist(_projectId, _coreContract);
+        AuthLib.onlyArtist({
+            _projectId: _projectId,
+            _coreContract: _coreContract,
+            _sender: msg.sender
+        });
         ProjectConfig storage _projectConfig = _projectConfigMapping[
             _coreContract
         ][_projectId];
@@ -205,7 +205,11 @@ contract MinterSetPriceERC20V5 is ReentrancyGuard, ISharedMinterV0 {
         string memory _currencySymbol,
         address _currencyAddress
     ) external nonReentrant {
-        _onlyArtist(_projectId, _coreContract);
+        AuthLib.onlyArtist({
+            _projectId: _projectId,
+            _coreContract: _coreContract,
+            _sender: msg.sender
+        });
         SplitFundsLib.SplitFundsProjectConfig
             storage _splitFundsProjectConfig = _splitFundsProjectConfigs[
                 _coreContract
@@ -457,7 +461,11 @@ contract MinterSetPriceERC20V5 is ReentrancyGuard, ISharedMinterV0 {
         uint256 _projectId,
         address _coreContract
     ) public {
-        _onlyArtist(_projectId, _coreContract);
+        AuthLib.onlyArtist({
+            _projectId: _projectId,
+            _coreContract: _coreContract,
+            _sender: msg.sender
+        });
 
         uint256 maxInvocations = MaxInvocationsLib
             .syncProjectMaxInvocationsToCore(

--- a/packages/contracts/contracts/minter-suite/Minters/MinterSetPriceERC20V5.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterSetPriceERC20V5.sol
@@ -89,11 +89,6 @@ contract MinterSetPriceERC20V5 is ReentrancyGuard, ISharedMinterV0 {
     // to reduce contract bytecode size
     // @dev contract uses AuthLib for some modifier-like functions
 
-    // function to require that a value is non-zero
-    function _onlyNonZero(uint256 _value) internal pure {
-        require(_value != 0, "Only non-zero");
-    }
-
     /**
      * @notice Initializes contract to be a Filtered Minter for
      * `_minterFilter` minter filter.

--- a/packages/contracts/contracts/minter-suite/Minters/MinterSetPriceHolderV5.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterSetPriceHolderV5.sol
@@ -7,6 +7,7 @@ import "../../interfaces/v0.8.x/ISharedMinterV0.sol";
 import "../../interfaces/v0.8.x/ISharedMinterHolderV0.sol";
 import "../../interfaces/v0.8.x/IMinterFilterV1.sol";
 
+import "../../libs/v0.8.x/AuthLib.sol";
 import "../../libs/v0.8.x/minter-libs/SplitFundsLib.sol";
 import "../../libs/v0.8.x/minter-libs/MaxInvocationsLib.sol";
 import "../../libs/v0.8.x/minter-libs/TokenHolderLib.sol";
@@ -130,23 +131,9 @@ contract MinterSetPriceHolderV5 is
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     // MODIFIERS
-    /**
-     * @dev Throws if called by any account other than the artist of the specified project.
-     * Requirements: `msg.sender` must be the artist associated with `_projectId`.
-     * @param _projectId The ID of the project being checked.
-     * @param _coreContract The address of the GenArt721CoreContractV3_Base contract.
-     */
-    function _onlyArtist(
-        uint256 _projectId,
-        address _coreContract
-    ) internal view {
-        require(
-            msg.sender ==
-                IGenArt721CoreContractV3_Base(_coreContract)
-                    .projectIdToArtistAddress(_projectId),
-            "Only Artist"
-        );
-    }
+    // @dev contract uses modifier-like internal functions instead of modifiers
+    // to reduce contract bytecode size
+    // @dev contract uses AuthLib for some modifier-like functions
 
     /**
      * @notice Initializes contract to be a Filtered Minter for
@@ -186,7 +173,11 @@ contract MinterSetPriceHolderV5 is
         address _coreContract,
         uint24 _maxInvocations
     ) external {
-        _onlyArtist(_projectId, _coreContract);
+        AuthLib.onlyArtist({
+            _projectId: _projectId,
+            _coreContract: _coreContract,
+            _sender: msg.sender
+        });
         MaxInvocationsLib.manuallyLimitProjectMaxInvocations(
             _projectId,
             _coreContract,
@@ -214,7 +205,11 @@ contract MinterSetPriceHolderV5 is
         address _coreContract,
         uint248 _pricePerTokenInWei
     ) external {
-        _onlyArtist(_projectId, _coreContract);
+        AuthLib.onlyArtist({
+            _projectId: _projectId,
+            _coreContract: _coreContract,
+            _sender: msg.sender
+        });
         ProjectConfig storage _projectConfig = _projectConfigMapping[
             _coreContract
         ][_projectId];
@@ -267,7 +262,11 @@ contract MinterSetPriceHolderV5 is
         address[] memory _ownedNFTAddresses,
         uint256[] memory _ownedNFTProjectIds
     ) external {
-        _onlyArtist(_projectId, _coreContract);
+        AuthLib.onlyArtist({
+            _projectId: _projectId,
+            _coreContract: _coreContract,
+            _sender: msg.sender
+        });
         TokenHolderLib.allowHoldersOfProjects(
             _allowedProjectHoldersMapping[_coreContract][_projectId],
             _ownedNFTAddresses,
@@ -304,7 +303,11 @@ contract MinterSetPriceHolderV5 is
         address[] memory _ownedNFTAddresses,
         uint256[] memory _ownedNFTProjectIds
     ) external {
-        _onlyArtist(_projectId, _coreContract);
+        AuthLib.onlyArtist({
+            _projectId: _projectId,
+            _coreContract: _coreContract,
+            _sender: msg.sender
+        });
         // require same length arrays
         TokenHolderLib.removeHoldersOfProjects(
             _allowedProjectHoldersMapping[_coreContract][_projectId],
@@ -359,7 +362,11 @@ contract MinterSetPriceHolderV5 is
         address[] memory _ownedNFTAddressesRemove,
         uint256[] memory _ownedNFTProjectIdsRemove
     ) external {
-        _onlyArtist(_projectId, _coreContract);
+        AuthLib.onlyArtist({
+            _projectId: _projectId,
+            _coreContract: _coreContract,
+            _sender: msg.sender
+        });
         TokenHolderLib.allowAndRemoveHoldersOfProjects(
             _allowedProjectHoldersMapping[_coreContract][_projectId],
             _ownedNFTAddressesAdd,
@@ -661,7 +668,11 @@ contract MinterSetPriceHolderV5 is
         uint256 _projectId,
         address _coreContract
     ) public {
-        _onlyArtist(_projectId, _coreContract);
+        AuthLib.onlyArtist({
+            _projectId: _projectId,
+            _coreContract: _coreContract,
+            _sender: msg.sender
+        });
 
         uint256 maxInvocations = MaxInvocationsLib
             .syncProjectMaxInvocationsToCore(

--- a/packages/contracts/contracts/minter-suite/Minters/MinterSetPriceMerkleV5.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterSetPriceMerkleV5.sol
@@ -7,6 +7,7 @@ import "../../interfaces/v0.8.x/ISharedMinterV0.sol";
 import "../../interfaces/v0.8.x/IMinterFilterV1.sol";
 import "../../interfaces/v0.8.x/ISharedMinterMerkleV0.sol";
 
+import "../../libs/v0.8.x/AuthLib.sol";
 import "../../libs/v0.8.x/minter-libs/MerkleLib.sol";
 import "../../libs/v0.8.x/minter-libs/SplitFundsLib.sol";
 import "../../libs/v0.8.x/minter-libs/MaxInvocationsLib.sol";
@@ -117,23 +118,9 @@ contract MinterSetPriceMerkleV5 is
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     // MODIFIERS
-    /**
-     * @dev Throws if called by any account other than the artist of the specified project.
-     * Requirements: `msg.sender` must be the artist associated with `_projectId`.
-     * @param _projectId The ID of the project being checked.
-     * @param _coreContract The address of the GenArt721CoreContractV3_Base contract.
-     */
-    function _onlyArtist(
-        uint256 _projectId,
-        address _coreContract
-    ) internal view {
-        require(
-            msg.sender ==
-                IGenArt721CoreContractV3_Base(_coreContract)
-                    .projectIdToArtistAddress(_projectId),
-            "Only Artist"
-        );
-    }
+    // @dev contract uses modifier-like internal functions instead of modifiers
+    // to reduce contract bytecode size
+    // @dev contract uses AuthLib for some modifier-like functions
 
     /**
      * @notice Initializes contract to be a Filtered Minter for
@@ -177,7 +164,11 @@ contract MinterSetPriceMerkleV5 is
         address _coreContract,
         uint24 _maxInvocations
     ) external {
-        _onlyArtist(_projectId, _coreContract);
+        AuthLib.onlyArtist({
+            _projectId: _projectId,
+            _coreContract: _coreContract,
+            _sender: msg.sender
+        });
         MaxInvocationsLib.manuallyLimitProjectMaxInvocations(
             _projectId,
             _coreContract,
@@ -205,7 +196,11 @@ contract MinterSetPriceMerkleV5 is
         address _coreContract,
         uint248 _pricePerTokenInWei
     ) external {
-        _onlyArtist(_projectId, _coreContract);
+        AuthLib.onlyArtist({
+            _projectId: _projectId,
+            _coreContract: _coreContract,
+            _sender: msg.sender
+        });
         ProjectConfig storage _projectConfig = _projectConfigMapping[
             _coreContract
         ][_projectId];
@@ -248,7 +243,11 @@ contract MinterSetPriceMerkleV5 is
         address _coreContract,
         bytes32 _root
     ) external {
-        _onlyArtist(_projectId, _coreContract);
+        AuthLib.onlyArtist({
+            _projectId: _projectId,
+            _coreContract: _coreContract,
+            _sender: msg.sender
+        });
         require(_root != bytes32(0), "Root must be provided");
         MerkleLib.updateMerkleRoot(
             _merkleProjectConfigMapping[_coreContract][_projectId],
@@ -280,7 +279,11 @@ contract MinterSetPriceMerkleV5 is
         address _coreContract,
         uint24 _maxInvocationsPerAddress
     ) external {
-        _onlyArtist(_projectId, _coreContract);
+        AuthLib.onlyArtist({
+            _projectId: _projectId,
+            _coreContract: _coreContract,
+            _sender: msg.sender
+        });
         MerkleLib.setProjectInvocationsPerAddress(
             _merkleProjectConfigMapping[_coreContract][_projectId],
             _maxInvocationsPerAddress
@@ -652,7 +655,11 @@ contract MinterSetPriceMerkleV5 is
         uint256 _projectId,
         address _coreContract
     ) public {
-        _onlyArtist(_projectId, _coreContract);
+        AuthLib.onlyArtist({
+            _projectId: _projectId,
+            _coreContract: _coreContract,
+            _sender: msg.sender
+        });
 
         uint256 maxInvocations = MaxInvocationsLib
             .syncProjectMaxInvocationsToCore(

--- a/packages/contracts/contracts/minter-suite/Minters/MinterSetPricePolyptychV5.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterSetPricePolyptychV5.sol
@@ -7,6 +7,7 @@ import "../../interfaces/v0.8.x/ISharedMinterV0.sol";
 import "../../interfaces/v0.8.x/ISharedMinterHolderV0.sol";
 import "../../interfaces/v0.8.x/IMinterFilterV1.sol";
 
+import "../../libs/v0.8.x/AuthLib.sol";
 import "../../libs/v0.8.x/minter-libs/SplitFundsLib.sol";
 import "../../libs/v0.8.x/minter-libs/MaxInvocationsLib.sol";
 import "../../libs/v0.8.x/minter-libs/TokenHolderLib.sol";
@@ -152,23 +153,9 @@ contract MinterSetPricePolyptychV5 is
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     // MODIFIERS
-    /**
-     * @dev Throws if called by any account other than the artist of the specified project.
-     * Requirements: `msg.sender` must be the artist associated with `_projectId`.
-     * @param _projectId The ID of the project being checked.
-     * @param _coreContract The address of the GenArt721CoreContractV3_Base contract.
-     */
-    function _onlyArtist(
-        uint256 _projectId,
-        address _coreContract
-    ) internal view {
-        require(
-            msg.sender ==
-                IGenArt721CoreContractV3_Base(_coreContract)
-                    .projectIdToArtistAddress(_projectId),
-            "Only Artist"
-        );
-    }
+    // @dev contract uses modifier-like internal functions instead of modifiers
+    // to reduce contract bytecode size
+    // @dev contract uses AuthLib for some modifier-like functions
 
     /**
      * @notice Initializes contract to be a Filtered Minter for
@@ -208,7 +195,11 @@ contract MinterSetPricePolyptychV5 is
         address _coreContract,
         uint24 _maxInvocations
     ) external {
-        _onlyArtist(_projectId, _coreContract);
+        AuthLib.onlyArtist({
+            _projectId: _projectId,
+            _coreContract: _coreContract,
+            _sender: msg.sender
+        });
         MaxInvocationsLib.manuallyLimitProjectMaxInvocations(
             _projectId,
             _coreContract,
@@ -236,7 +227,11 @@ contract MinterSetPricePolyptychV5 is
         address _coreContract,
         uint248 _pricePerTokenInWei
     ) external {
-        _onlyArtist(_projectId, _coreContract);
+        AuthLib.onlyArtist({
+            _projectId: _projectId,
+            _coreContract: _coreContract,
+            _sender: msg.sender
+        });
         ProjectConfig storage _projectConfig = _projectConfigMapping[
             _coreContract
         ][_projectId];
@@ -285,7 +280,11 @@ contract MinterSetPricePolyptychV5 is
         address[] memory _ownedNFTAddresses,
         uint256[] memory _ownedNFTProjectIds
     ) external {
-        _onlyArtist(_projectId, _coreContract);
+        AuthLib.onlyArtist({
+            _projectId: _projectId,
+            _coreContract: _coreContract,
+            _sender: msg.sender
+        });
         TokenHolderLib.allowHoldersOfProjects(
             _allowedProjectHoldersMapping[_coreContract][_projectId],
             _ownedNFTAddresses,
@@ -322,7 +321,11 @@ contract MinterSetPricePolyptychV5 is
         address[] memory _ownedNFTAddresses,
         uint256[] memory _ownedNFTProjectIds
     ) external {
-        _onlyArtist(_projectId, _coreContract);
+        AuthLib.onlyArtist({
+            _projectId: _projectId,
+            _coreContract: _coreContract,
+            _sender: msg.sender
+        });
         // require same length arrays
         TokenHolderLib.removeHoldersOfProjects(
             _allowedProjectHoldersMapping[_coreContract][_projectId],
@@ -377,7 +380,11 @@ contract MinterSetPricePolyptychV5 is
         address[] memory _ownedNFTAddressesRemove,
         uint256[] memory _ownedNFTProjectIdsRemove
     ) external {
-        _onlyArtist(_projectId, _coreContract);
+        AuthLib.onlyArtist({
+            _projectId: _projectId,
+            _coreContract: _coreContract,
+            _sender: msg.sender
+        });
         TokenHolderLib.allowAndRemoveHoldersOfProjects(
             _allowedProjectHoldersMapping[_coreContract][_projectId],
             _ownedNFTAddressesAdd,
@@ -409,7 +416,11 @@ contract MinterSetPricePolyptychV5 is
         uint256 _projectId,
         address _coreContract
     ) public {
-        _onlyArtist(_projectId, _coreContract);
+        AuthLib.onlyArtist({
+            _projectId: _projectId,
+            _coreContract: _coreContract,
+            _sender: msg.sender
+        });
         PolyptychLib.PolyptychProjectConfig
             storage _polyptychProjectConfig = _polyptychProjectConfigs[
                 _coreContract
@@ -754,7 +765,11 @@ contract MinterSetPricePolyptychV5 is
         uint256 _projectId,
         address _coreContract
     ) public {
-        _onlyArtist(_projectId, _coreContract);
+        AuthLib.onlyArtist({
+            _projectId: _projectId,
+            _coreContract: _coreContract,
+            _sender: msg.sender
+        });
 
         uint256 maxInvocations = MaxInvocationsLib
             .syncProjectMaxInvocationsToCore(

--- a/packages/contracts/contracts/minter-suite/Minters/MinterSetPriceV5.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterSetPriceV5.sol
@@ -83,11 +83,6 @@ contract MinterSetPriceV5 is ReentrancyGuard, ISharedMinterV0 {
     // to reduce contract bytecode size
     // @dev contract uses AuthLib for some modifier-like functions
 
-    // function to require that a value is non-zero
-    function _onlyNonZero(uint256 _value) internal pure {
-        require(_value != 0, "Only non-zero");
-    }
-
     /**
      * @notice Initializes contract to be a Filtered Minter for
      * `_minterFilter` minter filter.


### PR DESCRIPTION
## Description of the change

Update all new shared minters to use the AuthLib introduced in #871.

This also cleans up some of the comments in `AuthLib.sol`.

Pure refactor - no functionality is changed.
