### PR TITLE
Add reclaimProjectExcessSettlementFunds to ISharedMinterDAExpSettlementV0 interface

### DIFF
--- a/packages/contracts/contracts/interfaces/v0.8.x/ISharedMinterDAExpSettlementV0.sol
+++ b/packages/contracts/contracts/interfaces/v0.8.x/ISharedMinterDAExpSettlementV0.sol
@@ -25,4 +25,23 @@ interface ISharedMinterDAExpSettlementV0 is ISharedMinterDAExpV0 {
         address coreContract,
         address walletAddress
     ) external view returns (uint256 excessSettlementFundsInWei);
+
+    /**
+     * @notice Reclaims the sender's payment above current settled price for
+     * project `projectId` on core contract `coreContract`.
+     * The current settled price is the price paid for the most recently
+     * purchased token, or the base price if the artist has withdrawn revenues
+     * after the auction reached base price.
+     * This function is callable at any point, but is expected to typically be
+     * called after auction has sold out above base price or after the auction
+     * has been purchased at base price. This minimizes the amount of gas
+     * required to send all excess settlement funds to the sender.
+     * Sends excess settlement funds to msg.sender.
+     * @param projectId Project ID to reclaim excess settlement funds on.
+     * @param coreContract Contract address of the core contract
+     */
+    function reclaimProjectExcessSettlementFunds(
+        uint256 projectId,
+        address coreContract
+    ) external;
 }


### PR DESCRIPTION
## Description of the change
This enables us to use the ISharedMinterDAExpSettlementV0 instead of a specific implementation for frontend claim experiences. 