### PR TITLE
Deploy shared minter suite to staging

### DIFF
--- a/packages/contracts/deployments/minter-filter/goerli-staging/DEPLOYMENTS.md
+++ b/packages/contracts/deployments/minter-filter/goerli-staging/DEPLOYMENTS.md
@@ -1,0 +1,21 @@
+
+# Shared Minter Filter Deployment
+
+Date: 2023-09-11T13:43:59.744Z
+
+## **Network:** goerli
+
+## **Environment:** staging
+
+**Deployment Input File:** `deployments/minter-filter/goerli-staging/shared-minter-filter-deploy-config.staging.ts`
+
+**MinterFilterV2:** https://goerli.etherscan.io/address/0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559#code
+
+**Associated AdminACL contract:** 0x512174CE633D08764809af74d7e62670BD764F3F
+
+**Associated CoreRegistry contract:** 0xddFfc62A975f7EBA75A877a0535755ceA18232C9
+
+**Deployment Args:** 0x512174CE633D08764809af74d7e62670BD764F3F,0xddFfc62A975f7EBA75A877a0535755ceA18232C9
+
+---
+

--- a/packages/contracts/deployments/minter-filter/goerli-staging/DEPLOYMENT_LOGS.log
+++ b/packages/contracts/deployments/minter-filter/goerli-staging/DEPLOYMENT_LOGS.log
@@ -1,0 +1,26 @@
+----------------------------------------
+[INFO] Datetime of deployment: 2023-09-11T13:41:29.617Z
+[INFO] Deployment configuration file: /Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/packages/contracts/deployments/minter-filter/goerli-staging/shared-minter-filter-deploy-config.staging.ts
+[INFO] Admin ACL contract AdminACLV0 deployed at 0x512174CE633D08764809af74d7e62670BD764F3F
+[INFO] Core Registry contract CoreRegistryV1 deployed at 0xddFfc62A975f7EBA75A877a0535755ceA18232C9
+[INFO] MinterFilterV2 deployed at 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559
+[INFO] Verifying AdminACLV0 contract deployment...
+The contract 0x512174CE633D08764809af74d7e62670BD764F3F has already been verified
+[INFO] AdminACLV0 contract verified on Etherscan at 0x512174CE633D08764809af74d7e62670BD764F3F
+[INFO] Verifying CoreRegistryV1 contract deployment...
+The contract 0xddFfc62A975f7EBA75A877a0535755ceA18232C9 has already been verified
+[INFO] CoreRegistryV1 contract verified on Etherscan at 0xddFfc62A975f7EBA75A877a0535755ceA18232C9
+[INFO] Verifying MinterFilterV2 contract deployment...
+Nothing to compile
+Successfully submitted source code for contract
+contracts/minter-suite/MinterFilter/MinterFilterV2.sol:MinterFilterV2 at 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559
+for verification on the block explorer. Waiting for verification result...
+
+[WARN] Etherscan verification of MinterFilterV2 failed: NomicLabsHardhatPluginError: The Etherscan API responded with a failure status.
+The verification may still succeed but should be checked manually.
+Reason: Already Verified
+[ACTION] Verify MinterFilterV2 contract deployment with:
+yarn hardhat verify --network goerli 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559 0x512174CE633D08764809af74d7e62670BD764F3F 0xddFfc62A975f7EBA75A877a0535755ceA18232C9
+[INFO] Deployment details written/appended to /Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/packages/contracts/deployments/minter-filter/goerli-staging/DEPLOYMENTS.md
+[INFO] Done!
+[INFO] Ensure any superAdmin migration actions are performed before proceeding to use the deployed contracts.

