### PR TITLE
View of all approved minters on shared minter filter

### DIFF
--- a/packages/contracts/contracts/interfaces/v0.8.x/IMinterFilterV1.sol
+++ b/packages/contracts/contracts/interfaces/v0.8.x/IMinterFilterV1.sol
@@ -167,6 +167,11 @@ interface IMinterFilterV1 {
             string memory minterType
         );
 
+    function getAllGloballyApprovedMinters()
+        external
+        view
+        returns (MinterWithType[] memory mintersWithTypes);
+
     /**
      * Owner of contract.
      * @dev This returns the address of the Admin ACL contract.

--- a/packages/contracts/contracts/interfaces/v0.8.x/IMinterFilterV1.sol
+++ b/packages/contracts/contracts/interfaces/v0.8.x/IMinterFilterV1.sol
@@ -85,6 +85,13 @@ interface IMinterFilterV1 {
      */
     event CoreRegistryUpdated(address indexed coreRegistry);
 
+    // struct used to return minter info
+    // @dev this is not used for storage of data
+    struct MinterWithType {
+        address minterAddress;
+        string minterType;
+    }
+
     function setMinterForProject(
         uint256 _projectId,
         address _coreContract,

--- a/packages/contracts/contracts/minter-suite/MinterFilter/MinterFilterV2.sol
+++ b/packages/contracts/contracts/minter-suite/MinterFilter/MinterFilterV2.sol
@@ -635,6 +635,42 @@ contract MinterFilterV2 is Ownable, IMinterFilterV1 {
     }
 
     /**
+     * @notice Gets all minters that are globally approved on this minter
+     * filter. Returns an array of MinterWithType structs, which contain the
+     * minter address and minter type.
+     * This function has unbounded gas, and should only be used for off-chain
+     * queries.
+     * Alternatively, the subgraph indexing layer may be used to query these
+     * values.
+     * @return mintersWithTypes Array of MinterWithType structs, which contain
+     * the minter address and minter type.
+     */
+    function getAllGloballyApprovedMinters()
+        external
+        view
+        returns (MinterWithType[] memory mintersWithTypes)
+    {
+        // initialize arrays with appropriate length
+        uint256 numMinters = globallyApprovedMinters.length();
+        mintersWithTypes = new MinterWithType[](numMinters);
+        // iterate over all globally approved minters, adding to array
+        for (uint256 i; i < numMinters; ) {
+            address minterAddress = globallyApprovedMinters.at(i);
+            // @dev we know minterType() does not revert, because it was called
+            // when globally approving the minter
+            string memory minterType = IFilteredMinterV0(minterAddress)
+                .minterType();
+            mintersWithTypes[i] = MinterWithType({
+                minterAddress: minterAddress,
+                minterType: minterType
+            });
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /**
      * @notice Convenience function that returns whether `_sender` is allowed
      * to call function with selector `_selector` on contract `_contract`, as
      * determined by this contract's current Admin ACL contract. Expected use

--- a/packages/contracts/test/minter-filter/v2/views.test.ts
+++ b/packages/contracts/test/minter-filter/v2/views.test.ts
@@ -493,6 +493,43 @@ runForEach.forEach((params) => {
       });
     });
 
+    describe("getAllGloballyApprovedMinters", async function () {
+      it("returns empty array when no minter approved", async function () {
+        const config = await loadFixture(_beforeEach);
+        await config.minterFilter
+          .connect(config.accounts.deployer)
+          .revokeMinterGlobally(config.minter.address);
+        let result = await config.minterFilter.getAllGloballyApprovedMinters();
+        expect(result).to.be.empty;
+      });
+
+      it("returns expected when minter is globally approved", async function () {
+        const config = await loadFixture(_beforeEach);
+        let result = await config.minterFilter.getAllGloballyApprovedMinters();
+        expect(result[0][0]).to.be.equal(config.minter.address);
+        expect(result[0][1]).to.be.equal(expectedMinterType);
+        expect(result.length).to.be.equal(1);
+      });
+
+      it("returns expected when >1 minter is globally approved", async function () {
+        const config = await loadFixture(_beforeEach);
+        // deploy and add new dummy shared minter
+        const newMinter = await deployAndGet(config, expectedMinterType, [
+          config.minterFilter.address,
+        ]);
+        await config.minterFilter
+          .connect(config.accounts.deployer)
+          .approveMinterGlobally(newMinter.address);
+        // expect both minters to be approved
+        let result = await config.minterFilter.getAllGloballyApprovedMinters();
+        expect(result[0][0]).to.be.equal(config.minter.address);
+        expect(result[0][1]).to.be.equal(expectedMinterType);
+        expect(result[1][0]).to.be.equal(newMinter.address);
+        expect(result[1][1]).to.be.equal(expectedMinterType);
+        expect(result.length).to.be.equal(2);
+      });
+    });
+
     describe("owner", async function () {
       it("returns expected value", async function () {
         const config = await loadFixture(_beforeEach);


### PR DESCRIPTION
## Description of the change

Add view that returns all globally approved minters on MinterFilterV2.

This adds a gas-unbounded convenience function that returns a list of all globally approved minters on MinterFilterV2.

This is intended to be useful for artists configuring their minters before strong infrastructure is built that makes configuring minters easier (i.e. dashboards, etc.). The functions also help with providing an easy way to determine the set of minters that are globally approved on a shared minter filter, which is a net-benefit to our overall security model.

Tests are added for the new view functionality.