### PR TITLE
Shared Minter Suite Reentrancy Tests

### DIFF
--- a/packages/contracts/contracts/interfaces/v0.8.x/ISharedMinterSEAV0.sol
+++ b/packages/contracts/contracts/interfaces/v0.8.x/ISharedMinterSEAV0.sol
@@ -75,4 +75,9 @@ interface ISharedMinterSEAV0 {
         uint256 indexed projectId,
         address indexed coreContract
     );
+
+    function createBid(
+        uint256 _projectId,
+        address _coreContract
+    ) external payable;
 }

--- a/packages/contracts/contracts/minter-suite/Minters/MinterSetPriceERC20V5.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterSetPriceERC20V5.sol
@@ -203,6 +203,8 @@ contract MinterSetPriceERC20V5 is
      * contract `_coreContract` to be `_currencySymbol` at address
      * `_currencyAddress`.
      * Only supports ERC20 tokens - for ETH minting, use a different minter.
+     * @dev nonReentrant because no reentrant use cases, and to eliminate an
+     * entire branch of reentrancy attack vectors.
      * @param _projectId Project ID to update.
      * @param _coreContract Core contract address for the given project.
      * @param _currencySymbol Currency symbol.

--- a/packages/contracts/contracts/minter-suite/Minters/MinterSetPricePolyptychERC20V5.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterSetPricePolyptychERC20V5.sol
@@ -286,6 +286,8 @@ contract MinterSetPricePolyptychERC20V5 is
      * contract `_coreContract` to be `_currencySymbol` at address
      * `_currencyAddress`.
      * Only supports ERC20 tokens - for ETH minting, use a different minter.
+     * @dev nonReentrant because no reentrant use cases, and to eliminate an
+     * entire branch of reentrancy attack vectors.
      * @param _projectId Project ID to update.
      * @param _coreContract Core contract address for the given project.
      * @param _currencySymbol Currency symbol.

--- a/packages/contracts/contracts/mock/ReentrancyHolderMockShared.sol
+++ b/packages/contracts/contracts/mock/ReentrancyHolderMockShared.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Created By: Art Blocks Inc.
+
+import "../interfaces/v0.8.x/ISharedMinterHolderV0.sol";
+
+pragma solidity ^0.8.0;
+
+contract ReentrancyHolderMockShared {
+    uint256 public currentQtyToPurchase;
+    uint256 public currentProjectId;
+    address public currentCoreContract;
+    uint256 public currentPriceToPay;
+    address public currentOwnedNftAddress;
+    uint256 public currentOwnedNftTokenId;
+
+    /**
+        @notice This function can be called to induce controlled reentrency attacks
+        on the shared AB minter filter suite. 
+        Note that _priceToPay should be > project price per token to induce refund, 
+        making reentrency possible via fallback function.
+     */
+    function attack(
+        uint256 _qtyToPurchase,
+        address _minterContractAddress,
+        uint256 _projectId,
+        address _coreContract,
+        uint256 _priceToPay,
+        address _ownedNftAddress,
+        uint256 _ownedNftTokenId
+    ) external payable {
+        // update state variables so that receive() knows what to do
+        currentQtyToPurchase = _qtyToPurchase;
+        currentProjectId = _projectId;
+        currentCoreContract = _coreContract;
+        currentPriceToPay = _priceToPay;
+        currentOwnedNftAddress = _ownedNftAddress;
+        currentOwnedNftTokenId = _ownedNftTokenId;
+        ISharedMinterHolderV0(_minterContractAddress).purchase{
+            value: _priceToPay
+        }(_projectId, _coreContract, _ownedNftAddress, _ownedNftTokenId);
+    }
+
+    // receiver is called when minter sends refunded Ether to this contract.
+    receive() external payable {
+        // decrement num to be purchased
+        currentQtyToPurchase--;
+        if (currentQtyToPurchase > 0) {
+            // purchase again!
+            ISharedMinterHolderV0(msg.sender).purchase{
+                value: currentPriceToPay
+            }(
+                currentProjectId,
+                currentCoreContract,
+                currentOwnedNftAddress,
+                currentOwnedNftTokenId
+            );
+        }
+    }
+}