--- a/packages/contracts/deployments/minter-filter/goerli-staging/shared-minter-filter-deploy-config.staging.ts
+++ b/packages/contracts/deployments/minter-filter/goerli-staging/shared-minter-filter-deploy-config.staging.ts
@@ -1,0 +1,26 @@
+// This file is used to configure the deployment of shared minter filter contracts.
+// It is intended to be imported by the generic shared minter filter deployer by running
+// one of the commands similar to `deploy:shared-minter-filter:<network>.
+
+export const deployConfigDetailsArray = [
+  {
+    network: "goerli",
+    // environment is only used for metadata purposes, and is not used in the deployment process
+    // Please set to "dev", "staging", or "mainnet", as appropriate
+    environment: "staging",
+    minterFilterName: "MinterFilterV2",
+    // if you want to use an existing admin ACL, set the address here (otherwise set as undefined to deploy a new one)
+    existingAdminACL: undefined,
+    // the following can be undefined if you are using an existing admin ACL, otherwise define the Admin ACL contract name
+    // if deploying a new AdminACL
+    // @dev no reason for payment approver functionality, so don't use AdminACLV1
+    adminACLContractName: "AdminACLV0",
+    // if the following is undefined, a new core registry will be deployed.
+    // if the following is defined, the existing core registry will be used.
+    existingCoreRegistry: undefined,
+    // the following can be undefined if coreRegistryAddress is defined,
+    // but must be defined if coreRegistryAddress is undefined (since new
+    // core registry will be deployed)
+    coreRegistryContractName: "CoreRegistryV1",
+  },
+];

