### PR TITLE
Allow admin to change artist name after lock

### DIFF
--- a/packages/contracts/contracts/GenArt721CoreV3.sol
+++ b/packages/contracts/contracts/GenArt721CoreV3.sol
@@ -893,6 +893,8 @@ contract GenArt721CoreV3 is
     /**
      * @notice Updates artist name for project `_projectId` to be
      * `_projectArtistName`.
+     * @dev allows admin to update after project is locked, due to our
+     * experiences of artist name changes being requested post-lock.
      * @param _projectId Project ID.
      * @param _projectArtistName New artist name.
      */
@@ -900,10 +902,17 @@ contract GenArt721CoreV3 is
         uint256 _projectId,
         string memory _projectArtistName
     ) external {
-        _onlyUnlocked(_projectId);
-        _onlyArtistOrAdminACL(
-            _projectId,
-            this.updateProjectArtistName.selector
+        // checks
+        // if unlocked, only artist may update, if locked, only admin may update
+        require(
+            _projectUnlocked(_projectId)
+                ? msg.sender == projectIdToFinancials[_projectId].artistAddress
+                : adminACLAllowed(
+                    msg.sender,
+                    address(this),
+                    this.updateProjectArtistName.selector
+                ),
+            "Only artist, owner when locked"
         );
         _onlyNonEmptyString(_projectArtistName);
         projects[_projectId].artist = _projectArtistName;
@@ -964,7 +973,7 @@ contract GenArt721CoreV3 is
                     address(this),
                     this.updateProjectDescription.selector
                 ),
-            "Only artist when unlocked, owner when locked"
+            "Only artist, owner when locked"
         );
         // effects
         // store description in contract bytecode, replacing reference address from

--- a/packages/contracts/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
+++ b/packages/contracts/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
@@ -1065,6 +1065,8 @@ contract GenArt721CoreV3_Engine_Flex is
     /**
      * @notice Updates artist name for project `_projectId` to be
      * `_projectArtistName`.
+     * @dev allows admin to update after project is locked, due to our
+     * experiences of artist name changes being requested post-lock.
      * @param _projectId Project ID.
      * @param _projectArtistName New artist name.
      */
@@ -1072,10 +1074,16 @@ contract GenArt721CoreV3_Engine_Flex is
         uint256 _projectId,
         string memory _projectArtistName
     ) external {
-        _onlyUnlocked(_projectId);
-        _onlyArtistOrAdminACL(
-            _projectId,
-            this.updateProjectArtistName.selector
+        // if unlocked, only artist may update, if locked, only admin may update
+        require(
+            _projectUnlocked(_projectId)
+                ? msg.sender == projectIdToFinancials[_projectId].artistAddress
+                : adminACLAllowed(
+                    msg.sender,
+                    address(this),
+                    this.updateProjectArtistName.selector
+                ),
+            "Only artist, owner when locked"
         );
         _onlyNonEmptyString(_projectArtistName);
         projects[_projectId].artist = _projectArtistName;
@@ -1136,7 +1144,7 @@ contract GenArt721CoreV3_Engine_Flex is
                     address(this),
                     this.updateProjectDescription.selector
                 ),
-            "Only artist when unlocked, owner when locked"
+            "Only artist, owner when locked"
         );
         // effects
         // store description in contract bytecode, replacing reference address from

--- a/packages/contracts/contracts/explorations/GenArt721CoreV3_Explorations.sol
+++ b/packages/contracts/contracts/explorations/GenArt721CoreV3_Explorations.sol
@@ -899,6 +899,8 @@ contract GenArt721CoreV3_Explorations is
     /**
      * @notice Updates artist name for project `_projectId` to be
      * `_projectArtistName`.
+     * @dev allows admin to update after project is locked, due to our
+     * experiences of artist name changes being requested post-lock.
      * @param _projectId Project ID.
      * @param _projectArtistName New artist name.
      */
@@ -906,10 +908,16 @@ contract GenArt721CoreV3_Explorations is
         uint256 _projectId,
         string memory _projectArtistName
     ) external {
-        _onlyUnlocked(_projectId);
-        _onlyArtistOrAdminACL(
-            _projectId,
-            this.updateProjectArtistName.selector
+        // if unlocked, only artist may update, if locked, only admin may update
+        require(
+            _projectUnlocked(_projectId)
+                ? msg.sender == projectIdToFinancials[_projectId].artistAddress
+                : adminACLAllowed(
+                    msg.sender,
+                    address(this),
+                    this.updateProjectArtistName.selector
+                ),
+            "Only artist, owner when locked"
         );
         _onlyNonEmptyString(_projectArtistName);
         projects[_projectId].artist = _projectArtistName;
@@ -970,7 +978,7 @@ contract GenArt721CoreV3_Explorations is
                     address(this),
                     this.updateProjectDescription.selector
                 ),
-            "Only artist when unlocked, owner when locked"
+            "Only artist, owner when locked"
         );
         // effects
         // store description in contract bytecode, replacing reference address from

