### PR TITLE
Offload Flex logic to external library V3 flex bytecode size by offloading logic into external library

### DIFF
--- a/packages/contracts/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
+++ b/packages/contracts/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
@@ -13,6 +13,7 @@ import "../../interfaces/v0.8.x/IManifold.sol";
 import "@openzeppelin-4.7/contracts/access/Ownable.sol";
 import "../../libs/v0.8.x/ERC721_PackedHashSeed.sol";
 import "../../libs/v0.8.x/BytecodeStorageV1.sol";
+import {V3FlexLib} from "../../libs/v0.8.x/V3FlexLib.sol";
 import "../../libs/v0.8.x/Bytes32Strings.sol";
 
 /**
@@ -191,15 +192,9 @@ contract GenArt721CoreV3_Engine_Flex is
         string aspectRatio;
         // mapping from script index to address storing script in bytecode
         mapping(uint256 => address) scriptBytecodeAddresses;
-        bool externalAssetDependenciesLocked;
-        uint24 externalAssetDependencyCount;
-        mapping(uint256 => ExternalAssetDependency) externalAssetDependencies;
     }
 
     mapping(uint256 => Project) projects;
-
-    string public preferredIPFSGateway;
-    string public preferredArweaveGateway;
 
     /// packed struct containing project financial information
     struct ProjectFinance {
@@ -270,7 +265,7 @@ contract GenArt721CoreV3_Engine_Flex is
     bool public immutable autoApproveArtistSplitProposals;
 
     /// version & type of this core contract
-    bytes32 constant CORE_VERSION = "v3.1.4";
+    bytes32 constant CORE_VERSION = "v3.1.7";
 
     function coreVersion() external pure returns (string memory) {
         return CORE_VERSION.toString();
@@ -284,15 +279,6 @@ contract GenArt721CoreV3_Engine_Flex is
 
     /// default base URI to initialize all new project projectBaseURI values to
     string public defaultBaseURI;
-
-    function _onlyUnlockedProjectExternalAssetDependencies(
-        uint256 _projectId
-    ) internal view {
-        require(
-            !projects[_projectId].externalAssetDependenciesLocked,
-            "External dependencies locked"
-        );
-    }
 
     function _onlyNonZeroAddress(address _address) internal pure {
         require(_address != address(0), "Must input non-zero address");
@@ -426,8 +412,7 @@ contract GenArt721CoreV3_Engine_Flex is
      */
     function updateIPFSGateway(string calldata _gateway) public {
         _onlyAdminACL(this.updateIPFSGateway.selector);
-        preferredIPFSGateway = _gateway;
-        emit GatewayUpdated(ExternalAssetDependencyType.IPFS, _gateway);
+        V3FlexLib.updateIPFSGateway({_gateway: _gateway});
     }
 
     /**
@@ -435,21 +420,20 @@ contract GenArt721CoreV3_Engine_Flex is
      */
     function updateArweaveGateway(string calldata _gateway) public {
         _onlyAdminACL(this.updateArweaveGateway.selector);
-        preferredArweaveGateway = _gateway;
-        emit GatewayUpdated(ExternalAssetDependencyType.ARWEAVE, _gateway);
+        V3FlexLib.updateArweaveGateway({_gateway: _gateway});
     }
 
     /**
      * @notice Locks external asset dependencies for project `_projectId`.
      */
     function lockProjectExternalAssetDependencies(uint256 _projectId) external {
-        _onlyUnlockedProjectExternalAssetDependencies(_projectId);
         _onlyArtistOrAdminACL(
             _projectId,
             this.lockProjectExternalAssetDependencies.selector
         );
-        projects[_projectId].externalAssetDependenciesLocked = true;
-        emit ProjectExternalAssetDependenciesLocked(_projectId);
+        V3FlexLib.lockProjectExternalAssetDependencies({
+            _projectId: _projectId
+        });
     }
 
     /**
@@ -468,45 +452,16 @@ contract GenArt721CoreV3_Engine_Flex is
         string memory _cidOrData,
         ExternalAssetDependencyType _dependencyType
     ) external {
-        _onlyUnlockedProjectExternalAssetDependencies(_projectId);
         _onlyArtistOrAdminACL(
             _projectId,
             this.updateProjectExternalAssetDependency.selector
         );
-        uint24 assetCount = projects[_projectId].externalAssetDependencyCount;
-        require(_index < assetCount, "Asset index out of range");
-        ExternalAssetDependency storage _oldDependency = projects[_projectId]
-            .externalAssetDependencies[_index];
-        ExternalAssetDependencyType _oldDependencyType = _oldDependency
-            .dependencyType;
-        projects[_projectId]
-            .externalAssetDependencies[_index]
-            .dependencyType = _dependencyType;
-        // if the incoming dependency type is onchain, we need to write the data to bytecode
-        if (_dependencyType == ExternalAssetDependencyType.ONCHAIN) {
-            if (_oldDependencyType != ExternalAssetDependencyType.ONCHAIN) {
-                // we only need to set the cid to an empty string if we are replacing an offchain asset
-                // an onchain asset will already have an empty cid
-                projects[_projectId].externalAssetDependencies[_index].cid = "";
-            }
-
-            projects[_projectId]
-                .externalAssetDependencies[_index]
-                .bytecodeAddress = _cidOrData.writeToBytecode();
-            // we don't want to emit data, so we emit the cid as an empty string
-            _cidOrData = "";
-        } else {
-            projects[_projectId]
-                .externalAssetDependencies[_index]
-                .cid = _cidOrData;
-        }
-        emit ExternalAssetDependencyUpdated(
-            _projectId,
-            _index,
-            _cidOrData,
-            _dependencyType,
-            assetCount
-        );
+        V3FlexLib.updateProjectExternalAssetDependency({
+            _projectId: _projectId,
+            _index: _index,
+            _cidOrData: _cidOrData,
+            _dependencyType: _dependencyType
+        });
     }
 
     /**
@@ -520,26 +475,14 @@ contract GenArt721CoreV3_Engine_Flex is
         uint256 _projectId,
         uint256 _index
     ) external {
-        _onlyUnlockedProjectExternalAssetDependencies(_projectId);
         _onlyArtistOrAdminACL(
             _projectId,
             this.removeProjectExternalAssetDependency.selector
         );
-        uint24 assetCount = projects[_projectId].externalAssetDependencyCount;
-        require(_index < assetCount, "Asset index out of range");
-
-        uint24 lastElementIndex = assetCount - 1;
-
-        // copy last element to index of element to be removed
-        projects[_projectId].externalAssetDependencies[_index] = projects[
-            _projectId
-        ].externalAssetDependencies[lastElementIndex];
-
-        delete projects[_projectId].externalAssetDependencies[lastElementIndex];
-
-        projects[_projectId].externalAssetDependencyCount = lastElementIndex;
-
-        emit ExternalAssetDependencyRemoved(_projectId, _index);
+        V3FlexLib.removeProjectExternalAssetDependency({
+            _projectId: _projectId,
+            _index: _index
+        });
     }
 
     /**
@@ -556,34 +499,15 @@ contract GenArt721CoreV3_Engine_Flex is
         string memory _cidOrData,
         ExternalAssetDependencyType _dependencyType
     ) external {
-        _onlyUnlockedProjectExternalAssetDependencies(_projectId);
         _onlyArtistOrAdminACL(
             _projectId,
             this.addProjectExternalAssetDependency.selector
         );
-        uint24 assetCount = projects[_projectId].externalAssetDependencyCount;
-        address _bytecodeAddress = address(0);
-        // if the incoming dependency type is onchain, we need to write the data to bytecode
-        if (_dependencyType == ExternalAssetDependencyType.ONCHAIN) {
-            _bytecodeAddress = _cidOrData.writeToBytecode();
-            // we don't want to emit data, so we emit the cid as an empty string
-            _cidOrData = "";
-        }
-        ExternalAssetDependency memory asset = ExternalAssetDependency({
-            cid: _cidOrData,
-            dependencyType: _dependencyType,
-            bytecodeAddress: _bytecodeAddress
+        V3FlexLib.addProjectExternalAssetDependency({
+            _projectId: _projectId,
+            _cidOrData: _cidOrData,
+            _dependencyType: _dependencyType
         });
-        projects[_projectId].externalAssetDependencies[assetCount] = asset;
-        projects[_projectId].externalAssetDependencyCount = assetCount + 1;
-
-        emit ExternalAssetDependencyUpdated(
-            _projectId,
-            assetCount,
-            _cidOrData,
-            _dependencyType,
-            assetCount + 1
-        );
     }
 
     /**
@@ -1991,19 +1915,10 @@ contract GenArt721CoreV3_Engine_Flex is
         uint256 _projectId,
         uint256 _index
     ) external view returns (ExternalAssetDependencyWithData memory) {
-        ExternalAssetDependency storage _dependency = projects[_projectId]
-            .externalAssetDependencies[_index];
-        address _bytecodeAddress = _dependency.bytecodeAddress;
-
         return
-            ExternalAssetDependencyWithData({
-                dependencyType: _dependency.dependencyType,
-                cid: _dependency.cid,
-                bytecodeAddress: _bytecodeAddress,
-                data: (_dependency.dependencyType ==
-                    ExternalAssetDependencyType.ONCHAIN)
-                    ? _readFromBytecode(_bytecodeAddress)
-                    : ""
+            V3FlexLib.projectExternalAssetDependencyByIndex({
+                _projectId: _projectId,
+                _index: _index
             });
     }
 
@@ -2013,7 +1928,24 @@ contract GenArt721CoreV3_Engine_Flex is
     function projectExternalAssetDependencyCount(
         uint256 _projectId
     ) external view returns (uint256) {
-        return uint256(projects[_projectId].externalAssetDependencyCount);
+        return
+            V3FlexLib.projectExternalAssetDependencyCount({
+                _projectId: _projectId
+            });
+    }
+
+    /**
+     * @notice Returns the preferred IPFS gateway for the platform.
+     */
+    function preferredIPFSGateway() external view returns (string memory) {
+        return V3FlexLib.preferredIPFSGateway();
+    }
+
+    /**
+     * @notice Returns the preferred Arweave gateway for the platform.
+     */
+    function preferredArweaveGateway() external view returns (string memory) {
+        return V3FlexLib.preferredArweaveGateway();
     }
 
     /**

--- a/packages/contracts/contracts/interfaces/v0.8.x/IGenArt721CoreContractV3_Engine_Flex.sol
+++ b/packages/contracts/contracts/interfaces/v0.8.x/IGenArt721CoreContractV3_Engine_Flex.sol
@@ -63,6 +63,15 @@ interface IGenArt721CoreContractV3_Engine_Flex is
     }
 
     /**
+     * @notice Project storage that relate to Flex data.
+     */
+    struct ProjectFlex {
+        bool externalAssetDependenciesLocked;
+        uint24 externalAssetDependencyCount;
+        mapping(uint256 => ExternalAssetDependency) externalAssetDependencies;
+    }
+
+    /**
      * @notice An external asset dependency. This is a struct that contains the CID of the dependency,
      * the type of the dependency, and the address of the bytecode for this dependency.
      */