--- a/packages/contracts/deployments/minters/goerli-staging/DEPLOYMENTS.md
+++ b/packages/contracts/deployments/minters/goerli-staging/DEPLOYMENTS.md
@@ -1,0 +1,209 @@
+
+# Shared Minter Deployment
+
+Date: 2023-09-11T13:47:04.659Z
+
+## **Network:** goerli
+
+## **Environment:** staging
+
+**Deployment Input File:** `deployments/minters/goerli-staging/shared-minter-deploy-config.staging.ts`
+
+**MinterSetPriceV5:** https://goerli.etherscan.io/address/0x1F3DF1E177B419bC46705F8138809893497aAadF#code
+
+**Associated Minter Filter:** 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559
+
+**Deployment Args:** 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559
+
+---
+
+
+# Shared Minter Deployment
+
+Date: 2023-09-11T13:48:03.554Z
+
+## **Network:** goerli
+
+## **Environment:** staging
+
+**Deployment Input File:** `deployments/minters/goerli-staging/shared-minter-deploy-config.staging.ts`
+
+**MinterSetPriceERC20V5:** https://goerli.etherscan.io/address/0xED081222a01d33ff751F656aD45342F08089776c#code
+
+**Associated Minter Filter:** 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559
+
+**Deployment Args:** 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559
+
+---
+
+
+# Shared Minter Deployment
+
+Date: 2023-09-11T13:48:49.713Z
+
+## **Network:** goerli
+
+## **Environment:** staging
+
+**Deployment Input File:** `deployments/minters/goerli-staging/shared-minter-deploy-config.staging.ts`
+
+**MinterSetPriceHolderV5:** https://goerli.etherscan.io/address/0x8Ade3fF97302BaEBE15C540e5de1abD6427A5243#code
+
+**Associated Minter Filter:** 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559
+
+**Deployment Args:** 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559,0x00000000000076A84feF008CDAbe6409d2FE638B
+
+---
+
+
+# Shared Minter Deployment
+
+Date: 2023-09-11T13:49:38.815Z
+
+## **Network:** goerli
+
+## **Environment:** staging
+
+**Deployment Input File:** `deployments/minters/goerli-staging/shared-minter-deploy-config.staging.ts`
+
+**MinterSetPriceMerkleV5:** https://goerli.etherscan.io/address/0x6e762e7Cb478b8C2C6424d8bBfb30F782b4A445d#code
+
+**Associated Minter Filter:** 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559
+
+**Deployment Args:** 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559,0x00000000000076A84feF008CDAbe6409d2FE638B
+
+---
+
+
+# Shared Minter Deployment
+
+Date: 2023-09-11T13:50:28.428Z
+
+## **Network:** goerli
+
+## **Environment:** staging
+
+**Deployment Input File:** `deployments/minters/goerli-staging/shared-minter-deploy-config.staging.ts`
+
+**MinterSetPricePolyptychV5:** https://goerli.etherscan.io/address/0x802e6209C6Acb7B0F87aFb687E61543E3fB57DcA#code
+
+**Associated Minter Filter:** 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559
+
+**Deployment Args:** 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559,0x00000000000076A84feF008CDAbe6409d2FE638B
+
+---
+
+
+# Shared Minter Deployment
+
+Date: 2023-09-11T13:51:14.035Z
+
+## **Network:** goerli
+
+## **Environment:** staging
+
+**Deployment Input File:** `deployments/minters/goerli-staging/shared-minter-deploy-config.staging.ts`
+
+**MinterSetPricePolyptychERC20V5:** https://goerli.etherscan.io/address/0x3CB4674f510966E1105eBe5d6c5F0b7a744F3272#code
+
+**Associated Minter Filter:** 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559
+
+**Deployment Args:** 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559,0x00000000000076A84feF008CDAbe6409d2FE638B
+
+---
+
+
+# Shared Minter Deployment
+
+Date: 2023-09-11T13:52:15.777Z
+
+## **Network:** goerli
+
+## **Environment:** staging
+
+**Deployment Input File:** `deployments/minters/goerli-staging/shared-minter-deploy-config.staging.ts`
+
+**MinterDAExpV5:** https://goerli.etherscan.io/address/0x431BCE8b28Bdd25c0a8843aC4a15F4E78537C1b4#code
+
+**Associated Minter Filter:** 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559
+
+**Deployment Args:** 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559
+
+---
+
+
+# Shared Minter Deployment
+
+Date: 2023-09-11T13:53:01.106Z
+
+## **Network:** goerli
+
+## **Environment:** staging
+
+**Deployment Input File:** `deployments/minters/goerli-staging/shared-minter-deploy-config.staging.ts`
+
+**MinterDALinV5:** https://goerli.etherscan.io/address/0x6DF4DcdF43023C882287afA78aDd00672e69BCbA#code
+
+**Associated Minter Filter:** 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559
+
+**Deployment Args:** 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559
+
+---
+
+
+# Shared Minter Deployment
+
+Date: 2023-09-11T13:53:54.388Z
+
+## **Network:** goerli
+
+## **Environment:** staging
+
+**Deployment Input File:** `deployments/minters/goerli-staging/shared-minter-deploy-config.staging.ts`
+
+**MinterDAExpSettlementV3:** https://goerli.etherscan.io/address/0xD56B16436B551d9a4b28d2f9A288688d7801f316#code
+
+**Associated Minter Filter:** 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559
+
+**Deployment Args:** 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559
+
+---
+
+
+# Shared Minter Deployment
+
+Date: 2023-09-11T13:54:48.424Z
+
+## **Network:** goerli
+
+## **Environment:** staging
+
+**Deployment Input File:** `deployments/minters/goerli-staging/shared-minter-deploy-config.staging.ts`
+
+**MinterDAExpHolderV5:** https://goerli.etherscan.io/address/0x448b4F7a0981beCd5e3079088413c8E48D6DF39b#code
+
+**Associated Minter Filter:** 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559
+
+**Deployment Args:** 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559,0x00000000000076A84feF008CDAbe6409d2FE638B
+
+---
+
+
+# Shared Minter Deployment
+
+Date: 2023-09-11T13:55:38.748Z
+
+## **Network:** goerli
+
+## **Environment:** staging
+
+**Deployment Input File:** `deployments/minters/goerli-staging/shared-minter-deploy-config.staging.ts`
+
+**MinterDALinHolderV5:** https://goerli.etherscan.io/address/0x2054C63D49EF5b77739E4DC2e978c5506Ae1b883#code
+
+**Associated Minter Filter:** 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559
+
+**Deployment Args:** 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559,0x00000000000076A84feF008CDAbe6409d2FE638B
+
+---
+

