### PR TITLE
Deploy Flex + legacy minter suite for migration testing

### DIFF
--- a/packages/contracts/deployments/engine/V3/internal-testing/dev-test-migration-flex/DEPLOYMENTS.md
+++ b/packages/contracts/deployments/engine/V3/internal-testing/dev-test-migration-flex/DEPLOYMENTS.md
@@ -1,0 +1,45 @@
+
+# Deployment
+
+Date: 2023-09-01T19:25:49.912Z
+
+## **Network:** goerli
+
+## **Environment:** dev
+
+**Deployment Input File:** `deployments/engine/V3/internal-testing/dev-test-migration-flex/deployment-config.dev.ts`
+
+**GenArt721CoreV3_Engine_Flex:** https://goerli.etherscan.io/address/0x46F341F90Eb308D62C8211607B87421756190b7F#code
+
+**AdminACLV0:** https://goerli.etherscan.io/address/0x3c615758a5C02C18d3C422590D84256c26EC7C1a#code
+
+**Engine Registry:** https://goerli.etherscan.io/address/0x2A39132E8d594d2c840D6656327fB26d900C05bA#code
+
+**MinterFilterV1:** https://goerli.etherscan.io/address/0x23c10E68c269A03246f5dF37335e148fE6B70c99#code
+
+**Minters:**
+
+**MinterSetPriceV4:** https://goerli.etherscan.io/address/0x9cDe518fDC34e76f9CaC602EA37dB1eD2CBB12dd#code
+
+**MinterDAExpSettlementV1:** https://goerli.etherscan.io/address/0xb1E1db1d10Db273971AF80658d368AD41c07399F#code
+
+
+
+**Metadata**
+
+- **Starting Project Id:** 0
+- **Token Name:** Engine Migrate Flex
+- **Token Ticker:** DEVMIGRATEFLEX
+- **Auto Approve Artist Split Proposals:** true
+- **Render Provider Address, Primary Sales:** deployer
+- **Platform Provider Address, Primary Sales:** deployer
+- **BytecodeStorageReader Library:** 0xB8B806A10d16cc80dB788552B54B3ECb4A2A3C3D
+
+**Other**
+
+- **Add initial project?:** false
+- **Add initial token?:** false
+- **Image Bucket:** engine-migrate-flex-goerli
+
+---
+

--- a/packages/contracts/deployments/engine/V3/internal-testing/dev-test-migration-flex/DEPLOYMENT_LOGS.log
+++ b/packages/contracts/deployments/engine/V3/internal-testing/dev-test-migration-flex/DEPLOYMENT_LOGS.log
@@ -1,0 +1,49 @@
+----------------------------------------
+[INFO] Datetime of deployment: 2023-09-01T19:22:38.048Z
+[INFO] Deployment configuration file: /Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/packages/contracts/deployments/engine/V3/internal-testing/dev-test-migration-flex/deployment-config.dev.ts
+[INFO] Deploying to network: goerli
+[INFO] Deploying to environment: dev
+[INFO] New Admin ACL AdminACLV0 deployed at address: 0x3c615758a5C02C18d3C422590D84256c26EC7C1a
+[INFO] Randomizer BasicRandomizerV2 deployed at 0xa5C9C8d1D5ac6360f2B4271b0D9D78A38E9fAB9d
+[INFO] Core GenArt721CoreV3_Engine_Flex deployed at 0x46F341F90Eb308D62C8211607B87421756190b7F
+[INFO] Minter Filter MinterFilterV1 deployed at 0x23c10E68c269A03246f5dF37335e148fE6B70c99
+[INFO] MinterSetPriceV4 deployed at 0x9cDe518fDC34e76f9CaC602EA37dB1eD2CBB12dd
+[INFO] MinterDAExpSettlementV1 deployed at 0xb1E1db1d10Db273971AF80658d368AD41c07399F
+[INFO] Assigned randomizer to core and renounced ownership of randomizer
+[INFO] Updated the Minter Filter on the Core contract to 0x23c10E68c269A03246f5dF37335e148fE6B70c99.
+[INFO] Allowlisted minter MinterSetPriceV4 at 0x9cDe518fDC34e76f9CaC602EA37dB1eD2CBB12dd on minter filter.
+[INFO] Allowlisted minter MinterDAExpSettlementV1 at 0xb1E1db1d10Db273971AF80658d368AD41c07399F on minter filter.
+[INFO] Skipping adding placeholder initial project.
+[INFO] Skipping adding placeholder initial token.
+[INFO] Skipping transfer of superAdmin role on adminACL.
+[INFO] Verifying core contract contract deployment...
+The contract 0x46F341F90Eb308D62C8211607B87421756190b7F has already been verified
+[INFO] Core contract verified on Etherscan at 0x46F341F90Eb308D62C8211607B87421756190b7F}
+[INFO] Verifying AdminACL contract deployment...
+The contract 0x3c615758a5C02C18d3C422590D84256c26EC7C1a has already been verified
+[INFO] AdminACL contract verified on Etherscan at 0x3c615758a5C02C18d3C422590D84256c26EC7C1a
+[INFO] Verifying MinterFilter contract deployment...
+The contract 0x23c10E68c269A03246f5dF37335e148fE6B70c99 has already been verified
+[INFO] MinterFilter contract verified on Etherscan at 0x23c10E68c269A03246f5dF37335e148fE6B70c99
+[INFO] Verifying MinterSetPriceV4 contract deployment...
+The contract 0x9cDe518fDC34e76f9CaC602EA37dB1eD2CBB12dd has already been verified
+[INFO] MinterSetPriceV4 contract verified on Etherscan at 0x9cDe518fDC34e76f9CaC602EA37dB1eD2CBB12dd
+[INFO] Verifying MinterDAExpSettlementV1 contract deployment...
+The contract 0xb1E1db1d10Db273971AF80658d368AD41c07399F has already been verified
+[INFO] MinterDAExpSettlementV1 contract verified on Etherscan at 0xb1E1db1d10Db273971AF80658d368AD41c07399F
+Created s3 bucket for https://engine-migrate-flex-goerli.s3.amazonaws.com
+[INFO] Created image bucket engine-migrate-flex-goerli
+[INFO] Deployment details written to /Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/packages/contracts/deployments/engine/V3/internal-testing/dev-test-migration-flex/DEPLOYMENTS.md
+Upserting 1 contract...
+Contracts metadata upsert input:
+{
+  "address": "0x46f341f90eb308d62c8211607b87421756190b7f",
+  "name": "Engine Migrate Flex",
+  "bucket_name": "engine-migrate-flex-goerli",
+  "default_vertical_name": "flex"
+}
+Successfully upserted 1 contract
+[ACTION] render provider sales payment addresses remain as deployer addresses: 0x2246475beddf9333b6a6D9217194576E7617Afd1. Update later as needed.
+[ACTION] platform provider sales payment addresses remain as deployer addresses: 0x2246475beddf9333b6a6D9217194576E7617Afd1. Update later as needed.
+[ACTION] AdminACL's superAdmin address is 0x2246475beddf9333b6a6D9217194576E7617Afd1, don't forget to update if required.
+[ACTION] Subgraph: Add Minter Filter and Minter contracts to subgraph config if desire to index minter suite.