--- a/packages/contracts/contracts/libs/v0.8.x/V3FlexLib.sol
+++ b/packages/contracts/contracts/libs/v0.8.x/V3FlexLib.sol
@@ -1,0 +1,377 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Created By: Art Blocks Inc.
+
+pragma solidity ^0.8.0;
+
+import {IGenArt721CoreContractV3_Engine_Flex} from "../../interfaces/v0.8.x/IGenArt721CoreContractV3_Engine_Flex.sol";
+import {BytecodeStorageWriter, BytecodeStorageReader} from "./BytecodeStorageV1.sol";
+
+/**
+ * @title Art Blocks V3 Engine Flex - External Helper Library
+ * @notice This library is designed to offload bytecode from the V3 Engine
+ * Flex contract. It implements logic that may be accessed via DELEGATECALL for
+ * operations related to the V3 Engine Flex contract.
+ * @author Art Blocks Inc.
+ */
+
+library V3FlexLib {
+    using BytecodeStorageWriter for string;
+    // For the purposes of this implementation, due to the limited scope and
+    // existing legacy infrastructure, the library emits the events
+    // defined in IGenArt721CoreContractV3_Engine_Flex.sol. The events are
+    // manually duplicated here
+    /**
+     * @notice When an external asset dependency is updated or added, this event is emitted.
+     * @param _projectId The project ID of the project that was updated.
+     * @param _index The index of the external asset dependency that was updated.
+     * @param _cid The content ID of the external asset dependency. This is an empty string
+     * if the dependency type is ONCHAIN.
+     * @param _dependencyType The type of the external asset dependency.
+     * @param _externalAssetDependencyCount The number of external asset dependencies.
+     */
+    event ExternalAssetDependencyUpdated(
+        uint256 indexed _projectId,
+        uint256 indexed _index,
+        string _cid,
+        IGenArt721CoreContractV3_Engine_Flex.ExternalAssetDependencyType _dependencyType,
+        uint24 _externalAssetDependencyCount
+    );
+
+    /**
+     * @notice The project id `_projectId` has had an external asset dependency removed at index `_index`.
+     */
+    event ExternalAssetDependencyRemoved(
+        uint256 indexed _projectId,
+        uint256 indexed _index
+    );
+
+    /**
+     * @notice The preferred gateway for dependency type `_dependencyType` has been updated to `_gatewayAddress`.
+     */
+    event GatewayUpdated(
+        IGenArt721CoreContractV3_Engine_Flex.ExternalAssetDependencyType indexed _dependencyType,
+        string _gatewayAddress
+    );
+
+    /**
+     * @notice The project id `_projectId` has had all external asset dependencies locked.
+     * @dev This is a one-way operation. Once locked, the external asset dependencies cannot be updated.
+     */
+    event ProjectExternalAssetDependenciesLocked(uint256 indexed _projectId);
+
+    // position of V3 Flex Lib storage, using a diamond storage pattern
+    // for this library
+    bytes32 constant V3_FLEX_LIB_STORAGE_POSITION =
+        keccak256("v3flexlib.storage");
+
+    // project-level variables
+    /**
+     * Struct used to store a project's currently configured price, and
+     * whether or not the price has been configured.
+     */
+    struct FlexProjectData {
+        bool externalAssetDependenciesLocked;
+        uint24 externalAssetDependencyCount;
+        mapping(uint256 => IGenArt721CoreContractV3_Engine_Flex.ExternalAssetDependency) externalAssetDependencies;
+    }
+
+    // Diamond storage pattern is used in this library
+    struct V3FlexLibStorage {
+        string preferredIPFSGateway;
+        string preferredArweaveGateway;
+        mapping(uint256 projectId => FlexProjectData) flexProjectsData;
+    }
+
+    /**
+     * @notice Updates preferredIPFSGateway to `_gateway`.
+     */
+    function updateIPFSGateway(string calldata _gateway) external {
+        s().preferredIPFSGateway = _gateway;
+        emit GatewayUpdated(
+            IGenArt721CoreContractV3_Engine_Flex
+                .ExternalAssetDependencyType
+                .IPFS,
+            _gateway
+        );
+    }
+
+    /**
+     * @notice Updates preferredArweaveGateway to `_gateway`.
+     */
+    function updateArweaveGateway(string calldata _gateway) external {
+        s().preferredArweaveGateway = _gateway;
+        emit GatewayUpdated(
+            IGenArt721CoreContractV3_Engine_Flex
+                .ExternalAssetDependencyType
+                .ARWEAVE,
+            _gateway
+        );
+    }
+
+    /**
+     * @notice Locks external asset dependencies for project `_projectId`.
+     */
+    function lockProjectExternalAssetDependencies(uint256 _projectId) external {
+        FlexProjectData storage flexProjectData = getFlexProjectData(
+            _projectId
+        );
+        _onlyUnlockedProjectExternalAssetDependencies(flexProjectData);
+        flexProjectData.externalAssetDependenciesLocked = true;
+        emit ProjectExternalAssetDependenciesLocked(_projectId);
+    }
+
+    /**
+     * @notice Updates external asset dependency for project `_projectId`.
+     * @dev Making this an external function adds roughly 1% to the gas cost of adding an asset, but
+     * significantly reduces the bytecode of contracts using this library.
+     * @param _projectId Project to be updated.
+     * @param _index Asset index.
+     * @param _cidOrData Asset cid (Content identifier) or data string to be translated into bytecode.
+     * @param _dependencyType Asset dependency type.
+     *  0 - IPFS
+     *  1 - ARWEAVE
+     *  2 - ONCHAIN
+     */
+    function updateProjectExternalAssetDependency(
+        uint256 _projectId,
+        uint256 _index,
+        string memory _cidOrData,
+        IGenArt721CoreContractV3_Engine_Flex.ExternalAssetDependencyType _dependencyType
+    ) external {
+        FlexProjectData storage flexProjectData = getFlexProjectData(
+            _projectId
+        );
+        _onlyUnlockedProjectExternalAssetDependencies(flexProjectData);
+        uint24 assetCount = flexProjectData.externalAssetDependencyCount;
+        require(_index < assetCount, "Asset index out of range");
+        IGenArt721CoreContractV3_Engine_Flex.ExternalAssetDependency
+            storage _oldDependency = flexProjectData.externalAssetDependencies[
+                _index
+            ];
+        IGenArt721CoreContractV3_Engine_Flex.ExternalAssetDependencyType _oldDependencyType = _oldDependency
+                .dependencyType;
+        flexProjectData
+            .externalAssetDependencies[_index]
+            .dependencyType = _dependencyType;
+        // if the incoming dependency type is onchain, we need to write the data to bytecode
+        if (
+            _dependencyType ==
+            IGenArt721CoreContractV3_Engine_Flex
+                .ExternalAssetDependencyType
+                .ONCHAIN
+        ) {
+            if (
+                _oldDependencyType !=
+                IGenArt721CoreContractV3_Engine_Flex
+                    .ExternalAssetDependencyType
+                    .ONCHAIN
+            ) {
+                // we only need to set the cid to an empty string if we are replacing an offchain asset
+                // an onchain asset will already have an empty cid
+                flexProjectData.externalAssetDependencies[_index].cid = "";
+            }
+
+            flexProjectData
+                .externalAssetDependencies[_index]
+                .bytecodeAddress = _cidOrData.writeToBytecode();
+            // we don't want to emit data, so we emit the cid as an empty string
+            _cidOrData = "";
+        } else {
+            flexProjectData.externalAssetDependencies[_index].cid = _cidOrData;
+        }
+        emit ExternalAssetDependencyUpdated(
+            _projectId,
+            _index,
+            _cidOrData,
+            _dependencyType,
+            assetCount
+        );
+    }
+
+    /**
+     * @notice Removes external asset dependency for project `_projectId` at index `_index`.
+     * Removal is done by swapping the element to be removed with the last element in the array, then deleting this last element.
+     * Assets with indices higher than `_index` can have their indices adjusted as a result of this operation.
+     * @param _projectId Project to be updated.
+     * @param _index Asset index
+     */
+    function removeProjectExternalAssetDependency(
+        uint256 _projectId,
+        uint256 _index
+    ) external {
+        FlexProjectData storage flexProjectData = getFlexProjectData(
+            _projectId
+        );
+        _onlyUnlockedProjectExternalAssetDependencies(flexProjectData);
+        uint24 assetCount = flexProjectData.externalAssetDependencyCount;
+        require(_index < assetCount, "Asset index out of range");
+
+        uint24 lastElementIndex = assetCount - 1;
+
+        // copy last element to index of element to be removed
+        flexProjectData.externalAssetDependencies[_index] = flexProjectData
+            .externalAssetDependencies[lastElementIndex];
+
+        delete flexProjectData.externalAssetDependencies[lastElementIndex];
+
+        flexProjectData.externalAssetDependencyCount = lastElementIndex;
+
+        emit ExternalAssetDependencyRemoved(_projectId, _index);
+    }
+
+    /**
+     * @notice Adds external asset dependency for project `_projectId`.
+     * @dev Making this an external function adds roughly 1% to the gas cost of adding an asset, but
+     * significantly reduces the bytecode of contracts using this library.
+     * @param _projectId Project to be updated.
+     * @param _cidOrData Asset cid (Content identifier) or data string to be translated into bytecode.
+     * @param _dependencyType Asset dependency type.
+     *  0 - IPFS
+     *  1 - ARWEAVE
+     *  2 - ONCHAIN
+     */
+    function addProjectExternalAssetDependency(
+        uint256 _projectId,
+        string memory _cidOrData,
+        IGenArt721CoreContractV3_Engine_Flex.ExternalAssetDependencyType _dependencyType
+    ) external {
+        FlexProjectData storage flexProjectData = getFlexProjectData(
+            _projectId
+        );
+        _onlyUnlockedProjectExternalAssetDependencies(flexProjectData);
+        uint24 assetCount = flexProjectData.externalAssetDependencyCount;
+        address _bytecodeAddress = address(0);
+        // if the incoming dependency type is onchain, we need to write the data to bytecode
+        if (
+            _dependencyType ==
+            IGenArt721CoreContractV3_Engine_Flex
+                .ExternalAssetDependencyType
+                .ONCHAIN
+        ) {
+            _bytecodeAddress = _cidOrData.writeToBytecode();
+            // we don't want to emit data, so we emit the cid as an empty string
+            _cidOrData = "";
+        }
+        IGenArt721CoreContractV3_Engine_Flex.ExternalAssetDependency
+            memory asset = IGenArt721CoreContractV3_Engine_Flex
+                .ExternalAssetDependency({
+                    cid: _cidOrData,
+                    dependencyType: _dependencyType,
+                    bytecodeAddress: _bytecodeAddress
+                });
+        flexProjectData.externalAssetDependencies[assetCount] = asset;
+        flexProjectData.externalAssetDependencyCount = assetCount + 1;
+
+        emit ExternalAssetDependencyUpdated(
+            _projectId,
+            assetCount,
+            _cidOrData,
+            _dependencyType,
+            assetCount + 1
+        );
+    }
+
+    /**
+     * @notice Returns external asset dependency count for project `_projectId` at index `_index`.
+     */
+    function projectExternalAssetDependencyCount(
+        uint256 _projectId
+    ) external view returns (uint256) {
+        FlexProjectData storage flexProjectData = getFlexProjectData(
+            _projectId
+        );
+        return uint256(flexProjectData.externalAssetDependencyCount);
+    }
+
+    /**
+     * @notice Returns external asset dependency for project `_projectId` at index `_index`.
+     * If the dependencyType is ONCHAIN, the `data` field will contain the extrated bytecode data and `cid`
+     * will be an empty string. Conversly, for any other dependencyType, the `data` field will be an empty string
+     * and the `bytecodeAddress` will point to the zero address.
+     */
+    function projectExternalAssetDependencyByIndex(
+        uint256 _projectId,
+        uint256 _index
+    )
+        external
+        view
+        returns (
+            IGenArt721CoreContractV3_Engine_Flex.ExternalAssetDependencyWithData
+                memory
+        )
+    {
+        FlexProjectData storage flexProjectData = getFlexProjectData(
+            _projectId
+        );
+        IGenArt721CoreContractV3_Engine_Flex.ExternalAssetDependency
+            storage _dependency = flexProjectData.externalAssetDependencies[
+                _index
+            ];
+        address _bytecodeAddress = _dependency.bytecodeAddress;
+
+        return
+            IGenArt721CoreContractV3_Engine_Flex
+                .ExternalAssetDependencyWithData({
+                    dependencyType: _dependency.dependencyType,
+                    cid: _dependency.cid,
+                    bytecodeAddress: _bytecodeAddress,
+                    data: (_dependency.dependencyType ==
+                        IGenArt721CoreContractV3_Engine_Flex
+                            .ExternalAssetDependencyType
+                            .ONCHAIN)
+                        ? BytecodeStorageReader.readFromBytecode(
+                            _bytecodeAddress
+                        )
+                        : ""
+                });
+    }
+
+    /**
+     * @notice Returns the preferred IPFS gateway.
+     */
+    function preferredIPFSGateway() external view returns (string memory) {
+        return s().preferredIPFSGateway;
+    }
+
+    /**
+     * @notice Returns the preferred Arweave gateway.
+     */
+    function preferredArweaveGateway() external view returns (string memory) {
+        return s().preferredArweaveGateway;
+    }
+
+    /**
+     * @notice Loads the FlexProjectData for a given project.
+     * @param projectId Project Id to get FlexProjectData for
+     */
+    function getFlexProjectData(
+        uint256 projectId
+    ) internal view returns (FlexProjectData storage) {
+        return s().flexProjectsData[projectId];
+    }
+
+    /**
+     * @notice Return the storage struct for reading and writing. This library
+     * uses a diamond storage pattern when managing storage.
+     * @return storageStruct The V3FlexLibStorage struct.
+     */
+    function s()
+        internal
+        pure
+        returns (V3FlexLibStorage storage storageStruct)
+    {
+        bytes32 position = V3_FLEX_LIB_STORAGE_POSITION;
+        assembly ("memory-safe") {
+            storageStruct.slot := position
+        }
+    }
+
+    function _onlyUnlockedProjectExternalAssetDependencies(
+        FlexProjectData storage flexProjectData
+    ) private view {
+        require(
+            !flexProjectData.externalAssetDependenciesLocked,
+            "External dependencies locked"
+        );
+    }
+}