--- a/packages/contracts/deployments/minters/goerli-staging/DEPLOYMENT_LOGS.log
+++ b/packages/contracts/deployments/minters/goerli-staging/DEPLOYMENT_LOGS.log
@@ -1,0 +1,70 @@
+----------------------------------------
+[INFO] Datetime of deployment: 2023-09-11T13:46:01.754Z
+[INFO] Deployment configuration file: /Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/packages/contracts/deployments/minters/goerli-staging/shared-minter-deploy-config.staging.ts
+[INFO] MinterSetPriceV5 deployed at 0x1F3DF1E177B419bC46705F8138809893497aAadF
+[INFO] MinterSetPriceV5 approved globally on minter filter at 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559
+[INFO] Verifying MinterSetPriceV5 contract deployment...
+The contract 0x1F3DF1E177B419bC46705F8138809893497aAadF has already been verified
+[INFO] MinterSetPriceV5 contract verified on Etherscan at 0x1F3DF1E177B419bC46705F8138809893497aAadF
+[INFO] Deployment details written/appended to /Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/packages/contracts/deployments/minters/goerli-staging/DEPLOYMENTS.md
+[INFO] MinterSetPriceERC20V5 deployed at 0xED081222a01d33ff751F656aD45342F08089776c
+[INFO] MinterSetPriceERC20V5 approved globally on minter filter at 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559
+[INFO] Verifying MinterSetPriceERC20V5 contract deployment...
+The contract 0xED081222a01d33ff751F656aD45342F08089776c has already been verified
+[INFO] MinterSetPriceERC20V5 contract verified on Etherscan at 0xED081222a01d33ff751F656aD45342F08089776c
+[INFO] Deployment details written/appended to /Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/packages/contracts/deployments/minters/goerli-staging/DEPLOYMENTS.md
+[INFO] MinterSetPriceHolderV5 deployed at 0x8Ade3fF97302BaEBE15C540e5de1abD6427A5243
+[INFO] MinterSetPriceHolderV5 approved globally on minter filter at 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559
+[INFO] Verifying MinterSetPriceHolderV5 contract deployment...
+The contract 0x8Ade3fF97302BaEBE15C540e5de1abD6427A5243 has already been verified
+[INFO] MinterSetPriceHolderV5 contract verified on Etherscan at 0x8Ade3fF97302BaEBE15C540e5de1abD6427A5243
+[INFO] Deployment details written/appended to /Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/packages/contracts/deployments/minters/goerli-staging/DEPLOYMENTS.md
+[INFO] MinterSetPriceMerkleV5 deployed at 0x6e762e7Cb478b8C2C6424d8bBfb30F782b4A445d
+[INFO] MinterSetPriceMerkleV5 approved globally on minter filter at 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559
+[INFO] Verifying MinterSetPriceMerkleV5 contract deployment...
+The contract 0x6e762e7Cb478b8C2C6424d8bBfb30F782b4A445d has already been verified
+[INFO] MinterSetPriceMerkleV5 contract verified on Etherscan at 0x6e762e7Cb478b8C2C6424d8bBfb30F782b4A445d
+[INFO] Deployment details written/appended to /Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/packages/contracts/deployments/minters/goerli-staging/DEPLOYMENTS.md
+[INFO] MinterSetPricePolyptychV5 deployed at 0x802e6209C6Acb7B0F87aFb687E61543E3fB57DcA
+[INFO] MinterSetPricePolyptychV5 approved globally on minter filter at 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559
+[INFO] Verifying MinterSetPricePolyptychV5 contract deployment...
+The contract 0x802e6209C6Acb7B0F87aFb687E61543E3fB57DcA has already been verified
+[INFO] MinterSetPricePolyptychV5 contract verified on Etherscan at 0x802e6209C6Acb7B0F87aFb687E61543E3fB57DcA
+[INFO] Deployment details written/appended to /Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/packages/contracts/deployments/minters/goerli-staging/DEPLOYMENTS.md
+[INFO] MinterSetPricePolyptychERC20V5 deployed at 0x3CB4674f510966E1105eBe5d6c5F0b7a744F3272
+[INFO] MinterSetPricePolyptychERC20V5 approved globally on minter filter at 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559
+[INFO] Verifying MinterSetPricePolyptychERC20V5 contract deployment...
+The contract 0x3CB4674f510966E1105eBe5d6c5F0b7a744F3272 has already been verified
+[INFO] MinterSetPricePolyptychERC20V5 contract verified on Etherscan at 0x3CB4674f510966E1105eBe5d6c5F0b7a744F3272
+[INFO] Deployment details written/appended to /Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/packages/contracts/deployments/minters/goerli-staging/DEPLOYMENTS.md
+[INFO] MinterDAExpV5 deployed at 0x431BCE8b28Bdd25c0a8843aC4a15F4E78537C1b4
+[INFO] MinterDAExpV5 approved globally on minter filter at 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559
+[INFO] Verifying MinterDAExpV5 contract deployment...
+The contract 0x431BCE8b28Bdd25c0a8843aC4a15F4E78537C1b4 has already been verified
+[INFO] MinterDAExpV5 contract verified on Etherscan at 0x431BCE8b28Bdd25c0a8843aC4a15F4E78537C1b4
+[INFO] Deployment details written/appended to /Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/packages/contracts/deployments/minters/goerli-staging/DEPLOYMENTS.md
+[INFO] MinterDALinV5 deployed at 0x6DF4DcdF43023C882287afA78aDd00672e69BCbA
+[INFO] MinterDALinV5 approved globally on minter filter at 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559
+[INFO] Verifying MinterDALinV5 contract deployment...
+The contract 0x6DF4DcdF43023C882287afA78aDd00672e69BCbA has already been verified
+[INFO] MinterDALinV5 contract verified on Etherscan at 0x6DF4DcdF43023C882287afA78aDd00672e69BCbA
+[INFO] Deployment details written/appended to /Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/packages/contracts/deployments/minters/goerli-staging/DEPLOYMENTS.md
+[INFO] MinterDAExpSettlementV3 deployed at 0xD56B16436B551d9a4b28d2f9A288688d7801f316
+[INFO] MinterDAExpSettlementV3 approved globally on minter filter at 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559
+[INFO] Verifying MinterDAExpSettlementV3 contract deployment...
+The contract 0xD56B16436B551d9a4b28d2f9A288688d7801f316 has already been verified
+[INFO] MinterDAExpSettlementV3 contract verified on Etherscan at 0xD56B16436B551d9a4b28d2f9A288688d7801f316
+[INFO] Deployment details written/appended to /Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/packages/contracts/deployments/minters/goerli-staging/DEPLOYMENTS.md
+[INFO] MinterDAExpHolderV5 deployed at 0x448b4F7a0981beCd5e3079088413c8E48D6DF39b
+[INFO] MinterDAExpHolderV5 approved globally on minter filter at 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559
+[INFO] Verifying MinterDAExpHolderV5 contract deployment...
+The contract 0x448b4F7a0981beCd5e3079088413c8E48D6DF39b has already been verified
+[INFO] MinterDAExpHolderV5 contract verified on Etherscan at 0x448b4F7a0981beCd5e3079088413c8E48D6DF39b
+[INFO] Deployment details written/appended to /Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/packages/contracts/deployments/minters/goerli-staging/DEPLOYMENTS.md
+[INFO] MinterDALinHolderV5 deployed at 0x2054C63D49EF5b77739E4DC2e978c5506Ae1b883
+[INFO] MinterDALinHolderV5 approved globally on minter filter at 0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559
+[INFO] Verifying MinterDALinHolderV5 contract deployment...
+The contract 0x2054C63D49EF5b77739E4DC2e978c5506Ae1b883 has already been verified
+[INFO] MinterDALinHolderV5 contract verified on Etherscan at 0x2054C63D49EF5b77739E4DC2e978c5506Ae1b883
+[INFO] Deployment details written/appended to /Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/packages/contracts/deployments/minters/goerli-staging/DEPLOYMENTS.md
+[INFO] Done!

