### PR TITLE
Use uint256 in interfaces of price

### DIFF
--- a/packages/contracts/contracts/interfaces/v0.8.x/ISharedMinterDAExpSettlementV0.sol
+++ b/packages/contracts/contracts/interfaces/v0.8.x/ISharedMinterDAExpSettlementV0.sol
@@ -11,7 +11,7 @@ interface ISharedMinterDAExpSettlementV0 is ISharedMinterDAExpV0 {
         uint256 indexed _projectId,
         address indexed _coreContract,
         uint24 _numPurchased,
-        uint232 _netPosted
+        uint256 _netPosted
     );
 
     /// returns latest purchase price for project `_projectId`, or 0 if no

--- a/packages/contracts/contracts/interfaces/v0.8.x/ISharedMinterDAExpV0.sol
+++ b/packages/contracts/contracts/interfaces/v0.8.x/ISharedMinterDAExpV0.sol
@@ -9,8 +9,8 @@ interface ISharedMinterDAExpV0 {
         address indexed _coreContract,
         uint40 _auctionTimestampStart,
         uint40 _priceDecayHalfLifeSeconds,
-        uint88 _startPrice,
-        uint88 _basePrice
+        uint256 _startPrice,
+        uint256 _basePrice
     );
     /// Minimum allowed price decay half life seconds updated.
     event AuctionMinHalfLifeSecondsUpdated(

--- a/packages/contracts/contracts/interfaces/v0.8.x/ISharedMinterDALinV0.sol
+++ b/packages/contracts/contracts/interfaces/v0.8.x/ISharedMinterDALinV0.sol
@@ -9,8 +9,8 @@ interface ISharedMinterDALinV0 {
         address indexed _coreContract,
         uint40 _auctionTimestampStart,
         uint40 _auctionTimestampEnd,
-        uint88 _startPrice,
-        uint88 _basePrice
+        uint256 _startPrice,
+        uint256 _basePrice
     );
 
     /// Minimum allowed auction length updated

--- a/packages/contracts/contracts/interfaces/v0.8.x/ISharedMinterDAV0.sol
+++ b/packages/contracts/contracts/interfaces/v0.8.x/ISharedMinterDAV0.sol
@@ -15,5 +15,5 @@ interface ISharedMinterDAV0 {
     function projectAuctionParameters(
         uint256 _projectId,
         address _coreContract
-    ) external view returns (uint40, uint40, uint88, uint88);
+    ) external view returns (uint40, uint40, uint256, uint256);
 }

--- a/packages/contracts/contracts/minter-suite/Minters/MinterDAExpHolderV5.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterDAExpHolderV5.sol
@@ -15,6 +15,7 @@ import "../../libs/v0.8.x/minter-libs/TokenHolderLib.sol";
 import "../../libs/v0.8.x/minter-libs/DAExpLib.sol";
 import "../../libs/v0.8.x/AuthLib.sol";
 
+import "@openzeppelin-4.7/contracts/utils/math/SafeCast.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/structs/EnumerableSet.sol";
 