--- a/packages/contracts/test/core/gas-tests/GenArt721CoreV3_Engine_Flex_GasTests_FlexAssetUpload.test.ts
+++ b/packages/contracts/test/core/gas-tests/GenArt721CoreV3_Engine_Flex_GasTests_FlexAssetUpload.test.ts
@@ -1,0 +1,195 @@
+import {
+  BN,
+  constants,
+  expectEvent,
+  expectRevert,
+  balance,
+  ether,
+} from "@openzeppelin/test-helpers";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+
+import {
+  T_Config,
+  getAccounts,
+  assignDefaultConstants,
+  deployAndGet,
+  deployCoreWithMinterFilter,
+  safeAddProject,
+} from "../../util/common";
+import {
+  SQUIGGLE_SCRIPT,
+  SKULPTUUR_SCRIPT_APPROX,
+  CONTRACT_SIZE_LIMIT_SCRIPT,
+} from "../../util/example-scripts";
+
+import { Logger } from "@ethersproject/logger";
+// hide nuisance logs about event overloading
+Logger.setLogLevel(Logger.levels.ERROR);
+
+const ONCHAIN = 2; // 2 is the enum value for ONCHAIN in the GenArt721CoreV3_Engine_Flex contract
+
+/**
+ * Flex on-chain asset Gas tests for V3 Engine Flex core.
+ * Used to test the gas cost of uploading on-chain flex assets.
+ */
+describe("GenArt721CoreV3_Engine_Flex Gas Tests - Script Upload", async function () {
+  // increase test timeout from 20s to 40s due to minting numMintsToAverage tokens in beforeEach
+  this.timeout(40000);
+
+  async function _beforeEach() {
+    let config: T_Config = {
+      accounts: await getAccounts(),
+    };
+    config = await assignDefaultConstants(config);
+    // use a higher max invocations to avoid artifically low gas costs
+    config.higherMaxInvocationsForGasTests = 1000;
+    // make price artifically low to enable more mints to simulate real-world common use cases
+    config.pricePerTokenInWei = ethers.utils.parseEther("0.1");
+
+    // deploy and configure minter filter and minter
+    ({
+      genArt721Core: config.genArt721Core,
+      minterFilter: config.minterFilter,
+      randomizer: config.randomizer,
+    } = await deployCoreWithMinterFilter(
+      config,
+      "GenArt721CoreV3_Engine_Flex",
+      "MinterFilterV1"
+    ));
+
+    config.minter = await deployAndGet(config, "MinterSetPriceV2", [
+      config.genArt721Core.address,
+      config.minterFilter.address,
+    ]);
+
+    // add four projects, test on project three to directly compare to V1 core, which starts at projectId = 3
+    for (let i = 0; i < 4; i++) {
+      await safeAddProject(
+        config.genArt721Core,
+        config.accounts.deployer,
+        config.accounts.artist.address
+      );
+    }
+
+    // configure project three (to compare directly to V1 core)
+    await config.genArt721Core
+      .connect(config.accounts.deployer)
+      .toggleProjectIsActive(config.projectThree);
+    await config.genArt721Core
+      .connect(config.accounts.artist)
+      .toggleProjectIsPaused(config.projectThree);
+    await config.genArt721Core
+      .connect(config.accounts.artist)
+      .updateProjectMaxInvocations(
+        config.projectThree,
+        config.higherMaxInvocationsForGasTests
+      );
+    return config;
+  }
+
+  describe("script upload gas optimization", function () {
+    it("test gas cost of uploading Chromie Squiggle script as external flex asset[ @skip-on-coverage ]", async function () {
+      const config = await loadFixture(_beforeEach);
+      const tx = await config.genArt721Core
+        .connect(config.accounts.artist)
+        .addProjectExternalAssetDependency(
+          config.projectThree,
+          SQUIGGLE_SCRIPT,
+          ONCHAIN
+        );
+      const receipt = await tx.wait();
+      const gasUsed = receipt.gasUsed.toNumber();
+      console.log("gas used for ONCHAIN upload: ", gasUsed);
+      // also report in USD at specific conditions
+      const gasCostAt100gwei = receipt.effectiveGasPrice
+        .mul(gasUsed)
+        .toString();
+      const gasCostAt100gweiInETH = parseFloat(
+        ethers.utils.formatUnits(gasCostAt100gwei, "ether")
+      );
+      const gasCostAt100gweiAt2kUSDPerETH = gasCostAt100gweiInETH * 2e3;
+      console.log(
+        `=USD at 100gwei, $2k USD/ETH: \$${gasCostAt100gweiAt2kUSDPerETH}`
+      );
+      // ensure value was updated
+      const script0 =
+        await config.genArt721Core.projectExternalAssetDependencyByIndex(
+          config.projectThree,
+          0
+        );
+      // console.info(script0);
+      expect(script0.data).to.equal(SQUIGGLE_SCRIPT);
+    });
+
+    it("test gas cost of uploading Skulptuur script [ @skip-on-coverage ]", async function () {
+      const config = await loadFixture(_beforeEach);
+      const tx = await config.genArt721Core
+        .connect(config.accounts.artist)
+        .addProjectExternalAssetDependency(
+          config.projectThree,
+          SKULPTUUR_SCRIPT_APPROX,
+          ONCHAIN
+        );
+      const receipt = await tx.wait();
+      const gasUsed = receipt.gasUsed.toNumber();
+      console.log("gas used for script upload: ", gasUsed);
+      // also report in USD at specific conditions
+      const gasCostAt100gwei = receipt.effectiveGasPrice
+        .mul(gasUsed)
+        .toString();
+      const gasCostAt100gweiInETH = parseFloat(
+        ethers.utils.formatUnits(gasCostAt100gwei, "ether")
+      );
+      const gasCostAt100gweiAt2kUSDPerETH = gasCostAt100gweiInETH * 2e3;
+      console.log(
+        `=USD at 100gwei, $2k USD/ETH: \$${gasCostAt100gweiAt2kUSDPerETH}`
+      );
+      // ensure value was updated
+      const script0 =
+        await config.genArt721Core.projectExternalAssetDependencyByIndex(
+          config.projectThree,
+          0
+        );
+      // console.info(script0);
+      expect(script0.data).to.equal(SKULPTUUR_SCRIPT_APPROX);
+    });
+
+    it("test gas cost of uploading 23.95 KB script [ @skip-on-coverage ]", async function () {
+      const config = await loadFixture(_beforeEach);
+      const tx = await config.genArt721Core
+        .connect(config.accounts.artist)
+        .addProjectExternalAssetDependency(
+          config.projectThree,
+          CONTRACT_SIZE_LIMIT_SCRIPT,
+          ONCHAIN,
+          {
+            gasLimit: 30000000, // hard-code gas limit because ethers sometimes estimates too high
+          }
+        );
+      const receipt = await tx.wait();
+      const gasUsed = receipt.gasUsed.toNumber();
+      console.log("gas used for script upload: ", gasUsed);
+      // also report in USD at specific conditions
+      const gasCostAt100gwei = receipt.effectiveGasPrice
+        .mul(gasUsed)
+        .toString();
+      const gasCostAt100gweiInETH = parseFloat(
+        ethers.utils.formatUnits(gasCostAt100gwei, "ether")
+      );
+      const gasCostAt100gweiAt2kUSDPerETH = gasCostAt100gweiInETH * 2e3;
+      console.log(
+        `=USD at 100gwei, $2k USD/ETH: \$${gasCostAt100gweiAt2kUSDPerETH}`
+      );
+      // ensure value was updated
+      const script0 =
+        await config.genArt721Core.projectExternalAssetDependencyByIndex(
+          config.projectThree,
+          0
+        );
+      // console.info(script0);
+      expect(script0.data).to.equal(CONTRACT_SIZE_LIMIT_SCRIPT);
+    });
+  });
+});