--- a/packages/contracts/deployments/minters/goerli-staging/shared-minter-deploy-config.staging.ts
+++ b/packages/contracts/deployments/minters/goerli-staging/shared-minter-deploy-config.staging.ts
@@ -1,0 +1,116 @@
+// This file is used to configure the deployment of shared minter contracts.
+// It is intended to be imported by the generic shared minter deployer by running
+// one of the commands similar to `deploy:shared-minters:<network>.
+
+export const deployConfigDetailsArray = [
+  {
+    network: "goerli",
+    // environment is only used for metadata purposes, and is not used in the deployment process
+    // Please set to "dev", "staging", or "mainnet", as appropriate
+    environment: "staging",
+    minterName: "MinterSetPriceV5",
+    minterFilterAddress: "0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559",
+    // may only set to true if deploying from the MinterFilter's admin wallet
+    approveMinterGlobally: true,
+  },
+  {
+    network: "goerli",
+    // environment is only used for metadata purposes, and is not used in the deployment process
+    // Please set to "dev", "staging", or "mainnet", as appropriate
+    environment: "staging",
+    minterName: "MinterSetPriceERC20V5",
+    minterFilterAddress: "0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559",
+    // may only set to true if deploying from the MinterFilter's admin wallet
+    approveMinterGlobally: true,
+  },
+  {
+    network: "goerli",
+    // environment is only used for metadata purposes, and is not used in the deployment process
+    // Please set to "dev", "staging", or "mainnet", as appropriate
+    environment: "staging",
+    minterName: "MinterSetPriceHolderV5",
+    minterFilterAddress: "0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559",
+    // may only set to true if deploying from the MinterFilter's admin wallet
+    approveMinterGlobally: true,
+  },
+  {
+    network: "goerli",
+    // environment is only used for metadata purposes, and is not used in the deployment process
+    // Please set to "dev", "staging", or "mainnet", as appropriate
+    environment: "staging",
+    minterName: "MinterSetPriceMerkleV5",
+    minterFilterAddress: "0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559",
+    // may only set to true if deploying from the MinterFilter's admin wallet
+    approveMinterGlobally: true,
+  },
+  {
+    network: "goerli",
+    // environment is only used for metadata purposes, and is not used in the deployment process
+    // Please set to "dev", "staging", or "mainnet", as appropriate
+    environment: "staging",
+    minterName: "MinterSetPricePolyptychV5",
+    minterFilterAddress: "0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559",
+    // may only set to true if deploying from the MinterFilter's admin wallet
+    approveMinterGlobally: true,
+  },
+  {
+    network: "goerli",
+    // environment is only used for metadata purposes, and is not used in the deployment process
+    // Please set to "dev", "staging", or "mainnet", as appropriate
+    environment: "staging",
+    minterName: "MinterSetPricePolyptychERC20V5",
+    minterFilterAddress: "0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559",
+    // may only set to true if deploying from the MinterFilter's admin wallet
+    approveMinterGlobally: true,
+  },
+  {
+    network: "goerli",
+    // environment is only used for metadata purposes, and is not used in the deployment process
+    // Please set to "dev", "staging", or "mainnet", as appropriate
+    environment: "staging",
+    minterName: "MinterDAExpV5",
+    minterFilterAddress: "0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559",
+    // may only set to true if deploying from the MinterFilter's admin wallet
+    approveMinterGlobally: true,
+  },
+  {
+    network: "goerli",
+    // environment is only used for metadata purposes, and is not used in the deployment process
+    // Please set to "dev", "staging", or "mainnet", as appropriate
+    environment: "staging",
+    minterName: "MinterDALinV5",
+    minterFilterAddress: "0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559",
+    // may only set to true if deploying from the MinterFilter's admin wallet
+    approveMinterGlobally: true,
+  },
+  {
+    network: "goerli",
+    // environment is only used for metadata purposes, and is not used in the deployment process
+    // Please set to "dev", "staging", or "mainnet", as appropriate
+    environment: "staging",
+    minterName: "MinterDAExpSettlementV3",
+    minterFilterAddress: "0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559",
+    // may only set to true if deploying from the MinterFilter's admin wallet
+    approveMinterGlobally: true,
+  },
+  {
+    network: "goerli",
+    // environment is only used for metadata purposes, and is not used in the deployment process
+    // Please set to "dev", "staging", or "mainnet", as appropriate
+    environment: "staging",
+    minterName: "MinterDAExpHolderV5",
+    minterFilterAddress: "0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559",
+    // may only set to true if deploying from the MinterFilter's admin wallet
+    approveMinterGlobally: true,
+  },
+  {
+    network: "goerli",
+    // environment is only used for metadata purposes, and is not used in the deployment process
+    // Please set to "dev", "staging", or "mainnet", as appropriate
+    environment: "staging",
+    minterName: "MinterDALinHolderV5",
+    minterFilterAddress: "0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559",
+    // may only set to true if deploying from the MinterFilter's admin wallet
+    approveMinterGlobally: true,
+  },
+];

