### PR TITLE
Remove CoreV3 25% platform primary sales limit

### DIFF
--- a/packages/contracts/contracts/GenArt721CoreV3.sol
+++ b/packages/contracts/contracts/GenArt721CoreV3.sol
@@ -103,7 +103,7 @@ contract GenArt721CoreV3 is
     uint8 constant AT_CHARACTER_CODE = uint8(bytes1("@")); // 0x40
 
     // numeric constants
-    uint256 constant ART_BLOCKS_MAX_PRIMARY_SALES_PERCENTAGE = 25; // 25%
+    // max art blocks primary sales percentage is 100%
     uint256 constant ART_BLOCKS_MAX_SECONDARY_SALES_BPS = 10000; // 10_000 BPS = 100%
     uint256 constant ARTIST_MAX_SECONDARY_ROYALTY_PERCENTAGE = 95; // 95%
 
@@ -550,11 +550,8 @@ contract GenArt721CoreV3 is
         uint256 artblocksPrimarySalesPercentage_
     ) external {
         _onlyAdminACL(this.updateArtblocksPrimarySalesPercentage.selector);
-        require(
-            artblocksPrimarySalesPercentage_ <=
-                ART_BLOCKS_MAX_PRIMARY_SALES_PERCENTAGE,
-            "Max of ART_BLOCKS_MAX_PRIMARY_SALES_PERCENTAGE percent"
-        );
+        // anything above 100 percent is illogical
+        require(artblocksPrimarySalesPercentage_ <= 100, "Max of 100 percent");
         _artblocksPrimarySalesPercentage = uint8(
             artblocksPrimarySalesPercentage_
         );

--- a/packages/contracts/contracts/explorations/GenArt721CoreV3_Explorations.sol
+++ b/packages/contracts/contracts/explorations/GenArt721CoreV3_Explorations.sol
@@ -103,7 +103,7 @@ contract GenArt721CoreV3_Explorations is
     uint8 constant AT_CHARACTER_CODE = uint8(bytes1("@")); // 0x40
 
     // numeric constants
-    uint256 constant ART_BLOCKS_MAX_PRIMARY_SALES_PERCENTAGE = 100; // 100%
+    // max art blocks primary sales percentage is 100%
     uint256 constant ART_BLOCKS_MAX_SECONDARY_SALES_BPS = 10000; // 10_000 BPS = 100%
     uint256 constant ARTIST_MAX_SECONDARY_ROYALTY_PERCENTAGE = 95; // 95%
 
@@ -556,11 +556,8 @@ contract GenArt721CoreV3_Explorations is
         uint256 artblocksPrimarySalesPercentage_
     ) external {
         _onlyAdminACL(this.updateArtblocksPrimarySalesPercentage.selector);
-        require(
-            artblocksPrimarySalesPercentage_ <=
-                ART_BLOCKS_MAX_PRIMARY_SALES_PERCENTAGE,
-            "Max of ART_BLOCKS_MAX_PRIMARY_SALES_PERCENTAGE percent"
-        );
+        // anything above 100 percent is illogical
+        require(artblocksPrimarySalesPercentage_ <= 100, "Max of 100 percent");
         _artblocksPrimarySalesPercentage = uint8(
             artblocksPrimarySalesPercentage_
         );

--- a/packages/contracts/test/core/V3/GenArt721CoreV3_ContractConfigure.test.ts
+++ b/packages/contracts/test/core/V3/GenArt721CoreV3_ContractConfigure.test.ts
@@ -90,7 +90,7 @@ for (const coreContractName of coreContractsToTest) {
       beforeEach(async function () {
         const config = await loadFixture(_beforeEach);
         if (coreContractName === "GenArt721CoreV3") {
-          config.maxABPrimarySalesPercentage = 25; // 25% maximum percentage on V3 core
+          config.maxABPrimarySalesPercentage = 100; // 100% maximum percentage on V3 core
         } else if (coreContractName === "GenArt721CoreV3_Explorations") {
           config.maxABPrimarySalesPercentage = 100; // 100% maximum percentage on V3 core explorations
         } else if (coreContractName.includes("GenArt721CoreV3_Engine")) {
@@ -163,7 +163,7 @@ for (const coreContractName of coreContractsToTest) {
               .updateArtblocksPrimarySalesPercentage(
                 config.maxABPrimarySalesPercentage + 1
               ),
-            "Max of ART_BLOCKS_MAX_PRIMARY_SALES_PERCENTAGE percent"
+            "Max of 100 percent"
           );
         });
 


### PR DESCRIPTION
## Description of the change

Remove the 25% platform limit on primary sales for V3 core due to operational benefit.

This is unrelated to studio work, but just removes a potential footgun from future contracts.
