### PR TITLE
Verify Split Totals

### DIFF
--- a/packages/contracts/contracts/libs/v0.8.x/minter-libs/SplitFundsLib.sol
+++ b/packages/contracts/contracts/libs/v0.8.x/minter-libs/SplitFundsLib.sol
@@ -122,6 +122,15 @@ library SplitFundsLib {
                 additionalPayeePrimaryAddress_
             ) = IGenArt721CoreContractV3_Engine(_coreContract)
                 .getPrimaryRevenueSplits(_projectId, _valueInWei);
+            // require total revenue split is 100%
+            require(
+                renderProviderRevenue_ +
+                    platformProviderRevenue_ +
+                    artistRevenue_ +
+                    additionalPayeePrimaryRevenue_ ==
+                    _valueInWei,
+                "Invalid revenue split totals"
+            );
             // Platform Provider payment (only possible if engine)
             if (platformProviderRevenue_ > 0) {
                 (success, ) = platformProviderAddress_.call{
@@ -141,6 +150,14 @@ library SplitFundsLib {
             ) = IGenArt721CoreContractV3(_coreContract).getPrimaryRevenueSplits(
                 _projectId,
                 _valueInWei
+            );
+            // require total revenue split is 100%
+            require(
+                renderProviderRevenue_ +
+                    artistRevenue_ +
+                    additionalPayeePrimaryRevenue_ ==
+                    _valueInWei,
+                "Invalid revenue split totals"
             );
         }
         // Render Provider / Art Blocks payment
@@ -225,6 +242,15 @@ library SplitFundsLib {
                 additionalPayeePrimaryAddress_
             ) = IGenArt721CoreContractV3_Engine(_coreContract)
                 .getPrimaryRevenueSplits(_projectId, _pricePerTokenInWei);
+            // require total revenue split is 100%
+            require(
+                renderProviderRevenue_ +
+                    platformProviderRevenue_ +
+                    artistRevenue_ +
+                    additionalPayeePrimaryRevenue_ ==
+                    _pricePerTokenInWei,
+                "Invalid revenue split totals"
+            );
             // Platform Provider payment (only possible if engine)
             if (platformProviderRevenue_ > 0) {
                 require(
@@ -248,6 +274,14 @@ library SplitFundsLib {
             ) = IGenArt721CoreContractV3(_coreContract).getPrimaryRevenueSplits(
                 _projectId,
                 _pricePerTokenInWei
+            );
+            // require total revenue split is 100%
+            require(
+                renderProviderRevenue_ +
+                    artistRevenue_ +
+                    additionalPayeePrimaryRevenue_ ==
+                    _pricePerTokenInWei,
+                "Invalid revenue split totals"
             );
         }
         // Art Blocks payment


### PR DESCRIPTION
## Description of the change

Add a check to verify split totals as prescribed by core contracts on shared minter contracts.

This is important to implement on the new (yet to be released) shared minter contracts because cross-contract interactions are now possible.

While core contracts must be allowlisted at the minter-filter level (delegated to the CoreRegistry), it is possible that, for example, a forked Engine contract unintentionally introduces a bug that results in insufficient or extra funds being split for a project. This check ensures that a core contract cannot prescribe more or less value be split than that requested by the minter.

## New Edge Case

This update introduces a new state that could result in loss of funds. Specifically:
- e.g. Settlement minter holds funds
- Artist attempts to withdraw revenues, but core contract returns incorrect total fund splits and withdrawal call reverts
- Project's revenue funds become locked due to core contract not conforming to the minter contract's requirements.
>note: purchasers will still be able to claim and collect their excess settlement funds - this only affects primary sales revenue collection

This edge case is both:
- unexpected (very unlikely that a forked contract would change prescription of splits)
- likely caught during testing, since all minters (not just settlement) minters would be affected.

Therefore, this edge case is much more preferable than the current state, where one core contract could affect available revenues on other core contracts. 

## Coverage Note

It is expected that coverage will fall in this PR because we don't have branch coverage on the checks in the PR. This is because we don't have any core contracts that intentionally return incorrect payment split values. Reviewers feel free to call out if you think we should mock a bugged contract for branch coverage here...

## Follow-on

A follow-on PR will be created that will implement a more explicit backstop that defines available funds for each project on shared minters that hold funds (e.g. Settlement minter, SEA minter)

---
Asana: https://app.asana.com/0/0/1205525270604522/f