### PR TITLE
Add forked set price minter for single core contract

### DIFF
--- a/packages/contracts/contracts/minter-suite/Minters/one-off/MinterSetPriceV5_SingleCore.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/one-off/MinterSetPriceV5_SingleCore.sol
@@ -1,0 +1,446 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Created By: Art Blocks Inc.
+
+// @dev fixed to specific solidity version for clarity and for more clear
+// source code verification purposes.
+pragma solidity 0.8.19;
+
+import {ISharedMinterSimplePurchaseV0} from "../../../interfaces/v0.8.x/ISharedMinterSimplePurchaseV0.sol";
+import {ISharedMinterV0} from "../../../interfaces/v0.8.x/ISharedMinterV0.sol";
+import {IMinterFilterV1} from "../../../interfaces/v0.8.x/IMinterFilterV1.sol";
+
+import {AuthLib} from "../../../libs/v0.8.x/AuthLib.sol";
+import {SplitFundsLib} from "../../../libs/v0.8.x/minter-libs/SplitFundsLib.sol";
+import {MaxInvocationsLib} from "../../../libs/v0.8.x/minter-libs/MaxInvocationsLib.sol";
+import {SetPriceLib} from "../../../libs/v0.8.x/minter-libs/SetPriceLib.sol";
+
+import {ReentrancyGuard} from "@openzeppelin-4.5/contracts/security/ReentrancyGuard.sol";
+
+/**
+ * @title Filtered Minter contract that allows tokens to be minted with
+ * ETH. Compatible with shared minter suite, but only allows minting with
+ * a single core contract. An updated purchaseTo function is provided to
+ * allow minting without a core contract argument.
+ * This is designed to be used with a GenArt721CoreContractV3 flagship or
+ * engine contract.
+ * This is a one-off contract that has not been audited, but is only a minor
+ * modification of the MinterSetPriceV5 contract.
+ * @author Art Blocks Inc.
+ * @notice Privileged Roles and Ownership:
+ * This contract is designed to be managed, with limited powers.
+ * Privileged roles and abilities are controlled by the project's artist, which
+ * can be modified by the core contract's Admin ACL contract. Both of these
+ * roles hold extensive power and can modify minter details.
+ * Care must be taken to ensure that the admin ACL contract and artist
+ * addresses are secure behind a multi-sig or other access control mechanism.
+ * ----------------------------------------------------------------------------
+ * The following functions are restricted to a project's artist:
+ * - updatePricePerTokenInWei
+ * - syncProjectMaxInvocationsToCore
+ * - manuallyLimitProjectMaxInvocations
+ * ----------------------------------------------------------------------------
+ * Additional admin and artist privileged roles may be described on other
+ * contracts that this minter integrates with.
+ * ----------------------------------------------------------------------------
+ * @notice Caution: While Engine projects must be registered on the Art Blocks
+ * Core Registry to assign this minter, this minter does not enforce that a
+ * project is registered when configured or queried. This is primarily for gas
+ * optimization purposes. It is, therefore, possible that fake projects may be
+ * configured on this minter, but they will not be able to mint tokens due to
+ * checks performed by this minter's Minter Filter.
+ */
+contract MinterSetPriceV5_SingleCore is
+    ReentrancyGuard,
+    ISharedMinterSimplePurchaseV0,
+    ISharedMinterV0
+{
+    /// Core contract address for this minter.
+    address public immutable coreContractAddress;
+
+    /// Minter filter address this minter interacts with
+    address public immutable minterFilterAddress;
+
+    /// Minter filter this minter may interact with.
+    IMinterFilterV1 private immutable _minterFilter;
+
+    /// minterType for this minter
+    string public constant minterType = "MinterSetPriceV5_SingleCore";
+
+    /// minter version for this minter
+    string public constant minterVersion = "v5.1.0";
+
+    // MODIFIERS
+    // @dev contract uses modifier-like internal functions instead of modifiers
+    // to reduce contract bytecode size
+    // @dev contract uses AuthLib for some modifier-like functions
+
+    /**
+     * @notice Initializes contract to be a Filtered Minter for
+     * `minterFilter` minter filter.
+     * @param minterFilter Minter filter for which this will be a
+     * filtered minter.
+     * @param coreContract The only core contract address this minter will
+     * interact with.
+     */
+    constructor(address minterFilter, address coreContract) ReentrancyGuard() {
+        minterFilterAddress = minterFilter;
+        _minterFilter = IMinterFilterV1(minterFilter);
+        coreContractAddress = coreContract;
+    }
+
+    /**
+     * @notice Manually sets the local maximum invocations of project `projectId`
+     * with the provided `maxInvocations`, checking that `maxInvocations` is less
+     * than or equal to the value of project `project_id`'s maximum invocations that is
+     * set on the core contract.
+     * @dev Note that a `maxInvocations` of 0 can only be set if the current `invocations`
+     * value is also 0 and this would also set `maxHasBeenInvoked` to true, correctly short-circuiting
+     * this minter's purchase function, avoiding extra gas costs from the core contract's maxInvocations check.
+     * @param projectId Project ID to set the maximum invocations for.
+     * @param coreContract Core contract address for the given project.
+     * @param maxInvocations Maximum invocations to set for the project.
+     */
+    function manuallyLimitProjectMaxInvocations(
+        uint256 projectId,
+        address coreContract,
+        uint24 maxInvocations
+    ) external {
+        AuthLib.onlyArtist({
+            projectId: projectId,
+            coreContract: coreContract,
+            sender: msg.sender
+        });
+        MaxInvocationsLib.manuallyLimitProjectMaxInvocations({
+            projectId: projectId,
+            coreContract: coreContract,
+            maxInvocations: maxInvocations
+        });
+    }
+
+    /**
+     * @notice Updates this minter's price per token of project `projectId`
+     * to be '_pricePerTokenInWei`, in Wei.
+     * @dev Note that it is intentionally supported here that the configured
+     * price may be explicitly set to `0`.
+     * @param projectId Project ID to set the price per token for.
+     * @param coreContract Core contract address for the given project.
+     * @param pricePerTokenInWei Price per token to set for the project, in Wei.
+     */
+    function updatePricePerTokenInWei(
+        uint256 projectId,
+        address coreContract,
+        uint248 pricePerTokenInWei
+    ) external {
+        AuthLib.onlyArtist({
+            projectId: projectId,
+            coreContract: coreContract,
+            sender: msg.sender
+        });
+        SetPriceLib.updatePricePerToken({
+            projectId: projectId,
+            coreContract: coreContract,
+            pricePerToken: pricePerTokenInWei
+        });
+
+        // for convenience, sync local max invocations to the core contract if
+        // and only if max invocations have not already been synced.
+        // @dev do not sync if max invocations have already been synced, as
+        // local max invocations could have been manually set to be
+        // intentionally less than the core contract's max invocations.
+        // @dev if local maxInvocations and maxHasBeenInvoked are both
+        // initial values, we know they have not been populated on this minter
+        if (
+            MaxInvocationsLib.maxInvocationsIsUnconfigured({
+                projectId: projectId,
+                coreContract: coreContract
+            })
+        ) {
+            MaxInvocationsLib.syncProjectMaxInvocationsToCore({
+                projectId: projectId,
+                coreContract: coreContract
+            });
+        }
+    }
+
+    /**
+     * @notice Purchase not supported - reverts.
+     */
+    function purchase(
+        uint256 /*projectId*/,
+        address /*coreContract*/
+    ) external payable returns (uint256 /*tokenId*/) {
+        revert("Purchase not supported");
+    }
+
+    /**
+     * @notice Purchases a token from project `projectId`.
+     * IMPORTANT: This forked V5 minter does not support the `coreContract`,
+     * and will attempt to mint only on the public immutable core contract
+     * address configured on this minter at `coreContractAddress`.
+     * @param projectId Project ID to mint a token on.
+     * @return tokenId Token ID of minted token
+     */
+    function purchase(
+        uint256 projectId
+    ) external payable returns (uint256 tokenId) {
+        // call the purchaseTo variant without a core contract argument
+        tokenId = purchaseTo({to: msg.sender, projectId: projectId});
+        return tokenId;
+    }
+
+    // public getter functions
+    /**
+     * @notice Gets the maximum invocations project configuration.
+     * @param projectId The ID of the project whose data needs to be fetched.
+     * @param coreContract The address of the core contract.
+     * @return MaxInvocationsLib.MaxInvocationsProjectConfig instance with the
+     * configuration data.
+     */
+    function maxInvocationsProjectConfig(
+        uint256 projectId,
+        address coreContract
+    )
+        external
+        view
+        returns (MaxInvocationsLib.MaxInvocationsProjectConfig memory)
+    {
+        return
+            MaxInvocationsLib.getMaxInvocationsProjectConfig({
+                projectId: projectId,
+                coreContract: coreContract
+            });
+    }
+
+    /**
+     * @notice Gets the set price project configuration.
+     * @param projectId The ID of the project whose data needs to be fetched.
+     * @param coreContract The address of the core contract.
+     * @return SetPriceProjectConfig struct with the fixed price project
+     * configuration data.
+     */
+    function setPriceProjectConfig(
+        uint256 projectId,
+        address coreContract
+    ) external view returns (SetPriceLib.SetPriceProjectConfig memory) {
+        return
+            SetPriceLib.getSetPriceProjectConfig({
+                projectId: projectId,
+                coreContract: coreContract
+            });
+    }
+
+    /**
+     * @notice Checks if the specified `coreContract` is a valid engine contract.
+     * @dev This function retrieves the cached value of `isEngine` from
+     * the `isEngineCache` mapping. If the cached value is already set, it
+     * returns the cached value. Otherwise, it calls the `getV3CoreIsEngineView`
+     * function from the `SplitFundsLib` library to check if `coreContract`
+     * is a valid engine contract.
+     * @dev This function will revert if the provided `coreContract` is not
+     * a valid Engine or V3 Flagship contract.
+     * @param coreContract The address of the contract to check.
+     * @return bool indicating if `coreContract` is a valid engine contract.
+     */
+    function isEngineView(address coreContract) external view returns (bool) {
+        SplitFundsLib.IsEngineCache storage isEngineCache = SplitFundsLib
+            .getIsEngineCacheConfig(coreContract);
+        if (isEngineCache.isCached) {
+            return isEngineCache.isEngine;
+        } else {
+            // @dev this calls the non-state-modifying variant of isEngine
+            return SplitFundsLib.getV3CoreIsEngineView(coreContract);
+        }
+    }
+
+    /**
+     * @notice projectId => has project reached its maximum number of
+     * invocations? Note that this returns a local cache of the core contract's
+     * state, and may be out of sync with the core contract. This is
+     * intentional, as it only enables gas optimization of mints after a
+     * project's maximum invocations has been reached. A false negative will
+     * only result in a gas cost increase, since the core contract will still
+     * enforce a maxInvocation check during minting. A false positive is not
+     * possible because the V3 core contract only allows maximum invocations
+     * to be reduced, not increased. Based on this rationale, we intentionally
+     * do not do input validation in this method as to whether or not the input
+     * @param projectId is an existing project ID.
+     * @param coreContract is an existing core contract address.
+     */
+    function projectMaxHasBeenInvoked(
+        uint256 projectId,
+        address coreContract
+    ) external view returns (bool) {
+        return
+            MaxInvocationsLib.getMaxHasBeenInvoked({
+                projectId: projectId,
+                coreContract: coreContract
+            });
+    }
+
+    /**
+     * @notice projectId => project's maximum number of invocations.
+     * Optionally synced with core contract value, for gas optimization.
+     * Note that this returns a local cache of the core contract's
+     * state, and may be out of sync with the core contract. This is
+     * intentional, as it only enables gas optimization of mints after a
+     * project's maximum invocations has been reached.
+     * @dev A number greater than the core contract's project max invocations
+     * will only result in a gas cost increase, since the core contract will
+     * still enforce a maxInvocation check during minting. A number less than
+     * the core contract's project max invocations is only possible when the
+     * project's max invocations have not been synced on this minter, since the
+     * V3 core contract only allows maximum invocations to be reduced, not
+     * increased. When this happens, the minter will enable minting, allowing
+     * the core contract to enforce the max invocations check. Based on this
+     * rationale, we intentionally do not do input validation in this method as
+     * to whether or not the input `projectId` is an existing project ID.
+     * @param projectId is an existing project ID.
+     * @param coreContract is an existing core contract address.
+     */
+    function projectMaxInvocations(
+        uint256 projectId,
+        address coreContract
+    ) external view returns (uint256) {
+        return
+            MaxInvocationsLib.getMaxInvocations({
+                projectId: projectId,
+                coreContract: coreContract
+            });
+    }
+
+    /**
+     * @notice Gets if price of token is configured, price of minting a
+     * token on project `projectId`, and currency symbol and address to be
+     * used as payment.
+     * @param projectId Project ID to get price information for
+     * @param coreContract Contract address of the core contract
+     * @return isConfigured true only if token price has been configured on
+     * this minter
+     * @return tokenPriceInWei current price of token on this minter - invalid
+     * if price has not yet been configured
+     * @return currencySymbol currency symbol for purchases of project on this
+     * minter. This minter always returns "ETH"
+     * @return currencyAddress currency address for purchases of project on
+     * this minter. This minter always returns null address, reserved for ether
+     */
+    function getPriceInfo(
+        uint256 projectId,
+        address coreContract
+    )
+        external
+        view
+        returns (
+            bool isConfigured,
+            uint256 tokenPriceInWei,
+            string memory currencySymbol,
+            address currencyAddress
+        )
+    {
+        SetPriceLib.SetPriceProjectConfig
+            storage setPriceProjectConfig_ = SetPriceLib
+                .getSetPriceProjectConfig({
+                    projectId: projectId,
+                    coreContract: coreContract
+                });
+        isConfigured = setPriceProjectConfig_.priceIsConfigured;
+        tokenPriceInWei = setPriceProjectConfig_.pricePerToken;
+        currencySymbol = "ETH";
+        currencyAddress = address(0);
+    }
+
+    /**
+     * @notice Syncs local maximum invocations of project `projectId` based on
+     * the value currently defined in the core contract.
+     * @param projectId Project ID to set the maximum invocations for.
+     * @param coreContract Core contract address for the given project.
+     * @dev this enables gas reduction after maxInvocations have been reached -
+     * core contracts shall still enforce a maxInvocation check during mint.
+     */
+    function syncProjectMaxInvocationsToCore(
+        uint256 projectId,
+        address coreContract
+    ) public {
+        AuthLib.onlyArtist({
+            projectId: projectId,
+            coreContract: coreContract,
+            sender: msg.sender
+        });
+
+        MaxInvocationsLib.syncProjectMaxInvocationsToCore({
+            projectId: projectId,
+            coreContract: coreContract
+        });
+    }
+
+    /**
+     * @notice purchaseTo with core contract arg not supported - reverts.
+     */
+    function purchaseTo(
+        address /*to*/,
+        uint256 /*projectId*/,
+        address /*coreContract*/
+    ) public payable nonReentrant returns (uint256 /*tokenId*/) {
+        revert("purchaseTo with core contract arg not supported");
+    }
+
+    /**
+     * @notice Purchases a token from project `projectId` and sets
+     * the token's owner to `to`.
+     * IMPORTANT: This forked V5 minter does not support the `coreContract`,
+     * and will attempt to mint only on the public immutable core contract
+     * address configured on this minter at `coreContractAddress`.
+     * @param to Address to be the new token's owner.
+     * @param projectId Project ID to mint a token on.
+     * @return tokenId Token ID of minted token
+     */
+    function purchaseTo(
+        address to,
+        uint256 projectId
+    ) public payable nonReentrant returns (uint256 tokenId) {
+        // load core contract address into memory
+        address coreContract = coreContractAddress;
+        // CHECKS
+        // pre-mint MaxInvocationsLib checks
+        // Note that `maxHasBeenInvoked` is only checked here to reduce gas
+        // consumption after a project has been fully minted.
+        // `maxInvocationsProjectConfig.maxHasBeenInvoked` is locally cached to reduce
+        // gas consumption, but if not in sync with the core contract's value,
+        // the core contract also enforces its own max invocation check during
+        // minting.
+        MaxInvocationsLib.preMintChecks({
+            projectId: projectId,
+            coreContract: coreContract
+        });
+
+        // pre-mint checks for set price lib, and get price per token in wei
+        // @dev price per token is loaded into memory here for gas efficiency
+        uint256 pricePerTokenInWei = SetPriceLib.preMintChecksAndGetPrice({
+            projectId: projectId,
+            coreContract: coreContract
+        });
+
+        require(msg.value >= pricePerTokenInWei, "Min value to mint req.");
+
+        // EFFECTS
+        tokenId = _minterFilter.mint_joo({
+            to: to,
+            projectId: projectId,
+            coreContract: coreContract,
+            sender: msg.sender
+        });
+
+        MaxInvocationsLib.validateMintEffectsInvocations({
+            tokenId: tokenId,
+            coreContract: coreContract
+        });
+
+        // INTERACTIONS
+        SplitFundsLib.splitFundsETHRefundSender({
+            projectId: projectId,
+            pricePerTokenInWei: pricePerTokenInWei,
+            coreContract: coreContract
+        });
+
+        return tokenId;
+    }
+}


### PR DESCRIPTION
## Description of the change

Add a forked set price minter that may be used for a single core contract.

This provides a purchase/purchaseTo interface compatible with legacy minters, utilizing the custom, one-off minter functionality of the shared minter suite.

## Tests

This contract is provided as-is, but is only slightly modified from the globally approved V5 set price shared minter.

Tests are not added for this minter fork.