--- a/packages/contracts/test/util/common.ts
+++ b/packages/contracts/test/util/common.ts
@@ -181,13 +181,26 @@ export async function deployWithStorageLibraryAndGet(
     .connect(config.accounts.deployer)
     .deploy(/* no args for library ever */);
 
+  let libraries = {
+    libraries: {
+      BytecodeStorageReader: library.address,
+    },
+  };
+  if (coreContractName.endsWith("Flex")) {
+    const flexLibraryFactory = await ethers.getContractFactory("V3FlexLib", {
+      libraries: { BytecodeStorageReader: library.address },
+    });
+    const flexLibrary = await flexLibraryFactory
+      .connect(config.accounts.deployer)
+      .deploy(/* no args for library ever */);
+    libraries.libraries.V3FlexLib = flexLibrary.address;
+  }
+
   // Deploy actual contract (with library linked)
   const coreContractFactory = await ethers.getContractFactory(
     coreContractName,
     {
-      libraries: {
-        BytecodeStorageReader: library.address,
-      },
+      ...libraries,
     }
   );
   return await coreContractFactory


### PR DESCRIPTION
## Description of the change

Reduce V3 Flex bytecode size by offloading logic into a new external library.

## Design

Because the V3 Flex contract is by far the closest to the 24-kb contract size limit, Flex-specific logic and data storage are offloaded into an external library. A similar pattern could be used for all project metadata, but this may be sufficient to accomplish our goals while minimizing impact across the V3 core variants.

## Performance

The following changes are good:

* ~1-mb reduced contract size for Flex V3 core
* Clearer distinction between logic associated with Flex vs. other core contract variants (e.g. data storage is separate)
* Less lines in V3 Flex contract itself

The following changes are drawbacks:
* Slightly higher costs associated with uploading on-chain assets and updating flex-related data
  * note: ~1% script upload cost increase, but this may enable on-chain compression, which reduces that by up to ~50%
 
## Alternatives

* Adding/Updating asset functions may be made internal in the library to eliminate all gas increases associated with uploading assets, but this erodes the 1-mb bytecode reduction to ~0.2-mb bytecode reduction (almost all of the benefit)
* offloading non-flex project metadata may be more lucrative at reducing bytecode size, but would have impacts in performance and complexity across more core contract variants

## Recommendation

Keep this in a draft state until we determine if it is needed and sufficiently impactful to enable other V3 core updates. 
