### PR TITLE
Allow artist name change after lock

### DIFF
--- a/packages/contracts/contracts/GenArt721CoreV3.sol
+++ b/packages/contracts/contracts/GenArt721CoreV3.sol
@@ -896,6 +896,8 @@ contract GenArt721CoreV3 is
     /**
      * @notice Updates artist name for project `_projectId` to be
      * `_projectArtistName`.
+     * @dev allows updates even after project is locked, due to our experiences
+     * of artist name changes being requested post-lock.
      * @param _projectId Project ID.
      * @param _projectArtistName New artist name.
      */
@@ -903,7 +905,6 @@ contract GenArt721CoreV3 is
         uint256 _projectId,
         string memory _projectArtistName
     ) external {
-        _onlyUnlocked(_projectId);
         _onlyArtistOrAdminACL(
             _projectId,
             this.updateProjectArtistName.selector

--- a/packages/contracts/contracts/engine/V3/GenArt721CoreV3_Engine.sol
+++ b/packages/contracts/contracts/engine/V3/GenArt721CoreV3_Engine.sol
@@ -962,7 +962,6 @@ contract GenArt721CoreV3_Engine is
         uint256 _projectId,
         string memory _projectArtistName
     ) external {
-        _onlyUnlocked(_projectId);
         _onlyArtistOrAdminACL(
             _projectId,
             this.updateProjectArtistName.selector

--- a/packages/contracts/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
+++ b/packages/contracts/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
@@ -1148,7 +1148,6 @@ contract GenArt721CoreV3_Engine_Flex is
         uint256 _projectId,
         string memory _projectArtistName
     ) external {
-        _onlyUnlocked(_projectId);
         _onlyArtistOrAdminACL(
             _projectId,
             this.updateProjectArtistName.selector

--- a/packages/contracts/contracts/explorations/GenArt721CoreV3_Explorations.sol
+++ b/packages/contracts/contracts/explorations/GenArt721CoreV3_Explorations.sol
@@ -909,7 +909,6 @@ contract GenArt721CoreV3_Explorations is
         uint256 _projectId,
         string memory _projectArtistName
     ) external {
-        _onlyUnlocked(_projectId);
         _onlyArtistOrAdminACL(
             _projectId,
             this.updateProjectArtistName.selector


### PR DESCRIPTION
## Description of the change

Update all V3 contracts to allow artist name change after lock.

This is due to operational experience, and was a request made by artists.
