### PR TITLE
Add standalone SEA testnet minter info

### DIFF
--- a/packages/contracts/deployments/engine/V3/partners/the-disruptive-gallery/DEPLOYMENTS.md
+++ b/packages/contracts/deployments/engine/V3/partners/the-disruptive-gallery/DEPLOYMENTS.md
@@ -19,6 +19,8 @@ Date: 2023-12-21T23:28:29.453Z
 
 **Minters:** All globally allowed minters on the shared minter filter contract may be used to mint tokens on the core contract.
 
+**Standalone Minter:** Serial English Auction - https://sepolia.etherscan.io/address/0x9E19D9Ec5a73E616C153E65291306F6ef1917Bdf#code
+
 **Metadata**
 
 - **Starting Project Id:** 0


### PR DESCRIPTION
## Description of the change

Included a link to the SEA minter deployed for TDG only, before available in the shared minter suite. 