--- a/packages/contracts/deployments/randomizer/goerli-staging/DEPLOYMENTS.md
+++ b/packages/contracts/deployments/randomizer/goerli-staging/DEPLOYMENTS.md
@@ -1,0 +1,19 @@
+
+# Shared Randomizer Deployment
+
+Date: 2023-09-11T13:39:40.675Z
+
+## **Network:** goerli
+
+## **Environment:** staging
+
+**Deployment Input File:** `deployments/randomizer/goerli-staging/shared-randomizer-deploy-config.staging.ts`
+
+**SharedRandomizerV0:** https://goerli.etherscan.io/address/0x88293a3eef2516855BE0F798630e141D14333423#code
+
+**Associated pseudorandom atomic contract:** 0x2fc784a8d3Cb5B440BFf01dcCe0AD93237033812
+
+**Deployment Args:** 0x2fc784a8d3Cb5B440BFf01dcCe0AD93237033812
+
+---
+

--- a/packages/contracts/deployments/randomizer/goerli-staging/DEPLOYMENT_LOGS.log
+++ b/packages/contracts/deployments/randomizer/goerli-staging/DEPLOYMENT_LOGS.log
@@ -1,0 +1,11 @@
+----------------------------------------
+[INFO] Datetime of deployment: 2023-09-11T13:38:59.125Z
+[INFO] Deployment configuration file: /Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/packages/contracts/deployments/randomizer/goerli-staging/shared-randomizer-deploy-config.staging.ts
+[INFO] pseudorandom atomic contract PseudorandomAtomic deployed at 0x2fc784a8d3Cb5B440BFf01dcCe0AD93237033812
+[INFO] SharedRandomizerV0 deployed at 0x88293a3eef2516855BE0F798630e141D14333423
+[INFO] Verifying SharedRandomizerV0 contract deployment...
+The contract 0x88293a3eef2516855BE0F798630e141D14333423 has already been verified
+[INFO] SharedRandomizerV0 contract verified on Etherscan at 0x88293a3eef2516855BE0F798630e141D14333423
+[INFO] Deployment details written/appended to /Users/ryleyohlsen/Documents/GitHub/artblocks-contracts/packages/contracts/deployments/randomizer/goerli-staging/DEPLOYMENTS.md
+[INFO] Done!
+[INFO] No contracts were migrated to use the new shared randomizers. Each contract must be migrated individually.

