### PR TITLE
Enforce per-project balances on shared minters that hold funds

### DIFF
--- a/packages/contracts/contracts/libs/v0.8.x/minter-libs/SettlementExpLib.sol
+++ b/packages/contracts/contracts/libs/v0.8.x/minter-libs/SettlementExpLib.sol
@@ -42,10 +42,11 @@ library SettlementExpLib {
         // In that case, the new auction will be required to have a starting
         // price less than or equal to this value, if one or more purchases
         // have been made on this minter.
-        // @dev max uint128 allows for > 1e51 ETH (much more than max supply)
+        // @dev max uint112 allows for > 1e15 ETH
+        // (one-hundred-trillion ETH is much more than max supply)
         // This enables struct packing, and is consistent with prices value
         // limits in DAExpLib's DAProjectConfig struct.
-        uint128 latestPurchasePrice;
+        uint112 latestPurchasePrice;
     }
 
     // The Receipt struct tracks the state of a user's settlement on a given
@@ -109,7 +110,7 @@ library SettlementExpLib {
     function adminEmergencyReduceSelloutPrice(
         uint256 _projectId,
         address _coreContract,
-        uint128 _newSelloutPrice,
+        uint112 _newSelloutPrice,
         SettlementAuctionProjectConfig storage _settlementAuctionProjectConfig,
         MaxInvocationsLib.MaxInvocationsProjectConfig
             storage _maxInvocationsProjectConfig,
@@ -221,7 +222,7 @@ library SettlementExpLib {
                 "Active auction not yet sold out"
             );
         } else {
-            uint128 basePrice = _DAProjectConfig.basePrice;
+            uint112 basePrice = _DAProjectConfig.basePrice;
             // base price of zero indicates no sales, since base price of zero
             // is not allowed when configuring an auction.
             // @dev no coverage else branch of following line because redundant

--- a/packages/contracts/contracts/minter-suite/Minters/MinterDAExpSettlementV3.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterDAExpSettlementV3.sol
@@ -478,6 +478,9 @@ contract MinterDAExpSettlementV3 is
             _isEngineCaches[_coreContract]
         );
         // CHECKS-EFFECTS-INTERACTIONS
+        // @dev the following function updates the project's balance and will
+        // revert if the project's balance is insufficient to cover the
+        // settlement amount (which is expected to not be possible)
         (
             bool maxInvocationsUpdated,
             bool settledPriceUpdated
@@ -752,6 +755,25 @@ contract MinterDAExpSettlementV3 is
     }
 
     /**
+     * @notice Gets the balance of ETH, in wei, currently held by the minter
+     * for project `_projectId`. This value is non-zero if not all purchasers
+     * have reclaimed their excess settlement funds, or if an artist/admin has
+     * not yet withdrawn their revenues.
+     * @param _projectId Project ID to get balance for.
+     * @param _coreContract Contract address of the core contract
+     */
+    function getProjectBalance(
+        uint256 _projectId,
+        address _coreContract
+    ) external view returns (uint256 projectBalance) {
+        SettlementExpLib.SettlementAuctionProjectConfig
+            storage _settlementAuctionProjectConfig = _settlementAuctionProjectConfigMapping[
+                _coreContract
+            ][_projectId];
+        return _settlementAuctionProjectConfig.projectBalance;
+    }
+
+    /**
      * @notice Gets if price of token is configured, price of minting a
      * token on project `_projectId`, and currency symbol and address to be
      * used as payment. Supersedes any core contract price information.
@@ -897,6 +919,11 @@ contract MinterDAExpSettlementV3 is
         uint232 newNetPosted = requiredAmountPosted.toUint232();
         _receipt.netPosted = newNetPosted;
 
+        // reduce project balance by the amount of ETH being distributed
+        // @dev underflow checked automatically in solidity ^0.8
+        _settlementAuctionProjectConfig.projectBalance -= excessSettlementFunds
+            .toUint112();
+
         emit ReceiptUpdated({
             _purchaser: msg.sender,
             _projectId: _projectId,
@@ -968,6 +995,12 @@ contract MinterDAExpSettlementV3 is
             uint232 newNetPosted = requiredAmountPosted.toUint232();
             _receipt.netPosted = newNetPosted;
 
+            // reduce project balance by the amount of ETH being distributed
+            // @dev underflow checked automatically in solidity ^0.8
+            _settlementAuctionProjectConfig
+                .projectBalance -= excessSettlementFundsForProject.toUint112();
+
+            // increase total excess settlement funds
             excessSettlementFunds += excessSettlementFundsForProject;
 
             // emit event indicating new receipt state
@@ -1068,6 +1101,9 @@ contract MinterDAExpSettlementV3 is
         });
 
         // EFFECTS
+        // update project balance
+        _settlementAuctionProjectConfig.projectBalance += msg.value.toUint112();
+
         // update the purchaser's receipt and require sufficient net payment
         SettlementExpLib.Receipt storage receipt = _receiptsMapping[msg.sender][
             _coreContract
@@ -1109,12 +1145,20 @@ contract MinterDAExpSettlementV3 is
         // @dev this logic is intentionally defined here to avoid a dependency
         // in SettlementLib on SplitFundsLib, which would increase complexity
         if (_settlementAuctionProjectConfig.auctionRevenuesCollected) {
-            // if revenues have been collected, split funds immediately.
+            // if revenues have been collected, split revenues immediately.
             // @dev note that we are guaranteed to be at auction base price,
             // since we know we didn't sellout prior to this tx.
             // note that we don't refund msg.sender here, since a separate
             // settlement mechanism is provided on this minter, unrelated to
             // msg.value
+
+            // reduce project balance by the amount of ETH being distributed
+            // @dev specifically, this is not decremented by msg.value, as
+            // msg.sender is not refunded here
+            // @dev underflow checked automatically in solidity ^0.8
+            _settlementAuctionProjectConfig.projectBalance -= currentPriceInWei
+                .toUint112();
+
             // INTERACTIONS
             bool isEngine = SplitFundsLib.isEngine(
                 _coreContract,
@@ -1131,6 +1175,7 @@ contract MinterDAExpSettlementV3 is
             // claimable by the artist and admin once auction is validated.
             // do not split revenue here since will be claimed at a later time.
             _settlementAuctionProjectConfig.numSettleableInvocations++;
+            // @dev project balance is unaffected because no funds are distributed
         }
 
         return tokenId;

--- a/packages/contracts/contracts/minter-suite/Minters/MinterDAExpSettlementV3.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterDAExpSettlementV3.sol
@@ -383,7 +383,7 @@ contract MinterDAExpSettlementV3 is
     function adminEmergencyReduceSelloutPrice(
         uint256 _projectId,
         address _coreContract,
-        uint128 _newSelloutPrice
+        uint112 _newSelloutPrice
     ) external {
         AuthLib.onlyCoreAdminACL({
             _coreContract: _coreContract,
@@ -1089,7 +1089,7 @@ contract MinterDAExpSettlementV3 is
         // @dev this is used to enforce monotonically decreasing purchase price
         // across multiple auctions
         _settlementAuctionProjectConfig.latestPurchasePrice = currentPriceInWei
-            .toUint128();
+            .toUint112();
 
         tokenId = minterFilter.mint_joo({
             _to: _to,

--- a/packages/contracts/test/minter-suite-minters/DA/DAExpSettlement/views.test.ts
+++ b/packages/contracts/test/minter-suite-minters/DA/DAExpSettlement/views.test.ts
@@ -475,6 +475,32 @@ runForEach.forEach((params) => {
       });
     });
 
+    describe("getProjectBalance", async function () {
+      it("returns zero if no purchases have been made", async function () {
+        const config = await loadFixture(_beforeEach);
+        const projectBalance = await config.minter.getProjectBalance(
+          config.projectZero,
+          config.genArt721Core.address
+        );
+        expect(projectBalance).to.equal(0);
+      });
+
+      it("returns balance after purchase", async function () {
+        const config = await loadFixture(_beforeEach);
+        await configureProjectZeroAuctionAndAdvanceToStart(config);
+        await config.minter
+          .connect(config.accounts.user)
+          .purchase(config.projectZero, config.genArt721Core.address, {
+            value: config.startingPrice,
+          });
+        const projectBalance = await config.minter.getProjectBalance(
+          config.projectZero,
+          config.genArt721Core.address
+        );
+        expect(projectBalance).to.equal(config.startingPrice);
+      });
+    });
+
     describe("getProjectExcessSettlementFunds", async function () {
       it("does not allow query of zero address", async function () {
         const config = await loadFixture(_beforeEach);


### PR DESCRIPTION
## Description of the change

Add a per-project fund balance to shared minters that hold funds to provide a redundant backstop that prevents a project from draining a minter contract's balance of ETH supplied by other projects.

## Design Choices

This is not required for baseline minter functionality, but is rather a failsafe backstop that attempts to limit damage in the case of an undiscovered bug existing in a shared minter contract. This was a recommended design change by our third party auditors, as well as by our internal AB eng team.

An efficient, struct-packed, per-project `projectBalance` is introduced. Every time the minter receives or distributes funds on behalf of a project, the value is updated. This additional value in contract storage provides an explicit place to track a project's total debit/credit to the minter, and payment operations can be reverted accordingly.

Tracking each project's balance is not implemented on minters that are not designed to hold funds, because the value would be set to zero at the end of each purchase transaction. This abstraction is useful in minters that carry a balance for projects across various core contracts.

## Special Case: SEA Minter

`MinterSEAV1` holds funds, but already implicitly tracks each project's balance in the storage value `SeaLib.SeaProjectConfig.activeAuction.currentBid`. The minter only holds funds for a single bid at a time, so tracking the current bid's value also implicitly tracks the project's total balance on the minter.

## Tests

- [x] Add tests for new view function
- [x] Add/modify tests to detect state updates to project balances:
  - after purchase (states of before and after revenues have been withdrawn)
  - after revenue withdrawal
  - after settlement collection (single project and multi-project)

## Gas Costs

The gas cost for the Settlement minter is only slightly increased as shown below. The small change would become a bigger change if struct packing had not been available.

| Minter | Baseline Avg Gas to Mint | New Avg Gas to Mint | Percent Change
| --- | --- | --- | --- |
| MinterDAExpSettlementV3 | 106_254 | 106_931 | +0.6% |

---
Asana: https://app.asana.com/0/0/1205525270604523/f