@@ -88,6 +89,7 @@ contract MinterDAExpHolderV5 is
     ISharedMinterDAExpV0,
     ISharedMinterHolderV0
 {
+    using SafeCast for uint256;
     // add Enumerable Set methods
     using EnumerableSet for EnumerableSet.AddressSet;
 
@@ -404,8 +406,8 @@ contract MinterDAExpHolderV5 is
         address _coreContract,
         uint40 _auctionTimestampStart,
         uint40 _priceDecayHalfLifeSeconds,
-        uint88 _startPrice,
-        uint88 _basePrice
+        uint256 _startPrice,
+        uint256 _basePrice
     ) external {
         AuthLib.onlyArtist({
             _projectId: _projectId,
@@ -435,8 +437,8 @@ contract MinterDAExpHolderV5 is
             _DAProjectConfig: _auctionProjectConfig,
             _auctionTimestampStart: _auctionTimestampStart,
             _priceDecayHalfLifeSeconds: _priceDecayHalfLifeSeconds,
-            _startPrice: _startPrice,
-            _basePrice: _basePrice,
+            _startPrice: _startPrice.toUint88(),
+            _basePrice: _basePrice.toUint88(),
             _allowReconfigureAfterStart: maxHasBeenInvoked
         });
 
@@ -612,8 +614,8 @@ contract MinterDAExpHolderV5 is
         returns (
             uint40 timestampStart,
             uint40 priceDecayHalfLifeSeconds,
-            uint88 startPrice,
-            uint88 basePrice
+            uint256 startPrice,
+            uint256 basePrice
         )
     {
         DAExpLib.DAProjectConfig

--- a/packages/contracts/contracts/minter-suite/Minters/MinterDAExpSettlementV3.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterDAExpSettlementV3.sol
@@ -216,8 +216,8 @@ contract MinterDAExpSettlementV3 is
         address _coreContract,
         uint40 _auctionTimestampStart,
         uint40 _priceDecayHalfLifeSeconds,
-        uint88 _startPrice,
-        uint88 _basePrice
+        uint256 _startPrice,
+        uint256 _basePrice
     ) external {
         AuthLib.onlyArtist({
             _projectId: _projectId,
@@ -255,8 +255,8 @@ contract MinterDAExpSettlementV3 is
             _DAProjectConfig: _auctionProjectConfig,
             _auctionTimestampStart: _auctionTimestampStart,
             _priceDecayHalfLifeSeconds: _priceDecayHalfLifeSeconds,
-            _startPrice: _startPrice,
-            _basePrice: _basePrice,
+            _startPrice: _startPrice.toUint88(),
+            _basePrice: _basePrice.toUint88(),
             // we set this to false so it prevents artist from altering auction
             // even after max has been invoked (require explicit auction reset
             // on settlement minter)
@@ -611,8 +611,8 @@ contract MinterDAExpSettlementV3 is
         returns (
             uint40 timestampStart,
             uint40 priceDecayHalfLifeSeconds,
-            uint88 startPrice,
-            uint88 basePrice
+            uint256 startPrice,
+            uint256 basePrice
         )
     {
         DAExpLib.DAProjectConfig

--- a/packages/contracts/contracts/minter-suite/Minters/MinterDAExpV5.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterDAExpV5.sol
@@ -13,6 +13,7 @@ import "../../libs/v0.8.x/minter-libs/MaxInvocationsLib.sol";
 import "../../libs/v0.8.x/minter-libs/DAExpLib.sol";
 import "../../libs/v0.8.x/AuthLib.sol";
 
+import "@openzeppelin-4.7/contracts/utils/math/SafeCast.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 
 pragma solidity 0.8.19;
@@ -64,6 +65,7 @@ contract MinterDAExpV5 is
     ISharedMinterDAV0,
     ISharedMinterDAExpV0
 {
+    using SafeCast for uint256;
     /// Minter filter address this minter interacts with
     address public immutable minterFilterAddress;
 
@@ -190,8 +192,8 @@ contract MinterDAExpV5 is
         address _coreContract,
         uint40 _auctionTimestampStart,
         uint40 _priceDecayHalfLifeSeconds,
-        uint88 _startPrice,
-        uint88 _basePrice
+        uint256 _startPrice,
+        uint256 _basePrice
     ) external {
         AuthLib.onlyArtist({
             _projectId: _projectId,
@@ -221,8 +223,8 @@ contract MinterDAExpV5 is
             _DAProjectConfig: _auctionProjectConfig,
             _auctionTimestampStart: _auctionTimestampStart,
             _priceDecayHalfLifeSeconds: _priceDecayHalfLifeSeconds,
-            _startPrice: _startPrice,
-            _basePrice: _basePrice,
+            _startPrice: _startPrice.toUint88(),
+            _basePrice: _basePrice.toUint88(),
             _allowReconfigureAfterStart: maxHasBeenInvoked
         });
 
@@ -356,8 +358,8 @@ contract MinterDAExpV5 is
         returns (
             uint40 timestampStart,
             uint40 priceDecayHalfLifeSeconds,
-            uint88 startPrice,
-            uint88 basePrice
+            uint256 startPrice,
+            uint256 basePrice
         )
     {
         DAExpLib.DAProjectConfig

--- a/packages/contracts/contracts/minter-suite/Minters/MinterDALinHolderV5.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterDALinHolderV5.sol
@@ -15,6 +15,7 @@ import "../../libs/v0.8.x/minter-libs/TokenHolderLib.sol";
 import "../../libs/v0.8.x/minter-libs/DALinLib.sol";
 import "../../libs/v0.8.x/AuthLib.sol";
 
+import "@openzeppelin-4.7/contracts/utils/math/SafeCast.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin-4.5/contracts/utils/structs/EnumerableSet.sol";
 
@@ -88,6 +89,7 @@ contract MinterDALinHolderV5 is
     ISharedMinterDALinV0,
     ISharedMinterHolderV0
 {
+    using SafeCast for uint256;
     // add Enumerable Set methods
     using EnumerableSet for EnumerableSet.AddressSet;
 
@@ -400,8 +402,8 @@ contract MinterDALinHolderV5 is
         address _coreContract,
         uint40 _auctionTimestampStart,
         uint40 _auctionTimestampEnd,
-        uint88 _startPrice,
-        uint88 _basePrice
+        uint256 _startPrice,
+        uint256 _basePrice
     ) external {
         AuthLib.onlyArtist({
             _projectId: _projectId,
@@ -432,8 +434,8 @@ contract MinterDALinHolderV5 is
             _DAProjectConfig: _auctionProjectConfig,
             _auctionTimestampStart: _auctionTimestampStart,
             _auctionTimestampEnd: _auctionTimestampEnd,
-            _startPrice: _startPrice,
-            _basePrice: _basePrice,
+            _startPrice: _startPrice.toUint88(),
+            _basePrice: _basePrice.toUint88(),
             _allowReconfigureAfterStart: maxHasBeenInvoked
         });
 
@@ -600,8 +602,8 @@ contract MinterDALinHolderV5 is
         returns (
             uint40 timestampStart,
             uint40 timestampEnd,
-            uint88 startPrice,
-            uint88 basePrice
+            uint256 startPrice,
+            uint256 basePrice
         )
     {
         DALinLib.DAProjectConfig

--- a/packages/contracts/contracts/minter-suite/Minters/MinterDALinV5.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterDALinV5.sol
@@ -13,6 +13,7 @@ import "../../libs/v0.8.x/minter-libs/MaxInvocationsLib.sol";
 import "../../libs/v0.8.x/minter-libs/DALinLib.sol";
 import "../../libs/v0.8.x/AuthLib.sol";
 
+import "@openzeppelin-4.7/contracts/utils/math/SafeCast.sol";
 import "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
 
 pragma solidity 0.8.19;
@@ -64,6 +65,7 @@ contract MinterDALinV5 is
     ISharedMinterDAV0,
     ISharedMinterDALinV0
 {
+    using SafeCast for uint256;
     /// Minter filter address this minter interacts with
     address public immutable minterFilterAddress;
 
@@ -184,8 +186,8 @@ contract MinterDALinV5 is
         address _coreContract,
         uint40 _auctionTimestampStart,
         uint40 _auctionTimestampEnd,
-        uint88 _startPrice,
-        uint88 _basePrice
+        uint256 _startPrice,
+        uint256 _basePrice
     ) external {
         AuthLib.onlyArtist({
             _projectId: _projectId,
@@ -216,8 +218,8 @@ contract MinterDALinV5 is
             _DAProjectConfig: _auctionProjectConfig,
             _auctionTimestampStart: _auctionTimestampStart,
             _auctionTimestampEnd: _auctionTimestampEnd,
-            _startPrice: _startPrice,
-            _basePrice: _basePrice,
+            _startPrice: _startPrice.toUint88(),
+            _basePrice: _basePrice.toUint88(),
             _allowReconfigureAfterStart: maxHasBeenInvoked
         });
 
@@ -342,8 +344,8 @@ contract MinterDALinV5 is
         returns (
             uint40 timestampStart,
             uint40 timestampEnd,
-            uint88 startPrice,
-            uint88 basePrice
+            uint256 startPrice,
+            uint256 basePrice
         )
     {
         DALinLib.DAProjectConfig


### PR DESCRIPTION
## Description of the change

Use `uint256` in interfaces dealing with price values.

In general, we want to pack prices in structs for gas efficiency in our minters. When dealing with ETH minters, maximum values are known well (300 million ETH is expected to be a safe upper price bound for an NFT sale).

However, if we were to develop a DA ERC20 minter, both decimals and upper bounds of pricing are no longer known, and uint256 must be used for price storage and interfaces.

## Design Choices

This update implements the following:
- updates interface functions and events to always communicate price values as `uint256`
  - this adds negligible gas cost, while making the current events compatible with ERC20 variants if we implement in the future (eliminating downstream impacts on subgraph and frontend)
- keep prices packed in storage
  - this avoids adding non-negligible gas costs to mint transactions
  - the downside is we will need to fork some libraries (e.g. make a `DAExpNotPackedLib`) to make them ERC20 compatible in the future, which seems like a reasonable tradeoff considering the gas efficiency tradeoffs associated with not packing prices
    - estimate ~4-5% additional mint gas costs if we were to fully unpack the ETH variants of these libs
- function inputs to the minter accept `uint256`, but function inputs to the underlying libraries accept the type that is used in storage. This separates the roles of the library and the minter: the library lets the minter decide if it wants to have function inputs equal to the storage type within the library or uint256.