### PR TITLE
Use ABHelpers Library

### DIFF
--- a/packages/contracts/contracts/libs/v0.8.x/ABHelpers.sol
+++ b/packages/contracts/contracts/libs/v0.8.x/ABHelpers.sol
@@ -13,24 +13,43 @@ pragma solidity ^0.8.0;
 library ABHelpers {
     uint256 constant ONE_MILLION = 1_000_000;
 
+    /**
+     * Convert token id to project id.
+     * @param _tokenId The id of the token.
+     */
     function tokenIdToProjectId(
         uint256 _tokenId
     ) internal pure returns (uint256) {
         // int division properly rounds down
-        return _tokenId / ONE_MILLION;
+        // @dev unchecked because will never divide by zero
+        unchecked {
+            return _tokenId / ONE_MILLION;
+        }
     }
 
+    /**
+     * Convert token id to token number.
+     * @param _tokenId The id of the token.
+     */
     function tokenIdToTokenNumber(
         uint256 _tokenId
     ) internal pure returns (uint256) {
         // mod returns remainder, which is the token number
+        // @dev no way to disable mod zero check in solidity, so not unchecked
         return _tokenId % ONE_MILLION;
     }
 
+    /**
+     * Convert project id and token number to token id.
+     * @param _projectId The id of the project.
+     * @param _tokenNumber The token number.
+     */
     function tokenIdFromProjectIdAndTokenNumber(
         uint256 _projectId,
         uint256 _tokenNumber
     ) internal pure returns (uint256) {
+        // @dev intentionally not unchecked to ensure overflow detection, which
+        // would likley only occur in a malicious call
         return (_projectId * ONE_MILLION) + _tokenNumber;
     }
 }

--- a/packages/contracts/contracts/minter-suite/Minters/MinterSEAV1.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterSEAV1.sol
@@ -115,8 +115,6 @@ contract MinterSEAV1 is ReentrancyGuard, ISharedMinterV0, ISharedMinterSEAV0 {
     /// minter version for this minter
     string public constant minterVersion = "v1.0.0";
 
-    uint256 constant ONE_MILLION = 1_000_000;
-
     uint256 public constant MIN_AUCTION_DURATION_SECONDS = 60; // seconds
 
     // minter-wide, AdminACL-configurable parameters, where AdminACL is the

--- a/packages/contracts/contracts/minter-suite/Minters/MinterSetPriceERC20V5.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterSetPriceERC20V5.sol
@@ -51,8 +51,6 @@ contract MinterSetPriceERC20V5 is ReentrancyGuard, ISharedMinterV0 {
     /// minter version for this minter
     string public constant minterVersion = "v5.0.0";
 
-    uint256 constant ONE_MILLION = 1_000_000;
-
     /// contractAddress => projectId => base project config
     mapping(address => mapping(uint256 => ProjectConfig))
         private _projectConfigMapping;

--- a/packages/contracts/contracts/minter-suite/Minters/MinterSetPriceHolderV5.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterSetPriceHolderV5.sol
@@ -86,8 +86,6 @@ contract MinterSetPriceHolderV5 is
     /// minter version for this minter
     string public constant minterVersion = "v5.0.0";
 
-    uint256 constant ONE_MILLION = 1_000_000;
-
     /// contractAddress => projectId => base project config
     mapping(address => mapping(uint256 => ProjectConfig))
         private _projectConfigMapping;

--- a/packages/contracts/contracts/minter-suite/Minters/MinterSetPriceMerkleV5.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterSetPriceMerkleV5.sol
@@ -71,8 +71,6 @@ contract MinterSetPriceMerkleV5 is
     /// minter version for this minter
     string public constant minterVersion = "v5.0.0";
 
-    uint256 constant ONE_MILLION = 1_000_000;
-
     /// Delegation registry address
     address public immutable delegationRegistryAddress;
     /// Delegation registry address

--- a/packages/contracts/contracts/minter-suite/Minters/MinterSetPricePolyptychV5.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterSetPricePolyptychV5.sol
@@ -7,6 +7,7 @@ import "../../interfaces/v0.8.x/ISharedMinterV0.sol";
 import "../../interfaces/v0.8.x/ISharedMinterHolderV0.sol";
 import "../../interfaces/v0.8.x/IMinterFilterV1.sol";
 
+import "../../libs/v0.8.x/ABHelpers.sol";
 import "../../libs/v0.8.x/AuthLib.sol";
 import "../../libs/v0.8.x/minter-libs/SplitFundsLib.sol";
 import "../../libs/v0.8.x/minter-libs/MaxInvocationsLib.sol";
@@ -95,8 +96,6 @@ contract MinterSetPricePolyptychV5 is
 
     /// minter version for this minter
     string public constant minterVersion = "v5.0.0";
-
-    uint256 constant ONE_MILLION = 1_000_000;
 
     /// contractAddress => projectId => base project config
     mapping(address => mapping(uint256 => ProjectConfig))
@@ -900,7 +899,12 @@ contract MinterSetPricePolyptychV5 is
                 );
             }
 
-            uint256 _newTokenId = (_projectId * ONE_MILLION) + _invocations;
+            uint256 _newTokenId = ABHelpers.tokenIdFromProjectIdAndTokenNumber({
+                _projectId: _projectId,
+                // @dev next token number is current invocations due to number
+                // being zero-based-indexed
+                _tokenNumber: _invocations
+            });
             PolyptychLib.setPolyptychHashSeed({
                 _coreContract: _coreContract,
                 _tokenId: _newTokenId, // new token ID

--- a/packages/contracts/contracts/minter-suite/Minters/MinterSetPriceV5.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterSetPriceV5.sol
@@ -49,8 +49,6 @@ contract MinterSetPriceV5 is ReentrancyGuard, ISharedMinterV0 {
     /// minter version for this minter
     string public constant minterVersion = "v5.0.0";
 
-    uint256 constant ONE_MILLION = 1_000_000;
-
     /// contractAddress => projectId => base project config
     mapping(address => mapping(uint256 => ProjectConfig))
         private _projectConfigMapping;


### PR DESCRIPTION
## Description of the change

Update all new shared minters to use the ABHelpers library introduced in https://github.com/ArtBlocks/artblocks-contracts/pull/871.

This also cleans up some of the comments in ABHelpers.sol.

Pure refactor - no functionality is changed.

Note that core V3 contracts are not updated to use the new lib. I avoided updating due to the sensitive contract size limits on the V3 Engine contracts. We should refactor future core V4 contracts to use the ABHelpers lib.