### PR TITLE
Reduce DA mint gas costs

### DIFF
--- a/packages/contracts/contracts/interfaces/v0.8.x/ISharedMinterDAExpV0.sol
+++ b/packages/contracts/contracts/interfaces/v0.8.x/ISharedMinterDAExpV0.sol
@@ -7,10 +7,10 @@ interface ISharedMinterDAExpV0 {
     event SetAuctionDetailsExp(
         uint256 indexed _projectId,
         address indexed _coreContract,
-        uint64 _auctionTimestampStart,
-        uint64 _priceDecayHalfLifeSeconds,
-        uint128 _startPrice,
-        uint128 _basePrice
+        uint40 _auctionTimestampStart,
+        uint40 _priceDecayHalfLifeSeconds,
+        uint88 _startPrice,
+        uint88 _basePrice
     );
     /// Minimum allowed price decay half life seconds updated.
     event AuctionMinHalfLifeSecondsUpdated(

--- a/packages/contracts/contracts/interfaces/v0.8.x/ISharedMinterDALinV0.sol
+++ b/packages/contracts/contracts/interfaces/v0.8.x/ISharedMinterDALinV0.sol
@@ -7,10 +7,10 @@ interface ISharedMinterDALinV0 {
     event SetAuctionDetailsLin(
         uint256 indexed _projectId,
         address indexed _coreContract,
-        uint64 _auctionTimestampStart,
-        uint64 _auctionTimestampEnd,
-        uint128 _startPrice,
-        uint128 _basePrice
+        uint40 _auctionTimestampStart,
+        uint40 _auctionTimestampEnd,
+        uint88 _startPrice,
+        uint88 _basePrice
     );
 
     /// Minimum allowed auction length updated

--- a/packages/contracts/contracts/interfaces/v0.8.x/ISharedMinterDAV0.sol
+++ b/packages/contracts/contracts/interfaces/v0.8.x/ISharedMinterDAV0.sol
@@ -15,5 +15,5 @@ interface ISharedMinterDAV0 {
     function projectAuctionParameters(
         uint256 _projectId,
         address _coreContract
-    ) external view returns (uint64, uint64, uint128, uint128);
+    ) external view returns (uint40, uint40, uint88, uint88);
 }

--- a/packages/contracts/contracts/libs/v0.8.x/minter-libs/DAExpLib.sol
+++ b/packages/contracts/contracts/libs/v0.8.x/minter-libs/DAExpLib.sol
@@ -13,14 +13,13 @@ pragma solidity ^0.8.0;
 
 library DAExpLib {
     struct DAProjectConfig {
-        // @dev max uint64 ~= 1.8e19 sec ~= 570 billion years
-        uint64 timestampStart;
-        uint64 priceDecayHalfLifeSeconds;
-        // @dev Prices are packed internally as uint128, resulting in a maximum
-        // allowed price of ~3.4e20 ETH. This is many orders of magnitude
-        // greater than current ETH supply.
-        uint128 startPrice;
-        uint128 basePrice;
+        // @dev max uint40 ~= 1.1e12 sec ~= 34 thousand years
+        uint40 timestampStart;
+        uint40 priceDecayHalfLifeSeconds;
+        // @dev max uint88 ~= 3e26 Wei = ~300 million ETH, which is well above
+        // the expected prices of any NFT mint in the foreseeable future.
+        uint88 startPrice;
+        uint88 basePrice;
     }
 
     /**
@@ -46,10 +45,10 @@ library DAExpLib {
      */
     function setAuctionDetailsExp(
         DAProjectConfig storage _DAProjectConfig,
-        uint64 _auctionTimestampStart,
-        uint64 _priceDecayHalfLifeSeconds,
-        uint128 _startPrice,
-        uint128 _basePrice,
+        uint40 _auctionTimestampStart,
+        uint40 _priceDecayHalfLifeSeconds,
+        uint88 _startPrice,
+        uint88 _basePrice,
         bool _allowReconfigureAfterStart
     ) internal {
         require(

--- a/packages/contracts/contracts/libs/v0.8.x/minter-libs/DALinLib.sol
+++ b/packages/contracts/contracts/libs/v0.8.x/minter-libs/DALinLib.sol
@@ -13,14 +13,13 @@ pragma solidity ^0.8.0;
 
 library DALinLib {
     struct DAProjectConfig {
-        // @dev max uint64 ~= 1.8e19 sec ~= 570 billion years
-        uint64 timestampStart;
-        uint64 timestampEnd;
-        // @dev Prices are packed internally as uint128, resulting in a maximum
-        // allowed price of ~3.4e20 ETH. This is many orders of magnitude
-        // greater than current ETH supply.
-        uint128 startPrice;
-        uint128 basePrice;
+        // @dev max uint40 ~= 1.1e12 sec ~= 34 thousand years
+        uint40 timestampStart;
+        uint40 timestampEnd;
+        // @dev max uint88 ~= 3e26 Wei = ~300 million ETH, which is well above
+        // the expected prices of any NFT mint in the foreseeable future.
+        uint88 startPrice;
+        uint88 basePrice;
     }
 
     /**
@@ -45,10 +44,10 @@ library DALinLib {
      */
     function setAuctionDetailsLin(
         DAProjectConfig storage _DAProjectConfig,
-        uint64 _auctionTimestampStart,
-        uint64 _auctionTimestampEnd,
-        uint128 _startPrice,
-        uint128 _basePrice,
+        uint40 _auctionTimestampStart,
+        uint40 _auctionTimestampEnd,
+        uint88 _startPrice,
+        uint88 _basePrice,
         bool _allowReconfigureAfterStart
     ) internal {
         require(

--- a/packages/contracts/contracts/minter-suite/Minters/MinterDAExpHolderV5.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterDAExpHolderV5.sol
@@ -402,10 +402,10 @@ contract MinterDAExpHolderV5 is
     function setAuctionDetails(
         uint256 _projectId,
         address _coreContract,
-        uint64 _auctionTimestampStart,
-        uint64 _priceDecayHalfLifeSeconds,
-        uint128 _startPrice,
-        uint128 _basePrice
+        uint40 _auctionTimestampStart,
+        uint40 _priceDecayHalfLifeSeconds,
+        uint88 _startPrice,
+        uint88 _basePrice
     ) external {
         AuthLib.onlyArtist({
             _projectId: _projectId,
@@ -610,10 +610,10 @@ contract MinterDAExpHolderV5 is
         external
         view
         returns (
-            uint64 timestampStart,
-            uint64 priceDecayHalfLifeSeconds,
-            uint128 startPrice,
-            uint128 basePrice
+            uint40 timestampStart,
+            uint40 priceDecayHalfLifeSeconds,
+            uint88 startPrice,
+            uint88 basePrice
         )
     {
         DAExpLib.DAProjectConfig

--- a/packages/contracts/contracts/minter-suite/Minters/MinterDAExpSettlementV3.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterDAExpSettlementV3.sol
@@ -214,10 +214,10 @@ contract MinterDAExpSettlementV3 is
     function setAuctionDetails(
         uint256 _projectId,
         address _coreContract,
-        uint64 _auctionTimestampStart,
-        uint64 _priceDecayHalfLifeSeconds,
-        uint128 _startPrice,
-        uint128 _basePrice
+        uint40 _auctionTimestampStart,
+        uint40 _priceDecayHalfLifeSeconds,
+        uint88 _startPrice,
+        uint88 _basePrice
     ) external {
         AuthLib.onlyArtist({
             _projectId: _projectId,
@@ -609,10 +609,10 @@ contract MinterDAExpSettlementV3 is
         external
         view
         returns (
-            uint64 timestampStart,
-            uint64 priceDecayHalfLifeSeconds,
-            uint128 startPrice,
-            uint128 basePrice
+            uint40 timestampStart,
+            uint40 priceDecayHalfLifeSeconds,
+            uint88 startPrice,
+            uint88 basePrice
         )
     {
         DAExpLib.DAProjectConfig

--- a/packages/contracts/contracts/minter-suite/Minters/MinterDAExpV5.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterDAExpV5.sol
@@ -188,10 +188,10 @@ contract MinterDAExpV5 is
     function setAuctionDetails(
         uint256 _projectId,
         address _coreContract,
-        uint64 _auctionTimestampStart,
-        uint64 _priceDecayHalfLifeSeconds,
-        uint128 _startPrice,
-        uint128 _basePrice
+        uint40 _auctionTimestampStart,
+        uint40 _priceDecayHalfLifeSeconds,
+        uint88 _startPrice,
+        uint88 _basePrice
     ) external {
         AuthLib.onlyArtist({
             _projectId: _projectId,
@@ -354,10 +354,10 @@ contract MinterDAExpV5 is
         external
         view
         returns (
-            uint64 timestampStart,
-            uint64 priceDecayHalfLifeSeconds,
-            uint128 startPrice,
-            uint128 basePrice
+            uint40 timestampStart,
+            uint40 priceDecayHalfLifeSeconds,
+            uint88 startPrice,
+            uint88 basePrice
         )
     {
         DAExpLib.DAProjectConfig

--- a/packages/contracts/contracts/minter-suite/Minters/MinterDALinHolderV5.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterDALinHolderV5.sol
@@ -398,10 +398,10 @@ contract MinterDALinHolderV5 is
     function setAuctionDetails(
         uint256 _projectId,
         address _coreContract,
-        uint64 _auctionTimestampStart,
-        uint64 _auctionTimestampEnd,
-        uint128 _startPrice,
-        uint128 _basePrice
+        uint40 _auctionTimestampStart,
+        uint40 _auctionTimestampEnd,
+        uint88 _startPrice,
+        uint88 _basePrice
     ) external {
         AuthLib.onlyArtist({
             _projectId: _projectId,
@@ -598,10 +598,10 @@ contract MinterDALinHolderV5 is
         external
         view
         returns (
-            uint64 timestampStart,
-            uint64 timestampEnd,
-            uint128 startPrice,
-            uint128 basePrice
+            uint40 timestampStart,
+            uint40 timestampEnd,
+            uint88 startPrice,
+            uint88 basePrice
         )
     {
         DALinLib.DAProjectConfig

--- a/packages/contracts/contracts/minter-suite/Minters/MinterDALinV5.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterDALinV5.sol
@@ -182,10 +182,10 @@ contract MinterDALinV5 is
     function setAuctionDetails(
         uint256 _projectId,
         address _coreContract,
-        uint64 _auctionTimestampStart,
-        uint64 _auctionTimestampEnd,
-        uint128 _startPrice,
-        uint128 _basePrice
+        uint40 _auctionTimestampStart,
+        uint40 _auctionTimestampEnd,
+        uint88 _startPrice,
+        uint88 _basePrice
     ) external {
         AuthLib.onlyArtist({
             _projectId: _projectId,
@@ -340,10 +340,10 @@ contract MinterDALinV5 is
         external
         view
         returns (
-            uint64 timestampStart,
-            uint64 timestampEnd,
-            uint128 startPrice,
-            uint128 basePrice
+            uint40 timestampStart,
+            uint40 timestampEnd,
+            uint88 startPrice,
+            uint88 basePrice
         )
     {
         DALinLib.DAProjectConfig


### PR DESCRIPTION
## Description of the change

Reduce DA mint gas costs via struct packing auction data.

This imposes stricter limits on
- max auction prices (max price of ~300 million ETH)
- only allows our minter to function for the next 34 thousand years
...but has the benefit of reducing DA mint gas costs by 2%. All DA minters benefit from this change, since the packing is implemented in the DA libraries used by the minters.

| Comparison | Before gas used | New gas used | Increase (%) |
| --- | --- | --- | --- |
| Minter Shared DA Exp w/Settlement | 108377 | 106254 | -2% |

## Recommendation
The new maximum values are acceptable for our ETH minters, so this seems like an easy 2% efficiency gain.

Note: both previous and new max limits on price are likely NOT acceptable for ERC20 minters, which likely need entire uint256 domain to define price.