--- a/packages/contracts/test/core/V3/GenArt721CoreV3_AdminACLRequests.test.ts
+++ b/packages/contracts/test/core/V3/GenArt721CoreV3_AdminACLRequests.test.ts
@@ -242,6 +242,14 @@ for (const coreContractName of coreContractsToTest) {
 
       it("updateProjectArtistName", async function () {
         const config = await loadFixture(_beforeEach);
+        // admin may only call when in a locked state
+        await mintProjectUntilRemaining(
+          config,
+          config.projectZero,
+          config.accounts.artist,
+          0
+        );
+        await advanceEVMByTime(FOUR_WEEKS + 1);
         await validateAdminACLRequest(config, "updateProjectArtistName", [
           config.projectZero,
           "New Artist Name",

--- a/packages/contracts/test/core/V3/GenArt721CoreV3_Events.test.ts
+++ b/packages/contracts/test/core/V3/GenArt721CoreV3_Events.test.ts
@@ -483,7 +483,7 @@ for (const coreContractName of coreContractsToTest) {
         // emits expected event arg(s)
         await expect(
           config.genArt721Core
-            .connect(config.accounts.deployer)
+            .connect(config.accounts.artist)
             .updateProjectArtistName(config.projectZero, "new artist name")
         )
           .to.emit(config.genArt721Core, "ProjectUpdated")

--- a/packages/contracts/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
+++ b/packages/contracts/test/core/V3/GenArt721CoreV3_ProjectConfigure.test.ts
@@ -280,7 +280,7 @@ for (const coreContractName of coreContractsToTest) {
     });
 
     describe("updateProjectDescription", function () {
-      const errorMessage = "Only artist when unlocked, owner when locked";
+      const errorMessage = "Only artist, owner when locked";
       it("owner cannot update when unlocked", async function () {
         const config = await loadFixture(_beforeEach);
         await expectRevert(
@@ -341,7 +341,6 @@ for (const coreContractName of coreContractsToTest) {
     });
 
     describe("updateProjectName", function () {
-      const errorMessage = "Only artist when unlocked, owner when locked";
       it("owner can update when unlocked", async function () {
         const config = await loadFixture(_beforeEach);
         await config.genArt721Core
@@ -389,8 +388,72 @@ for (const coreContractName of coreContractsToTest) {
       });
     });
 
+    describe("updateProjectArtistName", function () {
+      it("owner can not update when unlocked", async function () {
+        const config = await loadFixture(_beforeEach);
+        await expectRevert(
+          config.genArt721Core
+            .connect(config.accounts.deployer)
+            .updateProjectArtistName(config.projectZero, "new name"),
+          "Only artist, owner when locked"
+        );
+      });
+
+      it("artist can update when unlocked", async function () {
+        const config = await loadFixture(_beforeEach);
+        await config.genArt721Core
+          .connect(config.accounts.artist)
+          .updateProjectArtistName(config.projectZero, "new name");
+        // expect view to be updated
+        const projectDetails = await config.genArt721Core
+          .connect(config.accounts.user)
+          .projectDetails(config.projectZero);
+        expect(projectDetails.artist).to.equal("new name");
+      });
+
+      it("owner can update when locked", async function () {
+        const config = await loadFixture(_beforeEach);
+        await mintProjectUntilRemaining(
+          config,
+          config.projectZero,
+          config.accounts.artist,
+          0
+        );
+        await advanceEVMByTime(FOUR_WEEKS + 1);
+        await config.genArt721Core
+          .connect(config.accounts.deployer)
+          .updateProjectArtistName(config.projectZero, "new artist");
+      });
+
+      it("artist can not update when locked", async function () {
+        const config = await loadFixture(_beforeEach);
+        await mintProjectUntilRemaining(
+          config,
+          config.projectZero,
+          config.accounts.artist,
+          0
+        );
+        await advanceEVMByTime(FOUR_WEEKS + 1);
+        await expectRevert(
+          config.genArt721Core
+            .connect(config.accounts.artist)
+            .updateProjectArtistName(config.projectZero, "new artist"),
+          "Only artist, owner when locked"
+        );
+      });
+
+      it("user cannot update", async function () {
+        const config = await loadFixture(_beforeEach);
+        await expectRevert(
+          config.genArt721Core
+            .connect(config.accounts.user)
+            .updateProjectArtistName(config.projectZero, "new artist"),
+          "Only artist, owner when locked"
+        );
+      });
+    });
+
     describe("updateProjectScriptType", function () {
-      const errorMessage = "Only artist when unlocked, owner when locked";
       it("owner can update when unlocked", async function () {
         const config = await loadFixture(_beforeEach);
         await config.genArt721Core


### PR DESCRIPTION
## Description of the change

Allow admin to change artist name after a project is locked.

This aligns the permissions of updating artist name with those on updating project description, and was a requested feature from previous artists.

## Tests

Tests are added for coverage of the new functionality.
