### PR TITLE
Allow DA setAuctionDetails when minter-local max invocations

### DIFF
--- a/packages/contracts/contracts/libs/v0.8.x/minter-libs/DAExpLib.sol
+++ b/packages/contracts/contracts/libs/v0.8.x/minter-libs/DAExpLib.sol
@@ -39,17 +39,21 @@ library DAExpLib {
      * seconds.
      * @param _startPrice The starting price of the auction.
      * @param _basePrice The base price of the auction.
+     * @param _maxHasBeenInvoked Whether or not the minter-local max
+     * invocations have been invoked.
      */
     function setAuctionDetailsExp(
         DAProjectConfig storage _DAProjectConfig,
         uint64 _auctionTimestampStart,
         uint64 _priceDecayHalfLifeSeconds,
         uint128 _startPrice,
-        uint128 _basePrice
+        uint128 _basePrice,
+        bool _maxHasBeenInvoked
     ) internal {
         require(
-            _DAProjectConfig.timestampStart == 0 ||
-                block.timestamp < _DAProjectConfig.timestampStart,
+            _DAProjectConfig.timestampStart == 0 || // uninitialized
+                block.timestamp < _DAProjectConfig.timestampStart || // auction not yet started
+                _maxHasBeenInvoked, // minter-local max invocations have been reached
             "No modifications mid-auction"
         );
         require(

--- a/packages/contracts/contracts/libs/v0.8.x/minter-libs/DALinLib.sol
+++ b/packages/contracts/contracts/libs/v0.8.x/minter-libs/DALinLib.sol
@@ -38,17 +38,21 @@ library DALinLib {
      * @param _auctionTimestampEnd The timestamp when the auction will end.
      * @param _startPrice The starting price of the auction.
      * @param _basePrice The base price of the auction.
+     * @param _maxHasBeenInvoked Whether or not the minter-local max
+     * invocations have been invoked.
      */
     function setAuctionDetailsLin(
         DAProjectConfig storage _DAProjectConfig,
         uint64 _auctionTimestampStart,
         uint64 _auctionTimestampEnd,
         uint128 _startPrice,
-        uint128 _basePrice
+        uint128 _basePrice,
+        bool _maxHasBeenInvoked
     ) internal {
         require(
-            _DAProjectConfig.timestampStart == 0 ||
-                block.timestamp < _DAProjectConfig.timestampStart,
+            _DAProjectConfig.timestampStart == 0 || // uninitialized
+                block.timestamp < _DAProjectConfig.timestampStart || // auction not yet started
+                _maxHasBeenInvoked, // minter-local max invocations have been reached
             "No modifications mid-auction"
         );
         require(

--- a/packages/contracts/contracts/minter-suite/Minters/MinterDAExpV5.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterDAExpV5.sol
@@ -193,6 +193,10 @@ contract MinterDAExpV5 is
             storage _auctionProjectConfig = _auctionProjectConfigMapping[
                 _coreContract
             ][_projectId];
+        MaxInvocationsLib.MaxInvocationsProjectConfig
+            storage _maxInvocationsProjectConfig = _maxInvocationsProjectConfigMapping[
+                _coreContract
+            ][_projectId];
 
         require(
             (_priceDecayHalfLifeSeconds >= minimumPriceDecayHalfLifeSeconds),
@@ -200,12 +204,16 @@ contract MinterDAExpV5 is
         );
 
         // EFFECTS
+        bool maxHasBeenInvoked = MaxInvocationsLib.getMaxHasBeenInvoked(
+            _maxInvocationsProjectConfig
+        );
         DAExpLib.setAuctionDetailsExp({
             _DAProjectConfig: _auctionProjectConfig,
             _auctionTimestampStart: _auctionTimestampStart,
             _priceDecayHalfLifeSeconds: _priceDecayHalfLifeSeconds,
             _startPrice: _startPrice,
-            _basePrice: _basePrice
+            _basePrice: _basePrice,
+            _maxHasBeenInvoked: maxHasBeenInvoked
         });
 
         emit SetAuctionDetailsExp({
@@ -216,11 +224,6 @@ contract MinterDAExpV5 is
             _startPrice: _startPrice,
             _basePrice: _basePrice
         });
-
-        MaxInvocationsLib.MaxInvocationsProjectConfig
-            storage _maxInvocationsProjectConfig = _maxInvocationsProjectConfigMapping[
-                _coreContract
-            ][_projectId];
 
         // sync local max invocations if not initially populated
         // @dev if local max invocations and maxHasBeenInvoked are both

--- a/packages/contracts/contracts/minter-suite/Minters/MinterDAExpV5.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterDAExpV5.sol
@@ -165,6 +165,14 @@ contract MinterDAExpV5 is
 
     /**
      * @notice Sets auction details for project `_projectId`.
+     * Requires one of the following:
+     * - The auction is unconfigured
+     * - The auction has not yet started
+     * - The minter-local max invocations have been reached
+     * @dev Note that allowing the artist to set auction details after reaching
+     * max invocations effectively grants the artist the ability to set a new
+     * auction at any point, since minter-local max invocations can be set by
+     * the artist.
      * @param _projectId Project ID to set auction details for.
      * @param _coreContract Core contract address for the given project.
      * @param _auctionTimestampStart Timestamp at which to start the auction.
@@ -287,6 +295,9 @@ contract MinterDAExpV5 is
 
     /**
      * @notice Purchases a token from project `_projectId`.
+     * Note: Collectors should not send excessive value with their purchase
+     * transaction, because the artist has the ability to change the auction
+     * details at any time, including the price.
      * @param _projectId Project ID to mint a token on.
      * @param _coreContract Core contract address for the given project.
      * @return tokenId Token ID of minted token
@@ -520,6 +531,9 @@ contract MinterDAExpV5 is
     /**
      * @notice Purchases a token from project `_projectId` and sets
      * the token's owner to `_to`.
+     * Note: Collectors should not send excessive value with their purchase
+     * transaction, because the artist has the ability to change the auction
+     * details at any time, including the price.
      * @param _to Address to be the new token's owner.
      * @param _projectId Project ID to mint a token on.
      * @param _coreContract Core contract address for the given project.

--- a/packages/contracts/contracts/minter-suite/Minters/MinterDALinV5.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterDALinV5.sol
@@ -191,6 +191,10 @@ contract MinterDALinV5 is
             storage _auctionProjectConfig = _auctionProjectConfigMapping[
                 _coreContract
             ][_projectId];
+        MaxInvocationsLib.MaxInvocationsProjectConfig
+            storage _maxInvocationsProjectConfig = _maxInvocationsProjectConfigMapping[
+                _coreContract
+            ][_projectId];
 
         require(
             _auctionTimestampEnd >=
@@ -199,12 +203,16 @@ contract MinterDALinV5 is
         );
 
         // EFFECTS
+        bool maxHasBeenInvoked = MaxInvocationsLib.getMaxHasBeenInvoked(
+            _maxInvocationsProjectConfig
+        );
         DALinLib.setAuctionDetailsLin({
             _DAProjectConfig: _auctionProjectConfig,
             _auctionTimestampStart: _auctionTimestampStart,
             _auctionTimestampEnd: _auctionTimestampEnd,
             _startPrice: _startPrice,
-            _basePrice: _basePrice
+            _basePrice: _basePrice,
+            _maxHasBeenInvoked: maxHasBeenInvoked
         });
 
         emit SetAuctionDetailsLin({
@@ -215,11 +223,6 @@ contract MinterDALinV5 is
             _startPrice: _startPrice,
             _basePrice: _basePrice
         });
-
-        MaxInvocationsLib.MaxInvocationsProjectConfig
-            storage _maxInvocationsProjectConfig = _maxInvocationsProjectConfigMapping[
-                _coreContract
-            ][_projectId];
 
         // sync local max invocations if not initially populated
         // @dev if local max invocations and maxHasBeenInvoked are both

--- a/packages/contracts/contracts/minter-suite/Minters/MinterDALinV5.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterDALinV5.sol
@@ -164,6 +164,10 @@ contract MinterDALinV5 is
 
     /**
      * @notice Sets auction details for project `_projectId`.
+     * @dev Note that allowing the artist to set auction details after reaching
+     * max invocations effectively grants the artist the ability to set a new
+     * auction at any point, since minter-local max invocations can be set by
+     * the artist.
      * @param _projectId Project ID to set auction details for.
      * @param _coreContract Core contract address for the given project.
      * @param _auctionTimestampStart Timestamp at which to start the auction.
@@ -278,6 +282,9 @@ contract MinterDALinV5 is
 
     /**
      * @notice Purchases a token from project `_projectId`.
+     * Note: Collectors should not send excessive value with their purchase
+     * transaction, because the artist has the ability to change the auction
+     * details at any time, including the price.
      * @param _projectId Project ID to mint a token on.
      * @param _coreContract Core contract address for the given project.
      * @return tokenId Token ID of minted token
@@ -509,6 +516,9 @@ contract MinterDALinV5 is
     /**
      * @notice Purchases a token from project `_projectId` and sets
      * the token's owner to `_to`.
+     * Note: Collectors should not send excessive value with their purchase
+     * transaction, because the artist has the ability to change the auction
+     * details at any time, including the price.
      * @param _to Address to be the new token's owner.
      * @param _projectId Project ID to mint a token on.
      * @param _coreContract Core contract address for the given project.

--- a/packages/contracts/test/minter-suite-minters/DA/DAExp/configure.test.ts
+++ b/packages/contracts/test/minter-suite-minters/DA/DAExp/configure.test.ts
@@ -419,6 +419,37 @@ runForEach.forEach((params) => {
         );
       });
 
+      it("Modifications okay after minter-local max invocations reached", async function () {
+        const config = await loadFixture(_beforeEach);
+        // configure auction
+        await configureProjectZeroAuctionAndAdvanceToStart(config);
+        // configure minter-local max invocations to 1
+        await config.minter
+          .connect(config.accounts.artist)
+          .manuallyLimitProjectMaxInvocations(
+            config.projectZero,
+            config.genArt721Core.address,
+            1
+          );
+        // mint a token
+        await config.minter
+          .connect(config.accounts.user)
+          .purchase(config.projectZero, config.genArt721Core.address, {
+            value: config.startingPrice,
+          });
+        // expect no revert when modifying auction after minter-local max invocations reached
+        await config.minter
+          .connect(config.accounts.artist)
+          .setAuctionDetails(
+            config.projectZero,
+            config.genArt721Core.address,
+            config.startTime + ONE_DAY,
+            config.defaultHalfLife,
+            config.startingPrice,
+            config.basePrice
+          );
+      });
+
       it("Only future auctions", async function () {
         const config = await loadFixture(_beforeEach);
         // expect revert when setting auction start time to past

--- a/packages/contracts/test/minter-suite-minters/DA/DALin/configure.test.ts
+++ b/packages/contracts/test/minter-suite-minters/DA/DALin/configure.test.ts
@@ -413,6 +413,37 @@ runForEach.forEach((params) => {
         );
       });
 
+      it("Modifications okay after minter-local max invocations reached", async function () {
+        const config = await loadFixture(_beforeEach);
+        // configure auction
+        await configureProjectZeroAuctionAndAdvanceToStart(config);
+        // configure minter-local max invocations to 1
+        await config.minter
+          .connect(config.accounts.artist)
+          .manuallyLimitProjectMaxInvocations(
+            config.projectZero,
+            config.genArt721Core.address,
+            1
+          );
+        // mint a token
+        await config.minter
+          .connect(config.accounts.user)
+          .purchase(config.projectZero, config.genArt721Core.address, {
+            value: config.startingPrice,
+          });
+        // expect no revert when modifying auction after minter-local max invocations reached
+        await config.minter
+          .connect(config.accounts.artist)
+          .setAuctionDetails(
+            config.projectZero,
+            config.genArt721Core.address,
+            config.startTime + ONE_DAY,
+            config.endTime + ONE_DAY,
+            config.startingPrice,
+            config.basePrice
+          );
+      });
+
       it("Only future auctions", async function () {
         const config = await loadFixture(_beforeEach);
         // expect revert when setting auction start time to past

--- a/yarn.lock
+++ b/yarn.lock
@@ -6204,6 +6204,23 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@typescript-eslint/eslint-plugin@^6.2.1":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.4.0.tgz#53428b616f7d80fe879f45a08f11cc0f0b62cf13"
+  integrity sha512-62o2Hmc7Gs3p8SLfbXcipjWAa6qk2wZGChXG2JbBtYpwSRmti/9KHLqfbLs9uDigOexG+3PaQ9G2g3201FWLKg==
+  dependencies:
+    "@eslint-community/regexpp" "^4.5.1"
+    "@typescript-eslint/scope-manager" "6.4.0"
+    "@typescript-eslint/type-utils" "6.4.0"
+    "@typescript-eslint/utils" "6.4.0"
+    "@typescript-eslint/visitor-keys" "6.4.0"
+    debug "^4.3.4"
+    graphemer "^1.4.0"
+    ignore "^5.2.4"
+    natural-compare "^1.4.0"
+    semver "^7.5.4"
+    ts-api-utils "^1.0.1"
+
 "@typescript-eslint/eslint-plugin@^6.3.0":
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.3.0.tgz#e751e148aab7ccaf8a7bfd370f7ce9e6bdd1f3f4"
@@ -6241,6 +6258,14 @@
     "@typescript-eslint/types" "6.3.0"
     "@typescript-eslint/visitor-keys" "6.3.0"
 
+"@typescript-eslint/scope-manager@6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-6.4.0.tgz#3048e4262ba3eafa4e2e69b08912d9037ec646ae"
+  integrity sha512-TUS7vaKkPWDVvl7GDNHFQMsMruD+zhkd3SdVW0d7b+7Zo+bd/hXJQ8nsiUZMi1jloWo6c9qt3B7Sqo+flC1nig==
+  dependencies:
+    "@typescript-eslint/types" "6.4.0"
+    "@typescript-eslint/visitor-keys" "6.4.0"
+
 "@typescript-eslint/type-utils@6.3.0":
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-6.3.0.tgz#3bf89ccd36621ddec1b7f8246afe467c67adc247"
@@ -6251,10 +6276,25 @@
     debug "^4.3.4"
     ts-api-utils "^1.0.1"
 
+"@typescript-eslint/type-utils@6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-6.4.0.tgz#c8ac92716ed6a9d5443aa3e342910355b0796ba0"
+  integrity sha512-TvqrUFFyGY0cX3WgDHcdl2/mMCWCDv/0thTtx/ODMY1QhEiyFtv/OlLaNIiYLwRpAxAtOLOY9SUf1H3Q3dlwAg==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "6.4.0"
+    "@typescript-eslint/utils" "6.4.0"
+    debug "^4.3.4"
+    ts-api-utils "^1.0.1"
+
 "@typescript-eslint/types@6.3.0":
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-6.3.0.tgz#84517f1427923e714b8418981e493b6635ab4c9d"
   integrity sha512-K6TZOvfVyc7MO9j60MkRNWyFSf86IbOatTKGrpTQnzarDZPYPVy0oe3myTMq7VjhfsUAbNUW8I5s+2lZvtx1gg==
+
+"@typescript-eslint/types@6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-6.4.0.tgz#5b109a59a805f0d8d375895e42d9e5f0037f66ee"
+  integrity sha512-+FV9kVFrS7w78YtzkIsNSoYsnOtrYVnKWSTVXoL1761CsCRv5wpDOINgsXpxD67YCLZtVQekDDyaxfjVWUJmmg==
 
 "@typescript-eslint/typescript-estree@6.3.0":
   version "6.3.0"
@@ -6263,6 +6303,19 @@
   dependencies:
     "@typescript-eslint/types" "6.3.0"
     "@typescript-eslint/visitor-keys" "6.3.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.5.4"
+    ts-api-utils "^1.0.1"
+
+"@typescript-eslint/typescript-estree@6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-6.4.0.tgz#3c58d20632db93fec3d6ab902acbedf593d37276"
+  integrity sha512-iDPJArf/K2sxvjOR6skeUCNgHR/tCQXBsa+ee1/clRKr3olZjZ/dSkXPZjG6YkPtnW6p5D1egeEPMCW6Gn4yLA==
+  dependencies:
+    "@typescript-eslint/types" "6.4.0"
+    "@typescript-eslint/visitor-keys" "6.4.0"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
@@ -6282,12 +6335,33 @@
     "@typescript-eslint/typescript-estree" "6.3.0"
     semver "^7.5.4"
 
+"@typescript-eslint/utils@6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-6.4.0.tgz#23e996b693603c5924b1fbb733cc73196256baa5"
+  integrity sha512-BvvwryBQpECPGo8PwF/y/q+yacg8Hn/2XS+DqL/oRsOPK+RPt29h5Ui5dqOKHDlbXrAeHUTnyG3wZA0KTDxRZw==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.4.0"
+    "@types/json-schema" "^7.0.12"
+    "@types/semver" "^7.5.0"
+    "@typescript-eslint/scope-manager" "6.4.0"
+    "@typescript-eslint/types" "6.4.0"
+    "@typescript-eslint/typescript-estree" "6.4.0"
+    semver "^7.5.4"
+
 "@typescript-eslint/visitor-keys@6.3.0":
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-6.3.0.tgz#8d09aa3e389ae0971426124c155ac289afbe450a"
   integrity sha512-kEhRRj7HnvaSjux1J9+7dBen15CdWmDnwrpyiHsFX6Qx2iW5LOBUgNefOFeh2PjWPlNwN8TOn6+4eBU3J/gupw==
   dependencies:
     "@typescript-eslint/types" "6.3.0"
+    eslint-visitor-keys "^3.4.1"
+
+"@typescript-eslint/visitor-keys@6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-6.4.0.tgz#96a426cdb1add28274abd7a34aefe27f8b7d51ef"
+  integrity sha512-yJSfyT+uJm+JRDWYRYdCm2i+pmvXJSMtPR9Cq5/XQs4QIgNoLcoRtDdzsLbLsFM/c6um6ohQkg/MLxWvoIndJA==
+  dependencies:
+    "@typescript-eslint/types" "6.4.0"
     eslint-visitor-keys "^3.4.1"
 
 "@urql/core@>=4.0.0", "@urql/core@^4.1.0":
@@ -9637,7 +9711,7 @@ eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
-eslint@^8.47.0:
+eslint@^8.46.0, eslint@^8.47.0:
   version "8.47.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.47.0.tgz#c95f9b935463fb4fad7005e626c7621052e90806"
   integrity sha512-spUQWrdPt+pRVP1TTJLmfRNJJHHZryFmptzcafwSvHsceV81djHOdnEeDmkdotZyLNjDhrOasNK8nikkoG1O8Q==


### PR DESCRIPTION
## Description of the change

Update new shared, DA, non-settlement minters to allow artist to call when minter-local max invocations are reached.

## Design Choices

This has an operational benefit by not requiring an admin call to `resetAuctionDetails` when successive DA are used on a project.

The operational benefit comes at the cost of a minor relaxing of separation of powers after an auction has started:
- Before: artist needs admin concurrence to change auction parameters after an auction has started
- After: artist could manually limit max invocations to current invocations, change auction parameters, then change max invocations back again

This is not a major security concern, because there is no reason for a user to send excessive value as part of their purchase transaction in these non-settlement minters, and because it would be very damaging to an artist's reputation to e.g. front-run a purchase transaction to change auction details with intent to capture excessive value. Comments are added to affected functions, including a warning on purchase functions.

## Other

Due DA w/Settlement's requirement that purchase prices be monotonically decreasing, successive DA w/Settlement are not designed to be possible on a single contract, and therefore this PR does not affect DA w/Settlement minters.

---
Asana task: https://app.asana.com/0/0/1205272459734294/f