--- a/packages/contracts/contracts/mock/ReentrancyMerkleMockShared.sol
+++ b/packages/contracts/contracts/mock/ReentrancyMerkleMockShared.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Created By: Art Blocks Inc.
+
+import "../interfaces/v0.8.x/ISharedMinterMerkleV0.sol";
+
+pragma solidity ^0.8.0;
+
+contract ReentrancyMerkleMockShared {
+    uint256 public currentQtyToPurchase;
+    uint256 public currentProjectId;
+    address public currentCoreContract;
+    uint256 public currentPriceToPay;
+    bytes32[3] currentProof;
+
+    /**
+        @notice This function can be called to induce controlled reentrency attacks
+        on the shared AB minter filter suite. 
+        Note that _priceToPay should be > project price per token to induce refund, 
+        making reentrency possible via fallback function.
+     */
+    function attack(
+        uint256 _qtyToPurchase,
+        address _minterContractAddress,
+        uint256 _projectId,
+        address _coreContract,
+        uint256 _priceToPay,
+        bytes32[] memory _proof
+    ) external payable {
+        // update state variables so that receive() knows what to do
+        currentQtyToPurchase = _qtyToPurchase;
+        currentProjectId = _projectId;
+        currentCoreContract = _coreContract;
+        currentPriceToPay = _priceToPay;
+        currentProof[0] = _proof[0];
+        currentProof[1] = _proof[1];
+        currentProof[2] = _proof[2];
+        ISharedMinterMerkleV0(_minterContractAddress).purchase{
+            value: _priceToPay
+        }(_projectId, _coreContract, _proof);
+    }
+
+    // receiver is called when minter sends refunded Ether to this contract.
+    receive() external payable {
+        // decrement num to be purchased
+        currentQtyToPurchase--;
+        if (currentQtyToPurchase > 0) {
+            // rebuild _proof
+            bytes32[] memory _proof = new bytes32[](3);
+            _proof[0] = currentProof[0];
+            _proof[1] = currentProof[1];
+            _proof[2] = currentProof[2];
+            // purchase again!
+            ISharedMinterMerkleV0(msg.sender).purchase{
+                value: currentPriceToPay
+            }(currentProjectId, currentCoreContract, _proof);
+        }
+    }
+}

--- a/packages/contracts/contracts/mock/ReentrancyMockShared.sol
+++ b/packages/contracts/contracts/mock/ReentrancyMockShared.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Created By: Art Blocks Inc.
+
+import "../interfaces/v0.8.x/ISharedMinterSimplePurchaseV0.sol";
+
+pragma solidity ^0.8.0;
+
+contract ReentrancyMockShared {
+    uint256 public currentQtyToPurchase;
+    uint256 public currentProjectId;
+    address public currentCoreContract;
+    uint256 public currentPriceToPay;
+
+    /**
+        @notice This function can be called to induce controlled reentrency attacks
+        on the shared AB minter filter suite. 
+        Note that _priceToPay should be > project price per token to induce refund, 
+        making reentrency possible via fallback function.
+     */
+    function attack(
+        uint256 _qtyToPurchase,
+        address _minterContractAddress,
+        uint256 _projectId,
+        address _coreContract,
+        uint256 _priceToPay
+    ) external payable {
+        // update state variables so that receive() knows what to do
+        currentQtyToPurchase = _qtyToPurchase;
+        currentProjectId = _projectId;
+        currentCoreContract = _coreContract;
+        currentPriceToPay = _priceToPay;
+        ISharedMinterSimplePurchaseV0(_minterContractAddress).purchase{
+            value: _priceToPay
+        }(_projectId, _coreContract);
+    }
+
+    // receiver is called when minter sends refunded Ether to this contract.
+    receive() external payable {
+        // decrement num to be purchased
+        currentQtyToPurchase--;
+        if (currentQtyToPurchase > 0) {
+            // purchase again!
+            ISharedMinterSimplePurchaseV0(msg.sender).purchase{
+                value: currentPriceToPay
+            }(currentProjectId, currentCoreContract);
+        }
+    }
+}