--- a/packages/contracts/deployments/engine/V3/internal-testing/dev-test-migration-flex/deployment-config.dev.ts
+++ b/packages/contracts/deployments/engine/V3/internal-testing/dev-test-migration-flex/deployment-config.dev.ts
@@ -1,0 +1,51 @@
+// This file is used to configure the deployment of the Engine Partner contracts
+// It is intended to be imported by the generic deployer in `/scripts/engine/V3/generic-v3-engine-deployer.ts`
+export const deployDetailsArray = [
+  {
+    network: "goerli",
+    // environment is only used for metadata purposes, and is not used in the deployment process
+    // Please set to "dev", "staging", or "mainnet", as appropriate
+    environment: "dev",
+    // if you want to use an existing admin ACL, set the address here (otherwise set as undefined to deploy a new one)
+    existingAdminACL: undefined,
+    // the following can be undefined if you are using an existing admin ACL, otherwise define the Admin ACL contract name
+    // if deploying a new AdminACL
+    adminACLContractName: "AdminACLV0",
+    // See the `KNOWN_ENGINE_REGISTRIES` object in `/scripts/engine/V3/constants.ts` for the correct registry address for
+    // the intended network and the corresponding deployer wallet addresses
+    // @dev if you neeed a new engine registry, use the `/scripts/engine/V3/engine-registry-deployer.ts` script
+    engineRegistryAddress: "0x2A39132E8d594d2c840D6656327fB26d900C05bA",
+    randomizerContractName: "BasicRandomizerV2",
+    genArt721CoreContractName: "GenArt721CoreV3_Engine_Flex",
+    tokenName: "Engine Migrate Flex",
+    tokenTicker: "DEVMIGRATEFLEX",
+    startingProjectId: 0,
+    autoApproveArtistSplitProposals: true,
+    renderProviderAddress: "deployer", // use either "0x..." or special "deployer" which sets the render provider to the deployer
+    platformProviderAddress: "deployer", // use either "0x..." or special "deployer" which sets the render provider to the deployer
+    // minter suite
+    minterFilterContractName: "MinterFilterV1",
+    minters: ["MinterSetPriceV4", "MinterDAExpSettlementV1"],
+    // set to true if you want to add an initial project to the core contract
+    addInitialProject: false,
+    // set to true if you want to add an initial token to the initial project
+    // (this will only work if you have set addInitialProject to true, and requires a MinterSetPriceV[4-9])
+    addInitialToken: false,
+    // set to true if you want to transfer the superAdmin role to a different address
+    doTransferSuperAdmin: false,
+    // set to the address you want to transfer the superAdmin role to
+    // (this will only work if you have set doTransferSuperAdmin to true, can be undefined if you are not transferring)
+    newSuperAdminAddress: undefined, // use either "0x..." or undefined if not transferring
+    // optionally define this to set default vertical name for the contract after deployment.
+    // if not defined, the default vertical name will be "unassigned".
+    // common values include `fullyonchain`, `flex`, or partnerships like `artblocksxpace`.
+    // also note that if you desire to create a new veritcal, you will need to add the vertical name to the
+    // `project_verticals` table in the database before running this deploy script.
+    // optionally define this to set default vertical name for the contract after deployment.
+    // if not defined, the default vertical name will be "unassigned".
+    // common values include `fullyonchain`, `flex`, or partnerships like `artblocksxpace`.
+    // also note that if you desire to create a new veritcal, you will need to add the vertical name to the
+    // `project_verticals` table in the database before running this deploy script.
+    defaultVerticalName: "flex",
+  },
+];


### PR DESCRIPTION
## Description of the change

Deploy a new Engine Flex core with a new legacy minter suite to enable migration testing for the new, shared minter suite.

Upon some investigation into deployments that already exist on Goerli, starting fresh seemed like the best, simplest option for this testing.