--- a/packages/contracts/deployments/randomizer/goerli-staging/shared-randomizer-deploy-config.staging.ts
+++ b/packages/contracts/deployments/randomizer/goerli-staging/shared-randomizer-deploy-config.staging.ts
@@ -1,0 +1,20 @@
+// This file is used to configure the deployment of shared randomizer contracts
+// It is intended to be imported by the generic shared randomizer deployer by running
+// one of the commands similar to `deploy:shared-randomizer:<network>.
+
+export const deployConfigDetailsArray = [
+  {
+    network: "goerli",
+    // environment is only used for metadata purposes, and is not used in the deployment process
+    // Please set to "dev", "staging", or "mainnet", as appropriate
+    environment: "staging",
+    randomizerName: "SharedRandomizerV0",
+    // if the following is undefined, a new pseudorandomAtomicContract will be deployed.
+    // if the following is defined, the existing pseudorandomAtomicContract will be used.
+    pseudorandomAtomicContractAddress: undefined,
+    // the following can be undefined if pseudorandomAtomicContractAddress is defined,
+    // but must be defined if pseudorandomAtomicContractAddress is undefined (since new
+    // pseudorandomAtomicContract will be deployed)
+    pseudorandomAtomicContractName: "PseudorandomAtomic",
+  },
+];


### PR DESCRIPTION
## Description of the change

Deploy shared minter suite to staging to support initial Engine testing of the new minter suite.

A couple notes:
- migration to a new admin of shared minter filter and shared core registry will be tested, therefore deployer wallet used in these scripts is not important (expected to be updated to staging-admin wallet in a few hours)
- we are not waiting for smart contract audit completion prior to deploying the minters to staging
  - this seems appropriate to lean forward on, as we don't expect the audit to affect interfaces or basic interaction patterns of Engine partners using the new shared minter suite