--- a/packages/contracts/contracts/mock/ReentrancySEAMockShared.sol
+++ b/packages/contracts/contracts/mock/ReentrancySEAMockShared.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Created By: Art Blocks Inc.
+
+import "../interfaces/v0.8.x/ISharedMinterSEAV0.sol";
+
+pragma solidity ^0.8.0;
+
+contract ReentrancySEAAutoBidderMockShared {
+    uint256 public targetTokenId;
+    address public targetCoreContract;
+
+    /**
+        @notice This function can be called to induce controlled reentrency attacks
+        on AB minter filter suite. 
+        Note that _priceToPay should be > project price per token to induce refund, 
+        making reentrency possible via fallback function.
+     */
+    function attack(
+        uint256 _targetTokenId,
+        address _targetCoreContract,
+        address _minterContractAddress,
+        uint256 _initialBidValue
+    ) external payable {
+        targetTokenId = _targetTokenId;
+        targetCoreContract = _targetCoreContract;
+        ISharedMinterSEAV0(_minterContractAddress).createBid{
+            value: _initialBidValue
+        }(_targetTokenId, _targetCoreContract);
+    }
+
+    // receiver is called when minter sends refunded Ether to this contract, when outbid
+    receive() external payable {
+        // auto-rebid
+        uint256 newBidValue = (msg.value * 110) / 100;
+        ISharedMinterSEAV0(msg.sender).createBid{value: newBidValue}(
+            targetTokenId,
+            targetCoreContract
+        );
+    }
+}

--- a/packages/contracts/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/integration.test.ts
+++ b/packages/contracts/test/minter-suite-minters/SetPrice/MinterSetPriceERC20/integration.test.ts
@@ -564,6 +564,10 @@ runForEach.forEach((params) => {
           );
         });
       });
+
+      // @dev not straightforward to test reentrancy attack, because it requires an ERC20 with pre or post
+      // transfer hooks, which we have not built a mock contract for. Instead, we test that the reentrancy
+      // guard is working on other minting contracts, and assume that the implementation works here as well.
     });
 
     describe("purchaseTo", async function () {

--- a/packages/contracts/test/minter-suite-minters/SetPrice/MinterSetPricePolyptychERC20/integration.test.ts
+++ b/packages/contracts/test/minter-suite-minters/SetPrice/MinterSetPricePolyptychERC20/integration.test.ts
@@ -731,6 +731,10 @@ runForEach.forEach((params) => {
         expect(gasCostMaxInvocations < (gasCostNoMaxInvocations * 110) / 100).to
           .be.true;
       });
+
+      // @dev not straightforward to test reentrancy attack, because it requires an ERC20 with pre or post
+      // transfer hooks, which we have not built a mock contract for. Instead, we test that the reentrancy
+      // guard is working on other minting contracts, and assume that the implementation works here as well.
     });
 
     describe("purchaseTo", async function () {

--- a/packages/contracts/test/minter-suite-minters/constants.ts
+++ b/packages/contracts/test/minter-suite-minters/constants.ts
@@ -88,4 +88,5 @@ export const revertMessages = {
   reclaimingFailed: "Reclaiming failed",
   noZeroAddress: "No zero address",
   arrayLengthsMatch: "Array lengths must match",
+  refundFailed: "Refund failed",
 };


### PR DESCRIPTION
## Description of the change

Add reentrancy tests for shared minter suite.

Due to the relatively large lift associated with writing reentrancy tests, these tests are not intended to reach 100% coverage of every nonreentrant function, but are rather intended to act as a check that the OpenZeppelin implementation is working as intended on critical purchase functions. This is consistent with our testing philosophy on our legacy minter suite.

## Additional context

Earlier this year, [a compiler bug in Vyper](https://twitter.com/vyperlang/status/1685692973051498497) caused its non-reentrant implementation to not actually be effective, resulting in [loss of funds for some users across web3](https://twitter.com/CurveFinance/status/1685693202722848768). The event highlights the importance of tests like the ones implemented here, which provide a check that the as-compiled contract's non-reentrancy guard is, in fact, effective and working as intended.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205435641764802