### PR TITLE
RAM: add project balance backstop

### DIFF
--- a/packages/contracts/contracts/minter-suite/Minters/MinterRAMV0.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/MinterRAMV0.sol
@@ -1185,6 +1185,26 @@ contract MinterRAMV0 is ReentrancyGuard, ISharedMinterV0, ISharedMinterRAMV0 {
     }
 
     /**
+     * Returns balance of project `projectId` on core contract `coreContract`
+     * on this minter contract.
+     * @dev project balance is a failsafe backstop used to ensure that funds
+     * from one project may never affect funds from another project on this
+     * shared minter contract.
+     * @param projectId Project ID to get the balance for
+     * @param coreContract Core contract address for the given project
+     */
+    function getProjectBalance(
+        uint256 projectId,
+        address coreContract
+    ) external view returns (uint256) {
+        return
+            RAMLib.getProjectBalance({
+                projectId: projectId,
+                coreContract: coreContract
+            });
+    }
+
+    /**
      * @notice Exists for interface conformance only.
      * Use manuallyLimitProjectMaxInvocations to set the maximum invocations
      * for a project instead.


### PR DESCRIPTION
## Description of the change

Add project balance tracking as a reasonable backstop to isolate project fund risks.

This is a similar strategy as implemented on our DA w/Settlement minter on the shared minter filter.
