### PR TITLE
Shared settlement minter event patch

### DIFF
--- a/packages/contracts/contracts/libs/v0.8.x/minter-libs/SettlementExpLib.sol
+++ b/packages/contracts/contracts/libs/v0.8.x/minter-libs/SettlementExpLib.sol
@@ -170,6 +170,8 @@ library SettlementExpLib {
      * @param _isEngine bool indicating whether the core contract is an engine
      * @return maxInvocationsUpdated whether or not the minter's local max
      * invocations state was updated during this function call.
+     * @return settledPriceUpdated whether or not the project's settled price
+     * was updated during this function call.
      */
     function distributeArtistAndAdminRevenues(
         uint256 _projectId,
@@ -179,7 +181,7 @@ library SettlementExpLib {
             storage _maxInvocationsProjectConfig,
         DAExpLib.DAProjectConfig storage _DAProjectConfig,
         bool _isEngine
-    ) internal returns (bool maxInvocationsUpdated) {
+    ) internal returns (bool maxInvocationsUpdated, bool settledPriceUpdated) {
         // require revenues to not have already been collected
         require(
             !_settlementAuctionProjectConfig.auctionRevenuesCollected,
@@ -229,6 +231,7 @@ library SettlementExpLib {
             // the base price is used for all future settlement calculations
             // EFFECTS
             _settlementAuctionProjectConfig.latestPurchasePrice = basePrice;
+            settledPriceUpdated = true;
         }
         _settlementAuctionProjectConfig.auctionRevenuesCollected = true;
         // calculate the artist and admin revenues
@@ -241,7 +244,7 @@ library SettlementExpLib {
             _coreContract: _coreContract,
             _isEngine: _isEngine
         });
-        // @dev maxInvocationsUpdated is returned
+        // @dev (maxInvocationsUpdated, settledPriceUpdated) is returned
     }
 
     /**

--- a/packages/contracts/contracts/minter-suite/Minters/MinterDAExpSettlementV3.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterDAExpSettlementV3.sol
@@ -478,8 +478,10 @@ contract MinterDAExpSettlementV3 is
             _isEngineCaches[_coreContract]
         );
         // CHECKS-EFFECTS-INTERACTIONS
-        bool maxInvocationsUpdated = SettlementExpLib
-            .distributeArtistAndAdminRevenues({
+        (
+            bool maxInvocationsUpdated,
+            bool settledPriceUpdated
+        ) = SettlementExpLib.distributeArtistAndAdminRevenues({
                 _projectId: _projectId,
                 _coreContract: _coreContract,
                 _settlementAuctionProjectConfig: _settlementAuctionProjectConfig,
@@ -493,7 +495,17 @@ contract MinterDAExpSettlementV3 is
             SettlementExpLib.CONFIG_AUCTION_REVENUES_COLLECTED,
             true
         );
+        if (settledPriceUpdated) {
+            // notify indexing service of settled price update
+            emit ConfigValueSet(
+                _projectId,
+                _coreContract,
+                SettlementExpLib.CONFIG_CURRENT_SETTLED_PRICE,
+                uint256(_settlementAuctionProjectConfig.latestPurchasePrice)
+            );
+        }
         if (maxInvocationsUpdated) {
+            // notify indexing service of max invocations update
             emit ProjectMaxInvocationsLimitUpdated(
                 _projectId,
                 _coreContract,


### PR DESCRIPTION
## Description of the change

Update `MinterDAExpSettlementV3` to emit event when settlement price is updated during revenue collection.

This change correctly updates indexed settled price when revenues are withdrawn by the artist (or admin), which is a common pattern, and is important to handle when a project reaches base price, but does not sell out.

Without this update, notifications are not created on our frontend until a subsequent purchase is made after reaching base price (and no sellout) due to stale subgraph data.

Thanks to generic events being used, no downstream changes to subgraph are required for this change. Additionally, although ABI bytecode field changes, no interface changes are required in this PR, so a new `@artblocks/contracts` npm release is not required (we don't require new contracts releases every time we touch an existing contract).

## Follow-on

A new deployment of the settlement minter should be made on dev after this is merged (+ new deployment should be indexed by dev subgraph)