### PR TITLE
V3 core - use enums in event fields

### DIFF
--- a/packages/contracts/contracts/engine/V3/GenArt721CoreV3_Engine.sol
+++ b/packages/contracts/contracts/engine/V3/GenArt721CoreV3_Engine.sol
@@ -115,50 +115,6 @@ contract GenArt721CoreV3_Engine is
     uint256 constant MAX_PROVIDER_SECONDARY_SALES_BPS = 10000; // 10_000 BPS = 100%
     uint256 constant ARTIST_MAX_SECONDARY_ROYALTY_PERCENTAGE = 95; // 95%
 
-    // This contract emits generic events that contain fields that indicate
-    // which parameter has been updated. This is sufficient for application
-    // state management, while also simplifying the contract and indexing code.
-    // This was done as an alternative to having custom events that emit what
-    // field-values have changed for each event, given that changed values can
-    // be introspected by indexers due to the design of this smart contract
-    // exposing these state changes via publicly viewable fields.
-    //
-    // The following fields are used to indicate which contract-level parameter
-    // has been updated in the `PlatformUpdated` event:
-    bytes32 constant FIELD_NEXT_PROJECT_ID = "nextProjectId";
-    bytes32 constant FIELD_NEW_PROJECTS_FORBIDDEN = "newProjectsForbidden";
-    bytes32 constant FIELD_DEFAULT_BASE_URI = "defaultBaseURI";
-    bytes32 constant FIELD_RANDOMIZER_ADDRESS = "randomizerAddress";
-    bytes32 constant FIELD_NEXT_CORE_CONTRACT = "nextCoreContract";
-    bytes32 constant FIELD_ARTBLOCKS_DEPENDENCY_REGISTRY_ADDRESS =
-        "dependencyRegistryAddress";
-    bytes32 constant FIELD_ARTBLOCKS_ON_CHAIN_GENERATOR_ADDRESS =
-        "onChainGeneratorAddress";
-    bytes32 constant FIELD_PROVIDER_SALES_ADDRESSES = "providerSalesAddresses";
-    bytes32 constant FIELD_PROVIDER_PRIMARY_SALES_PERCENTAGES =
-        "providerPrimaryPercentages";
-    bytes32 constant FIELD_PROVIDER_SECONDARY_SALES_BPS =
-        "providerSecondaryBPS";
-    // The following fields are used to indicate which project-level parameter
-    // has been updated in the `ProjectUpdated` event:
-    bytes32 constant FIELD_PROJECT_COMPLETED = "completed";
-    bytes32 constant FIELD_PROJECT_ACTIVE = "active";
-    bytes32 constant FIELD_PROJECT_ARTIST_ADDRESS = "artistAddress";
-    bytes32 constant FIELD_PROJECT_PAUSED = "paused";
-    bytes32 constant FIELD_PROJECT_CREATED = "created";
-    bytes32 constant FIELD_PROJECT_NAME = "name";
-    bytes32 constant FIELD_PROJECT_ARTIST_NAME = "artistName";
-    bytes32 constant FIELD_PROJECT_SECONDARY_MARKET_ROYALTY_PERCENTAGE =
-        "royaltyPercentage";
-    bytes32 constant FIELD_PROJECT_DESCRIPTION = "description";
-    bytes32 constant FIELD_PROJECT_WEBSITE = "website";
-    bytes32 constant FIELD_PROJECT_LICENSE = "license";
-    bytes32 constant FIELD_PROJECT_MAX_INVOCATIONS = "maxInvocations";
-    bytes32 constant FIELD_PROJECT_SCRIPT = "script";
-    bytes32 constant FIELD_PROJECT_SCRIPT_TYPE = "scriptType";
-    bytes32 constant FIELD_PROJECT_ASPECT_RATIO = "aspectRatio";
-    bytes32 constant FIELD_PROJECT_BASE_URI = "baseURI";
-
     /// pointer to next core contract associated with this contract
     address public nextCoreContract;
 
@@ -409,7 +365,9 @@ contract GenArt721CoreV3_Engine is
         );
         // initialize next project ID
         _nextProjectId = _startingProjectId;
-        emit PlatformUpdated(FIELD_NEXT_PROJECT_ID);
+        emit PlatformUpdated(
+            bytes32(uint256(PlatformUpdatedFields.FIELD_NEXT_PROJECT_ID))
+        );
         // @dev follow-on action: This contract does not self-register. A core
         // registry owner must register contract in a subsequent call.
     }
@@ -554,7 +512,9 @@ contract GenArt721CoreV3_Engine is
     function updateNextCoreContract(address _nextCoreContract) external {
         _onlyAdminACL(this.updateNextCoreContract.selector);
         nextCoreContract = _nextCoreContract;
-        emit PlatformUpdated(FIELD_NEXT_CORE_CONTRACT);
+        emit PlatformUpdated(
+            bytes32(uint256(PlatformUpdatedFields.FIELD_NEXT_CORE_CONTRACT))
+        );
     }
 
     /**
@@ -568,7 +528,14 @@ contract GenArt721CoreV3_Engine is
         _onlyAdminACL(this.updateArtblocksDependencyRegistryAddress.selector);
         _onlyNonZeroAddress(_artblocksDependencyRegistryAddress);
         artblocksDependencyRegistryAddress = _artblocksDependencyRegistryAddress;
-        emit PlatformUpdated(FIELD_ARTBLOCKS_DEPENDENCY_REGISTRY_ADDRESS);
+        emit PlatformUpdated(
+            bytes32(
+                uint256(
+                    PlatformUpdatedFields
+                        .FIELD_ARTBLOCKS_DEPENDENCY_REGISTRY_ADDRESS
+                )
+            )
+        );
     }
 
     /**
@@ -581,7 +548,14 @@ contract GenArt721CoreV3_Engine is
         _onlyAdminACL(this.updateArtblocksOnChainGeneratorAddress.selector);
         _onlyNonZeroAddress(_artblocksOnChainGeneratorAddress);
         artblocksOnChainGeneratorAddress = _artblocksOnChainGeneratorAddress;
-        emit PlatformUpdated(FIELD_ARTBLOCKS_ON_CHAIN_GENERATOR_ADDRESS);
+        emit PlatformUpdated(
+            bytes32(
+                uint256(
+                    PlatformUpdatedFields
+                        .FIELD_ARTBLOCKS_ON_CHAIN_GENERATOR_ADDRESS
+                )
+            )
+        );
     }
 
     /**
@@ -642,7 +616,14 @@ contract GenArt721CoreV3_Engine is
         _platformProviderPrimarySalesPercentage = uint8(
             platformProviderPrimarySalesPercentage_
         );
-        emit PlatformUpdated(FIELD_PROVIDER_PRIMARY_SALES_PERCENTAGES);
+        emit PlatformUpdated(
+            bytes32(
+                uint256(
+                    PlatformUpdatedFields
+                        .FIELD_PROVIDER_PRIMARY_SALES_PERCENTAGES
+                )
+            )
+        );
     }
 
     /**
@@ -672,7 +653,13 @@ contract GenArt721CoreV3_Engine is
         );
         renderProviderSecondarySalesBPS = _renderProviderSecondarySalesBPS;
         platformProviderSecondarySalesBPS = _platformProviderSecondarySalesBPS;
-        emit PlatformUpdated(FIELD_PROVIDER_SECONDARY_SALES_BPS);
+        emit PlatformUpdated(
+            bytes32(
+                uint256(
+                    PlatformUpdatedFields.FIELD_PROVIDER_SECONDARY_SALES_BPS
+                )
+            )
+        );
     }
 
     /**
@@ -704,7 +691,10 @@ contract GenArt721CoreV3_Engine is
         _onlyAdminACL(this.toggleProjectIsActive.selector);
         _onlyValidProjectId(_projectId);
         projects[_projectId].active = !projects[_projectId].active;
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_ACTIVE);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_ACTIVE))
+        );
     }
 
     /**
@@ -926,7 +916,10 @@ contract GenArt721CoreV3_Engine is
         );
         _onlyNonZeroAddress(_artistAddress);
         projectIdToFinancials[_projectId].artistAddress = _artistAddress;
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_ARTIST_ADDRESS);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_ARTIST_ADDRESS))
+        );
     }
 
     /**
@@ -936,7 +929,10 @@ contract GenArt721CoreV3_Engine is
     function toggleProjectIsPaused(uint256 _projectId) external {
         _onlyArtist(_projectId);
         projects[_projectId].paused = !projects[_projectId].paused;
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_PAUSED);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_PAUSED))
+        );
     }
 
     /**
@@ -961,7 +957,10 @@ contract GenArt721CoreV3_Engine is
         projects[projectId].projectBaseURI = defaultBaseURI;
 
         _nextProjectId = uint248(projectId) + 1;
-        emit ProjectUpdated(projectId, FIELD_PROJECT_CREATED);
+        emit ProjectUpdated(
+            projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_CREATED))
+        );
     }
 
     /**
@@ -986,7 +985,10 @@ contract GenArt721CoreV3_Engine is
         _onlyArtistOrAdminACL(_projectId, this.updateProjectName.selector);
         _onlyNonEmptyString(_projectName);
         projects[_projectId].name = _projectName;
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_NAME);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_NAME))
+        );
     }
 
     /**
@@ -1014,7 +1016,10 @@ contract GenArt721CoreV3_Engine is
         );
         _onlyNonEmptyString(_projectArtistName);
         projects[_projectId].artist = _projectArtistName;
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_ARTIST_NAME);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_ARTIST_NAME))
+        );
     }
 
     /**
@@ -1041,7 +1046,12 @@ contract GenArt721CoreV3_Engine is
             .secondaryMarketRoyaltyPercentage = uint8(_secondMarketRoyalty);
         emit ProjectUpdated(
             _projectId,
-            FIELD_PROJECT_SECONDARY_MARKET_ROYALTY_PERCENTAGE
+            bytes32(
+                uint256(
+                    ProjectUpdatedFields
+                        .FIELD_PROJECT_SECONDARY_MARKET_ROYALTY_PERCENTAGE
+                )
+            )
         );
     }
 
@@ -1078,7 +1088,10 @@ contract GenArt721CoreV3_Engine is
         // the old storage description with the newly created one
         projects[_projectId].descriptionAddress = _projectDescription
             .writeToBytecode();
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_DESCRIPTION);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_DESCRIPTION))
+        );
     }
 
     /**
@@ -1093,7 +1106,10 @@ contract GenArt721CoreV3_Engine is
     ) external {
         _onlyArtist(_projectId);
         projects[_projectId].website = _projectWebsite;
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_WEBSITE);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_WEBSITE))
+        );
     }
 
     /**
@@ -1109,7 +1125,10 @@ contract GenArt721CoreV3_Engine is
         _onlyArtistOrAdminACL(_projectId, this.updateProjectLicense.selector);
         _onlyNonEmptyString(_projectLicense);
         projects[_projectId].license = _projectLicense;
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_LICENSE);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_LICENSE))
+        );
     }
 
     /**
@@ -1136,7 +1155,10 @@ contract GenArt721CoreV3_Engine is
         require(_maxInvocations >= _invocations, "Only gte invocations");
         // EFFECTS
         project.maxInvocations = _maxInvocations;
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_MAX_INVOCATIONS);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_MAX_INVOCATIONS))
+        );
 
         // register completed timestamp if action completed the project
         if (_maxInvocations == _invocations) {
@@ -1162,7 +1184,10 @@ contract GenArt721CoreV3_Engine is
         project.scriptBytecodeAddresses[project.scriptCount] = _script
             .writeToBytecode();
         project.scriptCount = project.scriptCount + 1;
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_SCRIPT);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_SCRIPT))
+        );
     }
 
     /**
@@ -1190,7 +1215,10 @@ contract GenArt721CoreV3_Engine is
         project.scriptBytecodeAddresses[project.scriptCount] = _compressedScript
             .writeToBytecodeCompressed();
         project.scriptCount = project.scriptCount + 1;
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_SCRIPT);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_SCRIPT))
+        );
     }
 
     /**
@@ -1213,7 +1241,10 @@ contract GenArt721CoreV3_Engine is
         // store script in contract bytecode, replacing reference address from
         // the old storage contract with the newly created one
         project.scriptBytecodeAddresses[_scriptId] = _script.writeToBytecode();
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_SCRIPT);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_SCRIPT))
+        );
     }
 
     /**
@@ -1244,7 +1275,10 @@ contract GenArt721CoreV3_Engine is
         // the old storage contract with the newly created one
         project.scriptBytecodeAddresses[_scriptId] = _compressedScript
             .writeToBytecodeCompressed();
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_SCRIPT);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_SCRIPT))
+        );
     }
 
     /**
@@ -1264,7 +1298,10 @@ contract GenArt721CoreV3_Engine is
         unchecked {
             project.scriptCount = project.scriptCount - 1;
         }
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_SCRIPT);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_SCRIPT))
+        );
     }
 
     /**
@@ -1292,7 +1329,10 @@ contract GenArt721CoreV3_Engine is
             "must contain exactly one @"
         );
         project.scriptTypeAndVersion = _scriptTypeAndVersion;
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_SCRIPT_TYPE);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_SCRIPT_TYPE))
+        );
     }
 
     /**
@@ -1340,7 +1380,10 @@ contract GenArt721CoreV3_Engine is
         require(hasSeenNumber, "Aspect ratio has no numbers");
 
         projects[_projectId].aspectRatio = _aspectRatio;
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_ASPECT_RATIO);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_ASPECT_RATIO))
+        );
     }
 
     /**
@@ -1358,7 +1401,10 @@ contract GenArt721CoreV3_Engine is
         _onlyArtist(_projectId);
         _onlyNonEmptyString(_newBaseURI);
         projects[_projectId].projectBaseURI = _newBaseURI;
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_BASE_URI);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_BASE_URI))
+        );
     }
 
     /**
@@ -1682,7 +1728,7 @@ contract GenArt721CoreV3_Engine is
      */
     function getCompressed(
         string memory _script
-    ) external view returns (bytes memory) {
+    ) external pure returns (bytes memory) {
         _onlyNonEmptyString(_script);
         return BytecodeStorageReader.getCompressed(_script);
     }
@@ -2010,7 +2056,11 @@ contract GenArt721CoreV3_Engine is
     function _forbidNewProjects() internal {
         if (!newProjectsForbidden) {
             newProjectsForbidden = true;
-            emit PlatformUpdated(FIELD_NEW_PROJECTS_FORBIDDEN);
+            emit PlatformUpdated(
+                bytes32(
+                    uint256(PlatformUpdatedFields.FIELD_NEW_PROJECTS_FORBIDDEN)
+                )
+            );
         }
     }
 
@@ -2060,7 +2110,11 @@ contract GenArt721CoreV3_Engine is
         renderProviderSecondarySalesAddress = payable(
             _renderProviderSecondarySalesAddress
         );
-        emit PlatformUpdated(FIELD_PROVIDER_SALES_ADDRESSES);
+        emit PlatformUpdated(
+            bytes32(
+                uint256(PlatformUpdatedFields.FIELD_PROVIDER_SALES_ADDRESSES)
+            )
+        );
     }
 
     /**
@@ -2074,7 +2128,9 @@ contract GenArt721CoreV3_Engine is
         randomizerContract = IRandomizer_V3CoreBase(_randomizerAddress);
         // populate historical randomizer array
         _historicalRandomizerAddresses.push(_randomizerAddress);
-        emit PlatformUpdated(FIELD_RANDOMIZER_ADDRESS);
+        emit PlatformUpdated(
+            bytes32(uint256(PlatformUpdatedFields.FIELD_RANDOMIZER_ADDRESS))
+        );
     }
 
     /**
@@ -2088,7 +2144,9 @@ contract GenArt721CoreV3_Engine is
      */
     function _updateDefaultBaseURI(string memory _defaultBaseURI) internal {
         defaultBaseURI = _defaultBaseURI;
-        emit PlatformUpdated(FIELD_DEFAULT_BASE_URI);
+        emit PlatformUpdated(
+            bytes32(uint256(PlatformUpdatedFields.FIELD_DEFAULT_BASE_URI))
+        );
     }
 
     /**
@@ -2097,7 +2155,10 @@ contract GenArt721CoreV3_Engine is
      */
     function _completeProject(uint256 _projectId) internal {
         projects[_projectId].completedTimestamp = uint64(block.timestamp);
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_COMPLETED);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_COMPLETED))
+        );
     }
 
     /**

--- a/packages/contracts/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
+++ b/packages/contracts/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
@@ -122,49 +122,49 @@ contract GenArt721CoreV3_Engine_Flex is
     uint256 constant MAX_PROVIDER_SECONDARY_SALES_BPS = 10000; // 10_000 BPS = 100%
     uint256 constant ARTIST_MAX_SECONDARY_ROYALTY_PERCENTAGE = 95; // 95%
 
-    // This contract emits generic events that contain fields that indicate
-    // which parameter has been updated. This is sufficient for application
-    // state management, while also simplifying the contract and indexing code.
-    // This was done as an alternative to having custom events that emit what
-    // field-values have changed for each event, given that changed values can
-    // be introspected by indexers due to the design of this smart contract
-    // exposing these state changes via publicly viewable fields.
-    //
-    // The following fields are used to indicate which contract-level parameter
-    // has been updated in the `PlatformUpdated` event:
-    bytes32 constant FIELD_NEXT_PROJECT_ID = "nextProjectId";
-    bytes32 constant FIELD_NEW_PROJECTS_FORBIDDEN = "newProjectsForbidden";
-    bytes32 constant FIELD_DEFAULT_BASE_URI = "defaultBaseURI";
-    bytes32 constant FIELD_RANDOMIZER_ADDRESS = "randomizerAddress";
-    bytes32 constant FIELD_NEXT_CORE_CONTRACT = "nextCoreContract";
-    bytes32 constant FIELD_ARTBLOCKS_DEPENDENCY_REGISTRY_ADDRESS =
-        "dependencyRegistryAddress";
-    bytes32 constant FIELD_ARTBLOCKS_ON_CHAIN_GENERATOR_ADDRESS =
-        "onChainGeneratorAddress";
-    bytes32 constant FIELD_PROVIDER_SALES_ADDRESSES = "providerSalesAddresses";
-    bytes32 constant FIELD_PROVIDER_PRIMARY_SALES_PERCENTAGES =
-        "providerPrimaryPercentages";
-    bytes32 constant FIELD_PROVIDER_SECONDARY_SALES_BPS =
-        "providerSecondaryBPS";
-    // The following fields are used to indicate which project-level parameter
-    // has been updated in the `ProjectUpdated` event:
-    bytes32 constant FIELD_PROJECT_COMPLETED = "completed";
-    bytes32 constant FIELD_PROJECT_ACTIVE = "active";
-    bytes32 constant FIELD_PROJECT_ARTIST_ADDRESS = "artistAddress";
-    bytes32 constant FIELD_PROJECT_PAUSED = "paused";
-    bytes32 constant FIELD_PROJECT_CREATED = "created";
-    bytes32 constant FIELD_PROJECT_NAME = "name";
-    bytes32 constant FIELD_PROJECT_ARTIST_NAME = "artistName";
-    bytes32 constant FIELD_PROJECT_SECONDARY_MARKET_ROYALTY_PERCENTAGE =
-        "royaltyPercentage";
-    bytes32 constant FIELD_PROJECT_DESCRIPTION = "description";
-    bytes32 constant FIELD_PROJECT_WEBSITE = "website";
-    bytes32 constant FIELD_PROJECT_LICENSE = "license";
-    bytes32 constant FIELD_PROJECT_MAX_INVOCATIONS = "maxInvocations";
-    bytes32 constant FIELD_PROJECT_SCRIPT = "script";
-    bytes32 constant FIELD_PROJECT_SCRIPT_TYPE = "scriptType";
-    bytes32 constant FIELD_PROJECT_ASPECT_RATIO = "aspectRatio";
-    bytes32 constant FIELD_PROJECT_BASE_URI = "baseURI";
+    // // This contract emits generic events that contain fields that indicate
+    // // which parameter has been updated. This is sufficient for application
+    // // state management, while also simplifying the contract and indexing code.
+    // // This was done as an alternative to having custom events that emit what
+    // // field-values have changed for each event, given that changed values can
+    // // be introspected by indexers due to the design of this smart contract
+    // // exposing these state changes via publicly viewable fields.
+    // //
+    // // The following fields are used to indicate which contract-level parameter
+    // // has been updated in the `PlatformUpdated` event:
+    // enum PlatformUpdatedFields {
+    //     FIELD_NEXT_PROJECT_ID,
+    //     FIELD_NEW_PROJECTS_FORBIDDEN,
+    //     FIELD_DEFAULT_BASE_URI,
+    //     FIELD_RANDOMIZER_ADDRESS,
+    //     FIELD_NEXT_CORE_CONTRACT,
+    //     FIELD_ARTBLOCKS_DEPENDENCY_REGISTRY_ADDRESS,
+    //     FIELD_ARTBLOCKS_ON_CHAIN_GENERATOR_ADDRESS,
+    //     FIELD_PROVIDER_SALES_ADDRESSES,
+    //     FIELD_PROVIDER_PRIMARY_SALES_PERCENTAGES,
+    //     FIELD_PROVIDER_SECONDARY_SALES_BPS
+    // }
+    // // The following fields are used to indicate which project-level parameter
+    // // has been updated in the `ProjectUpdated` event:
+    // // @dev only append to the end of this enum in the case of future updates
+    // enum ProjectUpdatedFields {
+    //     FIELD_PROJECT_COMPLETED,
+    //     FIELD_PROJECT_ACTIVE,
+    //     FIELD_PROJECT_ARTIST_ADDRESS,
+    //     FIELD_PROJECT_PAUSED,
+    //     FIELD_PROJECT_CREATED,
+    //     FIELD_PROJECT_NAME,
+    //     FIELD_PROJECT_ARTIST_NAME,
+    //     FIELD_PROJECT_SECONDARY_MARKET_ROYALTY_PERCENTAGE,
+    //     FIELD_PROJECT_DESCRIPTION,
+    //     FIELD_PROJECT_WEBSITE,
+    //     FIELD_PROJECT_LICENSE,
+    //     FIELD_PROJECT_MAX_INVOCATIONS,
+    //     FIELD_PROJECT_SCRIPT,
+    //     FIELD_PROJECT_SCRIPT_TYPE,
+    //     FIELD_PROJECT_ASPECT_RATIO,
+    //     FIELD_PROJECT_BASE_URI
+    // }
 
     /// pointer to next core contract associated with this contract
     address public nextCoreContract;
@@ -416,7 +416,9 @@ contract GenArt721CoreV3_Engine_Flex is
         );
         // initialize next project ID
         _nextProjectId = _startingProjectId;
-        emit PlatformUpdated(FIELD_NEXT_PROJECT_ID);
+        emit PlatformUpdated(
+            bytes32(uint256(PlatformUpdatedFields.FIELD_NEXT_PROJECT_ID))
+        );
         // @dev follow-on action: This contract does not self-register. A core
         // registry owner must register contract in a subsequent call.
     }
@@ -664,7 +666,9 @@ contract GenArt721CoreV3_Engine_Flex is
     function updateNextCoreContract(address _nextCoreContract) external {
         _onlyAdminACL(this.updateNextCoreContract.selector);
         nextCoreContract = _nextCoreContract;
-        emit PlatformUpdated(FIELD_NEXT_CORE_CONTRACT);
+        emit PlatformUpdated(
+            bytes32(uint256(PlatformUpdatedFields.FIELD_NEXT_CORE_CONTRACT))
+        );
     }
 
     /**
@@ -678,7 +682,14 @@ contract GenArt721CoreV3_Engine_Flex is
         _onlyAdminACL(this.updateArtblocksDependencyRegistryAddress.selector);
         _onlyNonZeroAddress(_artblocksDependencyRegistryAddress);
         artblocksDependencyRegistryAddress = _artblocksDependencyRegistryAddress;
-        emit PlatformUpdated(FIELD_ARTBLOCKS_DEPENDENCY_REGISTRY_ADDRESS);
+        emit PlatformUpdated(
+            bytes32(
+                uint256(
+                    PlatformUpdatedFields
+                        .FIELD_ARTBLOCKS_DEPENDENCY_REGISTRY_ADDRESS
+                )
+            )
+        );
     }
 
     /**
@@ -691,7 +702,14 @@ contract GenArt721CoreV3_Engine_Flex is
         _onlyAdminACL(this.updateArtblocksOnChainGeneratorAddress.selector);
         _onlyNonZeroAddress(_artblocksOnChainGeneratorAddress);
         artblocksOnChainGeneratorAddress = _artblocksOnChainGeneratorAddress;
-        emit PlatformUpdated(FIELD_ARTBLOCKS_ON_CHAIN_GENERATOR_ADDRESS);
+        emit PlatformUpdated(
+            bytes32(
+                uint256(
+                    PlatformUpdatedFields
+                        .FIELD_ARTBLOCKS_ON_CHAIN_GENERATOR_ADDRESS
+                )
+            )
+        );
     }
 
     /**
@@ -752,7 +770,14 @@ contract GenArt721CoreV3_Engine_Flex is
         _platformProviderPrimarySalesPercentage = uint8(
             platformProviderPrimarySalesPercentage_
         );
-        emit PlatformUpdated(FIELD_PROVIDER_PRIMARY_SALES_PERCENTAGES);
+        emit PlatformUpdated(
+            bytes32(
+                uint256(
+                    PlatformUpdatedFields
+                        .FIELD_PROVIDER_PRIMARY_SALES_PERCENTAGES
+                )
+            )
+        );
     }
 
     /**
@@ -782,7 +807,13 @@ contract GenArt721CoreV3_Engine_Flex is
         );
         renderProviderSecondarySalesBPS = _renderProviderSecondarySalesBPS;
         platformProviderSecondarySalesBPS = _platformProviderSecondarySalesBPS;
-        emit PlatformUpdated(FIELD_PROVIDER_SECONDARY_SALES_BPS);
+        emit PlatformUpdated(
+            bytes32(
+                uint256(
+                    PlatformUpdatedFields.FIELD_PROVIDER_SECONDARY_SALES_BPS
+                )
+            )
+        );
     }
 
     /**
@@ -814,7 +845,10 @@ contract GenArt721CoreV3_Engine_Flex is
         _onlyAdminACL(this.toggleProjectIsActive.selector);
         _onlyValidProjectId(_projectId);
         projects[_projectId].active = !projects[_projectId].active;
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_ACTIVE);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_ACTIVE))
+        );
     }
 
     /**
@@ -1036,7 +1070,10 @@ contract GenArt721CoreV3_Engine_Flex is
         );
         _onlyNonZeroAddress(_artistAddress);
         projectIdToFinancials[_projectId].artistAddress = _artistAddress;
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_ARTIST_ADDRESS);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_ARTIST_ADDRESS))
+        );
     }
 
     /**
@@ -1046,7 +1083,10 @@ contract GenArt721CoreV3_Engine_Flex is
     function toggleProjectIsPaused(uint256 _projectId) external {
         _onlyArtist(_projectId);
         projects[_projectId].paused = !projects[_projectId].paused;
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_PAUSED);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_PAUSED))
+        );
     }
 
     /**
@@ -1071,7 +1111,10 @@ contract GenArt721CoreV3_Engine_Flex is
         projects[projectId].projectBaseURI = defaultBaseURI;
 
         _nextProjectId = uint248(projectId) + 1;
-        emit ProjectUpdated(projectId, FIELD_PROJECT_CREATED);
+        emit ProjectUpdated(
+            projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_CREATED))
+        );
     }
 
     /**
@@ -1096,7 +1139,10 @@ contract GenArt721CoreV3_Engine_Flex is
         _onlyArtistOrAdminACL(_projectId, this.updateProjectName.selector);
         _onlyNonEmptyString(_projectName);
         projects[_projectId].name = _projectName;
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_NAME);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_NAME))
+        );
     }
 
     /**
@@ -1124,7 +1170,10 @@ contract GenArt721CoreV3_Engine_Flex is
         );
         _onlyNonEmptyString(_projectArtistName);
         projects[_projectId].artist = _projectArtistName;
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_ARTIST_NAME);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_ARTIST_NAME))
+        );
     }
 
     /**
@@ -1151,7 +1200,12 @@ contract GenArt721CoreV3_Engine_Flex is
             .secondaryMarketRoyaltyPercentage = uint8(_secondMarketRoyalty);
         emit ProjectUpdated(
             _projectId,
-            FIELD_PROJECT_SECONDARY_MARKET_ROYALTY_PERCENTAGE
+            bytes32(
+                uint256(
+                    ProjectUpdatedFields
+                        .FIELD_PROJECT_SECONDARY_MARKET_ROYALTY_PERCENTAGE
+                )
+            )
         );
     }
 
@@ -1188,7 +1242,10 @@ contract GenArt721CoreV3_Engine_Flex is
         // the old storage description with the newly created one
         projects[_projectId].descriptionAddress = _projectDescription
             .writeToBytecode();
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_DESCRIPTION);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_DESCRIPTION))
+        );
     }
 
     /**
@@ -1203,7 +1260,10 @@ contract GenArt721CoreV3_Engine_Flex is
     ) external {
         _onlyArtist(_projectId);
         projects[_projectId].website = _projectWebsite;
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_WEBSITE);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_WEBSITE))
+        );
     }
 
     /**
@@ -1219,7 +1279,10 @@ contract GenArt721CoreV3_Engine_Flex is
         _onlyArtistOrAdminACL(_projectId, this.updateProjectLicense.selector);
         _onlyNonEmptyString(_projectLicense);
         projects[_projectId].license = _projectLicense;
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_LICENSE);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_LICENSE))
+        );
     }
 
     /**
@@ -1246,7 +1309,10 @@ contract GenArt721CoreV3_Engine_Flex is
         require(_maxInvocations >= _invocations, "Only gte invocations");
         // EFFECTS
         project.maxInvocations = _maxInvocations;
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_MAX_INVOCATIONS);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_MAX_INVOCATIONS))
+        );
 
         // register completed timestamp if action completed the project
         if (_maxInvocations == _invocations) {
@@ -1272,7 +1338,10 @@ contract GenArt721CoreV3_Engine_Flex is
         project.scriptBytecodeAddresses[project.scriptCount] = _script
             .writeToBytecode();
         project.scriptCount = project.scriptCount + 1;
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_SCRIPT);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_SCRIPT))
+        );
     }
 
     /**
@@ -1300,7 +1369,10 @@ contract GenArt721CoreV3_Engine_Flex is
         project.scriptBytecodeAddresses[project.scriptCount] = _compressedScript
             .writeToBytecodeCompressed();
         project.scriptCount = project.scriptCount + 1;
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_SCRIPT);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_SCRIPT))
+        );
     }
 
     /**
@@ -1323,7 +1395,10 @@ contract GenArt721CoreV3_Engine_Flex is
         // store script in contract bytecode, replacing reference address from
         // the old storage contract with the newly created one
         project.scriptBytecodeAddresses[_scriptId] = _script.writeToBytecode();
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_SCRIPT);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_SCRIPT))
+        );
     }
 
     /**
@@ -1354,7 +1429,10 @@ contract GenArt721CoreV3_Engine_Flex is
         // the old storage contract with the newly created one
         project.scriptBytecodeAddresses[_scriptId] = _compressedScript
             .writeToBytecodeCompressed();
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_SCRIPT);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_SCRIPT))
+        );
     }
 
     /**
@@ -1374,7 +1452,10 @@ contract GenArt721CoreV3_Engine_Flex is
         unchecked {
             project.scriptCount = project.scriptCount - 1;
         }
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_SCRIPT);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_SCRIPT))
+        );
     }
 
     /**
@@ -1402,7 +1483,10 @@ contract GenArt721CoreV3_Engine_Flex is
             "must contain exactly one @"
         );
         project.scriptTypeAndVersion = _scriptTypeAndVersion;
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_SCRIPT_TYPE);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_SCRIPT_TYPE))
+        );
     }
 
     /**
@@ -1450,7 +1534,10 @@ contract GenArt721CoreV3_Engine_Flex is
         require(hasSeenNumber, "Aspect ratio has no numbers");
 
         projects[_projectId].aspectRatio = _aspectRatio;
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_ASPECT_RATIO);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_ASPECT_RATIO))
+        );
     }
 
     /**
@@ -1468,7 +1555,10 @@ contract GenArt721CoreV3_Engine_Flex is
         _onlyArtist(_projectId);
         _onlyNonEmptyString(_newBaseURI);
         projects[_projectId].projectBaseURI = _newBaseURI;
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_BASE_URI);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_BASE_URI))
+        );
     }
 
     /**
@@ -1781,7 +1871,7 @@ contract GenArt721CoreV3_Engine_Flex is
      */
     function getCompressed(
         string memory _script
-    ) external view returns (bytes memory) {
+    ) external pure returns (bytes memory) {
         _onlyNonEmptyString(_script);
         return BytecodeStorageReader.getCompressed(_script);
     }
@@ -2163,7 +2253,11 @@ contract GenArt721CoreV3_Engine_Flex is
     function _forbidNewProjects() internal {
         if (!newProjectsForbidden) {
             newProjectsForbidden = true;
-            emit PlatformUpdated(FIELD_NEW_PROJECTS_FORBIDDEN);
+            emit PlatformUpdated(
+                bytes32(
+                    uint256(PlatformUpdatedFields.FIELD_NEW_PROJECTS_FORBIDDEN)
+                )
+            );
         }
     }
 
@@ -2213,7 +2307,11 @@ contract GenArt721CoreV3_Engine_Flex is
         renderProviderSecondarySalesAddress = payable(
             _renderProviderSecondarySalesAddress
         );
-        emit PlatformUpdated(FIELD_PROVIDER_SALES_ADDRESSES);
+        emit PlatformUpdated(
+            bytes32(
+                uint256(PlatformUpdatedFields.FIELD_PROVIDER_SALES_ADDRESSES)
+            )
+        );
     }
 
     /**
@@ -2227,7 +2325,9 @@ contract GenArt721CoreV3_Engine_Flex is
         randomizerContract = IRandomizer_V3CoreBase(_randomizerAddress);
         // populate historical randomizer array
         _historicalRandomizerAddresses.push(_randomizerAddress);
-        emit PlatformUpdated(FIELD_RANDOMIZER_ADDRESS);
+        emit PlatformUpdated(
+            bytes32(uint256(PlatformUpdatedFields.FIELD_RANDOMIZER_ADDRESS))
+        );
     }
 
     /**
@@ -2241,7 +2341,9 @@ contract GenArt721CoreV3_Engine_Flex is
      */
     function _updateDefaultBaseURI(string memory _defaultBaseURI) internal {
         defaultBaseURI = _defaultBaseURI;
-        emit PlatformUpdated(FIELD_DEFAULT_BASE_URI);
+        emit PlatformUpdated(
+            bytes32(uint256(PlatformUpdatedFields.FIELD_DEFAULT_BASE_URI))
+        );
     }
 
     /**
@@ -2250,7 +2352,10 @@ contract GenArt721CoreV3_Engine_Flex is
      */
     function _completeProject(uint256 _projectId) internal {
         projects[_projectId].completedTimestamp = uint64(block.timestamp);
-        emit ProjectUpdated(_projectId, FIELD_PROJECT_COMPLETED);
+        emit ProjectUpdated(
+            _projectId,
+            bytes32(uint256(ProjectUpdatedFields.FIELD_PROJECT_COMPLETED))
+        );
     }
 
     /**

--- a/packages/contracts/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
+++ b/packages/contracts/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
@@ -122,50 +122,6 @@ contract GenArt721CoreV3_Engine_Flex is
     uint256 constant MAX_PROVIDER_SECONDARY_SALES_BPS = 10000; // 10_000 BPS = 100%
     uint256 constant ARTIST_MAX_SECONDARY_ROYALTY_PERCENTAGE = 95; // 95%
 
-    // // This contract emits generic events that contain fields that indicate
-    // // which parameter has been updated. This is sufficient for application
-    // // state management, while also simplifying the contract and indexing code.
-    // // This was done as an alternative to having custom events that emit what
-    // // field-values have changed for each event, given that changed values can
-    // // be introspected by indexers due to the design of this smart contract
-    // // exposing these state changes via publicly viewable fields.
-    // //
-    // // The following fields are used to indicate which contract-level parameter
-    // // has been updated in the `PlatformUpdated` event:
-    // enum PlatformUpdatedFields {
-    //     FIELD_NEXT_PROJECT_ID,
-    //     FIELD_NEW_PROJECTS_FORBIDDEN,
-    //     FIELD_DEFAULT_BASE_URI,
-    //     FIELD_RANDOMIZER_ADDRESS,
-    //     FIELD_NEXT_CORE_CONTRACT,
-    //     FIELD_ARTBLOCKS_DEPENDENCY_REGISTRY_ADDRESS,
-    //     FIELD_ARTBLOCKS_ON_CHAIN_GENERATOR_ADDRESS,
-    //     FIELD_PROVIDER_SALES_ADDRESSES,
-    //     FIELD_PROVIDER_PRIMARY_SALES_PERCENTAGES,
-    //     FIELD_PROVIDER_SECONDARY_SALES_BPS
-    // }
-    // // The following fields are used to indicate which project-level parameter
-    // // has been updated in the `ProjectUpdated` event:
-    // // @dev only append to the end of this enum in the case of future updates
-    // enum ProjectUpdatedFields {
-    //     FIELD_PROJECT_COMPLETED,
-    //     FIELD_PROJECT_ACTIVE,
-    //     FIELD_PROJECT_ARTIST_ADDRESS,
-    //     FIELD_PROJECT_PAUSED,
-    //     FIELD_PROJECT_CREATED,
-    //     FIELD_PROJECT_NAME,
-    //     FIELD_PROJECT_ARTIST_NAME,
-    //     FIELD_PROJECT_SECONDARY_MARKET_ROYALTY_PERCENTAGE,
-    //     FIELD_PROJECT_DESCRIPTION,
-    //     FIELD_PROJECT_WEBSITE,
-    //     FIELD_PROJECT_LICENSE,
-    //     FIELD_PROJECT_MAX_INVOCATIONS,
-    //     FIELD_PROJECT_SCRIPT,
-    //     FIELD_PROJECT_SCRIPT_TYPE,
-    //     FIELD_PROJECT_ASPECT_RATIO,
-    //     FIELD_PROJECT_BASE_URI
-    // }
-
     /// pointer to next core contract associated with this contract
     address public nextCoreContract;
 

--- a/packages/contracts/contracts/interfaces/v0.8.x/IGenArt721CoreContractV3_Base.sol
+++ b/packages/contracts/contracts/interfaces/v0.8.x/IGenArt721CoreContractV3_Base.sol
@@ -15,6 +15,52 @@ import "./IManifold.sol";
  * @author Art Blocks Inc.
  */
 interface IGenArt721CoreContractV3_Base is IManifold {
+    // This interface emits generic events that contain fields that indicate
+    // which parameter has been updated. This is sufficient for application
+    // state management, while also simplifying the contract and indexing code.
+    // This was done as an alternative to having custom events that emit what
+    // field-values have changed for each event, given that changed values can
+    // be introspected by indexers due to the design of this smart contract
+    // exposing these state changes via publicly viewable fields.
+
+    // The following fields are used to indicate which contract-level parameter
+    // has been updated in the `PlatformUpdated` event:
+    // @dev only append to the end of this enum in the case of future updates
+    enum PlatformUpdatedFields {
+        FIELD_NEXT_PROJECT_ID, // 0
+        FIELD_NEW_PROJECTS_FORBIDDEN, // 1
+        FIELD_DEFAULT_BASE_URI, // 2
+        FIELD_RANDOMIZER_ADDRESS, // 3
+        FIELD_NEXT_CORE_CONTRACT, // 4
+        FIELD_ARTBLOCKS_DEPENDENCY_REGISTRY_ADDRESS, // 5
+        FIELD_ARTBLOCKS_ON_CHAIN_GENERATOR_ADDRESS, // 6
+        FIELD_PROVIDER_SALES_ADDRESSES, // 7
+        FIELD_PROVIDER_PRIMARY_SALES_PERCENTAGES, // 8
+        FIELD_PROVIDER_SECONDARY_SALES_BPS // 9
+    }
+
+    // The following fields are used to indicate which project-level parameter
+    // has been updated in the `ProjectUpdated` event:
+    // @dev only append to the end of this enum in the case of future updates
+    enum ProjectUpdatedFields {
+        FIELD_PROJECT_COMPLETED, // 0
+        FIELD_PROJECT_ACTIVE, // 1
+        FIELD_PROJECT_ARTIST_ADDRESS, // 2
+        FIELD_PROJECT_PAUSED, // 3
+        FIELD_PROJECT_CREATED, // 4
+        FIELD_PROJECT_NAME, // 5
+        FIELD_PROJECT_ARTIST_NAME, // 6
+        FIELD_PROJECT_SECONDARY_MARKET_ROYALTY_PERCENTAGE, // 7
+        FIELD_PROJECT_DESCRIPTION, // 8
+        FIELD_PROJECT_WEBSITE, // 9
+        FIELD_PROJECT_LICENSE, // 10
+        FIELD_PROJECT_MAX_INVOCATIONS, // 11
+        FIELD_PROJECT_SCRIPT, // 12
+        FIELD_PROJECT_SCRIPT_TYPE, // 13
+        FIELD_PROJECT_ASPECT_RATIO, // 14
+        FIELD_PROJECT_BASE_URI // 15
+    }
+
     /**
      * @notice Token ID `_tokenId` minted to `_to`.
      */

--- a/packages/contracts/test/core/V3/GenArt721CoreV3_Events.test.ts
+++ b/packages/contracts/test/core/V3/GenArt721CoreV3_Events.test.ts
@@ -19,6 +19,8 @@ import {
   deployCoreWithMinterFilter,
   mintProjectUntilRemaining,
   advanceEVMByTime,
+  PLATFORM_UPDATED_FIELDS,
+  PROJECT_UPDATED_FIELDS,
 } from "../../util/common";
 
 // test the following V3 core contract derivatives:
@@ -163,7 +165,7 @@ for (const coreContractName of coreContractsToTest) {
           );
           // expect field to be bytes32 of "nextProjectId" as log 1
           await expect(targetLog.topics[1]).to.be.equal(
-            ethers.utils.formatBytes32String("nextProjectId")
+            PLATFORM_UPDATED_FIELDS.FIELD_NEXT_PROJECT_ID
           );
         } else {
           tx = await coreContractFactory
@@ -186,43 +188,26 @@ for (const coreContractName of coreContractsToTest) {
           );
           // expect field to be bytes32 of "nextProjectId" as log 1
           await expect(targetLog.topics[1]).to.be.equal(
-            ethers.utils.formatBytes32String("nextProjectId")
+            PLATFORM_UPDATED_FIELDS.FIELD_NEXT_PROJECT_ID
           );
         }
       });
 
       it("emits {artblocksSecondary,provider}SalesAddress", async function () {
         const config = await loadFixture(_beforeEach);
-        if (coreContractName.includes("GenArt721CoreV3_Engine")) {
-          // emits expected event arg(s)
-          await expect(
-            config.genArt721Core
-              .connect(config.accounts.deployer)
-              .updateProviderSalesAddresses(
-                config.accounts.deployer2.address,
-                config.accounts.deployer2.address,
-                config.accounts.deployer2.address,
-                config.accounts.deployer2.address
-              )
-          )
-            .to.emit(config.genArt721Core, "PlatformUpdated")
-            .withArgs(
-              ethers.utils.formatBytes32String("providerSalesAddresses")
-            );
-        } else {
-          // emits expected event arg(s)
-          await expect(
-            config.genArt721Core
-              .connect(config.accounts.deployer)
-              .updateArtblocksSecondarySalesAddress(
-                config.accounts.artist.address
-              )
-          )
-            .to.emit(config.genArt721Core, "PlatformUpdated")
-            .withArgs(
-              ethers.utils.formatBytes32String("artblocksSecondarySalesAddress")
-            );
-        }
+        // emits expected event arg(s)
+        await expect(
+          config.genArt721Core
+            .connect(config.accounts.deployer)
+            .updateProviderSalesAddresses(
+              config.accounts.deployer2.address,
+              config.accounts.deployer2.address,
+              config.accounts.deployer2.address,
+              config.accounts.deployer2.address
+            )
+        )
+          .to.emit(config.genArt721Core, "PlatformUpdated")
+          .withArgs(PLATFORM_UPDATED_FIELDS.FIELD_PROVIDER_SALES_ADDRESSES);
       });
 
       it("emits 'randomizerAddress'", async function () {
@@ -236,7 +221,7 @@ for (const coreContractName of coreContractsToTest) {
             .updateRandomizerAddress(config.accounts.additional.address)
         )
           .to.emit(config.genArt721Core, "PlatformUpdated")
-          .withArgs(ethers.utils.formatBytes32String("randomizerAddress"));
+          .withArgs(PLATFORM_UPDATED_FIELDS.FIELD_RANDOMIZER_ADDRESS);
       });
 
       it("emits 'curationRegistryAddress'", async function () {
@@ -273,7 +258,7 @@ for (const coreContractName of coreContractsToTest) {
         )
           .to.emit(config.genArt721Core, "PlatformUpdated")
           .withArgs(
-            ethers.utils.formatBytes32String("onChainGeneratorAddress")
+            PLATFORM_UPDATED_FIELDS.FIELD_ARTBLOCKS_ON_CHAIN_GENERATOR_ADDRESS
           );
       });
 
@@ -289,7 +274,7 @@ for (const coreContractName of coreContractsToTest) {
         )
           .to.emit(config.genArt721Core, "PlatformUpdated")
           .withArgs(
-            ethers.utils.formatBytes32String("dependencyRegistryAddress")
+            PLATFORM_UPDATED_FIELDS.FIELD_ARTBLOCKS_DEPENDENCY_REGISTRY_ADDRESS
           );
       });
 
@@ -304,59 +289,33 @@ for (const coreContractName of coreContractsToTest) {
             )
         )
           .to.emit(config.genArt721Core, "PlatformUpdated")
-          .withArgs(ethers.utils.formatBytes32String("nextCoreContract"));
+          .withArgs(PLATFORM_UPDATED_FIELDS.FIELD_NEXT_CORE_CONTRACT);
       });
 
       it("emits '{artblocks,provider}PrimaryPercentage'", async function () {
         const config = await loadFixture(_beforeEach);
-        if (coreContractName.includes("GenArt721CoreV3_Engine")) {
-          // emits expected event arg(s)
-          await expect(
-            config.genArt721Core
-              .connect(config.accounts.deployer)
-              .updateProviderPrimarySalesPercentages(11, 11)
-          )
-            .to.emit(config.genArt721Core, "PlatformUpdated")
-            .withArgs(
-              ethers.utils.formatBytes32String("providerPrimaryPercentages")
-            );
-        } else {
-          // emits expected event arg(s)
-          await expect(
-            config.genArt721Core
-              .connect(config.accounts.deployer)
-              .updateArtblocksPrimarySalesPercentage(11)
-          )
-            .to.emit(config.genArt721Core, "PlatformUpdated")
-            .withArgs(
-              ethers.utils.formatBytes32String("artblocksPrimaryPercentage")
-            );
-        }
+        // emits expected event arg(s)
+        await expect(
+          config.genArt721Core
+            .connect(config.accounts.deployer)
+            .updateProviderPrimarySalesPercentages(11, 11)
+        )
+          .to.emit(config.genArt721Core, "PlatformUpdated")
+          .withArgs(
+            PLATFORM_UPDATED_FIELDS.FIELD_PROVIDER_PRIMARY_SALES_PERCENTAGES
+          );
       });
 
       it("emits '{artblocks,provider}SecondaryBPS'", async function () {
         const config = await loadFixture(_beforeEach);
-        if (coreContractName.includes("GenArt721CoreV3_Engine")) {
-          // emits expected event arg(s)
-          await expect(
-            config.genArt721Core
-              .connect(config.accounts.deployer)
-              .updateProviderSecondarySalesBPS(240, 240)
-          )
-            .to.emit(config.genArt721Core, "PlatformUpdated")
-            .withArgs(ethers.utils.formatBytes32String("providerSecondaryBPS"));
-        } else {
-          // emits expected event arg(s)
-          await expect(
-            config.genArt721Core
-              .connect(config.accounts.deployer)
-              .updateArtblocksSecondarySalesBPS(240)
-          )
-            .to.emit(config.genArt721Core, "PlatformUpdated")
-            .withArgs(
-              ethers.utils.formatBytes32String("artblocksSecondaryBPS")
-            );
-        }
+        // emits expected event arg(s)
+        await expect(
+          config.genArt721Core
+            .connect(config.accounts.deployer)
+            .updateProviderSecondarySalesBPS(240, 240)
+        )
+          .to.emit(config.genArt721Core, "PlatformUpdated")
+          .withArgs(PLATFORM_UPDATED_FIELDS.FIELD_PROVIDER_SECONDARY_SALES_BPS);
       });
 
       it("emits 'newProjectsForbidden'", async function () {
@@ -368,7 +327,7 @@ for (const coreContractName of coreContractsToTest) {
             .forbidNewProjects()
         )
           .to.emit(config.genArt721Core, "PlatformUpdated")
-          .withArgs(ethers.utils.formatBytes32String("newProjectsForbidden"));
+          .withArgs(PLATFORM_UPDATED_FIELDS.FIELD_NEW_PROJECTS_FORBIDDEN);
       });
 
       it("emits `defaultBaseURI`", async function () {
@@ -380,7 +339,7 @@ for (const coreContractName of coreContractsToTest) {
             .updateDefaultBaseURI("https://newbaseuri.com/token/")
         )
           .to.emit(config.genArt721Core, "PlatformUpdated")
-          .withArgs(ethers.utils.formatBytes32String("defaultBaseURI"));
+          .withArgs(PLATFORM_UPDATED_FIELDS.FIELD_DEFAULT_BASE_URI);
       });
     });
 
@@ -402,7 +361,7 @@ for (const coreContractName of coreContractsToTest) {
           .to.emit(config.genArt721Core, "ProjectUpdated")
           .withArgs(
             config.projectZero,
-            ethers.utils.formatBytes32String("completed")
+            PROJECT_UPDATED_FIELDS.FIELD_PROJECT_COMPLETED
           );
       });
 
@@ -417,7 +376,7 @@ for (const coreContractName of coreContractsToTest) {
           .to.emit(config.genArt721Core, "ProjectUpdated")
           .withArgs(
             config.projectZero,
-            ethers.utils.formatBytes32String("active")
+            PROJECT_UPDATED_FIELDS.FIELD_PROJECT_ACTIVE
           );
         // emits expected event arg(s) when toggling project active
         await expect(
@@ -428,7 +387,7 @@ for (const coreContractName of coreContractsToTest) {
           .to.emit(config.genArt721Core, "ProjectUpdated")
           .withArgs(
             config.projectZero,
-            ethers.utils.formatBytes32String("active")
+            PROJECT_UPDATED_FIELDS.FIELD_PROJECT_ACTIVE
           );
       });
 
@@ -446,7 +405,7 @@ for (const coreContractName of coreContractsToTest) {
           .to.emit(config.genArt721Core, "ProjectUpdated")
           .withArgs(
             config.projectZero,
-            ethers.utils.formatBytes32String("artistAddress")
+            PROJECT_UPDATED_FIELDS.FIELD_PROJECT_ARTIST_ADDRESS
           );
       });
 
@@ -461,7 +420,7 @@ for (const coreContractName of coreContractsToTest) {
           .to.emit(config.genArt721Core, "ProjectUpdated")
           .withArgs(
             config.projectZero,
-            ethers.utils.formatBytes32String("paused")
+            PROJECT_UPDATED_FIELDS.FIELD_PROJECT_PAUSED
           );
       });
 
@@ -476,7 +435,7 @@ for (const coreContractName of coreContractsToTest) {
           .to.emit(config.genArt721Core, "ProjectUpdated")
           .withArgs(
             config.projectOne,
-            ethers.utils.formatBytes32String("created")
+            PROJECT_UPDATED_FIELDS.FIELD_PROJECT_CREATED
           );
       });
 
@@ -491,7 +450,7 @@ for (const coreContractName of coreContractsToTest) {
           .to.emit(config.genArt721Core, "ProjectUpdated")
           .withArgs(
             config.projectZero,
-            ethers.utils.formatBytes32String("name")
+            PROJECT_UPDATED_FIELDS.FIELD_PROJECT_NAME
           );
       });
 
@@ -506,7 +465,7 @@ for (const coreContractName of coreContractsToTest) {
           .to.emit(config.genArt721Core, "ProjectUpdated")
           .withArgs(
             config.projectZero,
-            ethers.utils.formatBytes32String("artistName")
+            PROJECT_UPDATED_FIELDS.FIELD_PROJECT_ARTIST_NAME
           );
       });
 
@@ -524,7 +483,7 @@ for (const coreContractName of coreContractsToTest) {
           .to.emit(config.genArt721Core, "ProjectUpdated")
           .withArgs(
             config.projectZero,
-            ethers.utils.formatBytes32String("royaltyPercentage")
+            PROJECT_UPDATED_FIELDS.FIELD_PROJECT_SECONDARY_MARKET_ROYALTY_PERCENTAGE
           );
       });
 
@@ -539,7 +498,7 @@ for (const coreContractName of coreContractsToTest) {
           .to.emit(config.genArt721Core, "ProjectUpdated")
           .withArgs(
             config.projectZero,
-            ethers.utils.formatBytes32String("description")
+            PROJECT_UPDATED_FIELDS.FIELD_PROJECT_DESCRIPTION
           );
       });
 
@@ -554,7 +513,7 @@ for (const coreContractName of coreContractsToTest) {
           .to.emit(config.genArt721Core, "ProjectUpdated")
           .withArgs(
             config.projectZero,
-            ethers.utils.formatBytes32String("website")
+            PROJECT_UPDATED_FIELDS.FIELD_PROJECT_WEBSITE
           );
       });
 
@@ -569,7 +528,7 @@ for (const coreContractName of coreContractsToTest) {
           .to.emit(config.genArt721Core, "ProjectUpdated")
           .withArgs(
             config.projectZero,
-            ethers.utils.formatBytes32String("license")
+            PROJECT_UPDATED_FIELDS.FIELD_PROJECT_LICENSE
           );
       });
 
@@ -584,7 +543,7 @@ for (const coreContractName of coreContractsToTest) {
           .to.emit(config.genArt721Core, "ProjectUpdated")
           .withArgs(
             config.projectZero,
-            ethers.utils.formatBytes32String("maxInvocations")
+            PROJECT_UPDATED_FIELDS.FIELD_PROJECT_MAX_INVOCATIONS
           );
       });
 
@@ -600,7 +559,7 @@ for (const coreContractName of coreContractsToTest) {
           .to.emit(config.genArt721Core, "ProjectUpdated")
           .withArgs(
             config.projectZero,
-            ethers.utils.formatBytes32String("script")
+            PROJECT_UPDATED_FIELDS.FIELD_PROJECT_SCRIPT
           );
         // edit script
         await expect(
@@ -615,7 +574,7 @@ for (const coreContractName of coreContractsToTest) {
           .to.emit(config.genArt721Core, "ProjectUpdated")
           .withArgs(
             config.projectZero,
-            ethers.utils.formatBytes32String("script")
+            PROJECT_UPDATED_FIELDS.FIELD_PROJECT_SCRIPT
           );
         // remove script
         await expect(
@@ -626,7 +585,7 @@ for (const coreContractName of coreContractsToTest) {
           .to.emit(config.genArt721Core, "ProjectUpdated")
           .withArgs(
             config.projectZero,
-            ethers.utils.formatBytes32String("script")
+            PROJECT_UPDATED_FIELDS.FIELD_PROJECT_SCRIPT
           );
       });
 
@@ -646,7 +605,7 @@ for (const coreContractName of coreContractsToTest) {
           .to.emit(config.genArt721Core, "ProjectUpdated")
           .withArgs(
             config.projectZero,
-            ethers.utils.formatBytes32String("script")
+            PROJECT_UPDATED_FIELDS.FIELD_PROJECT_SCRIPT
           );
         // edit script
         const compressedScript2 = await config.genArt721Core
@@ -664,7 +623,7 @@ for (const coreContractName of coreContractsToTest) {
           .to.emit(config.genArt721Core, "ProjectUpdated")
           .withArgs(
             config.projectZero,
-            ethers.utils.formatBytes32String("script")
+            PROJECT_UPDATED_FIELDS.FIELD_PROJECT_SCRIPT
           );
         // remove script
         await expect(
@@ -675,7 +634,7 @@ for (const coreContractName of coreContractsToTest) {
           .to.emit(config.genArt721Core, "ProjectUpdated")
           .withArgs(
             config.projectZero,
-            ethers.utils.formatBytes32String("script")
+            PROJECT_UPDATED_FIELDS.FIELD_PROJECT_SCRIPT
           );
       });
 
@@ -693,7 +652,7 @@ for (const coreContractName of coreContractsToTest) {
           .to.emit(config.genArt721Core, "ProjectUpdated")
           .withArgs(
             config.projectZero,
-            ethers.utils.formatBytes32String("scriptType")
+            PROJECT_UPDATED_FIELDS.FIELD_PROJECT_SCRIPT_TYPE
           );
       });
 
@@ -708,7 +667,7 @@ for (const coreContractName of coreContractsToTest) {
           .to.emit(config.genArt721Core, "ProjectUpdated")
           .withArgs(
             config.projectZero,
-            ethers.utils.formatBytes32String("aspectRatio")
+            PROJECT_UPDATED_FIELDS.FIELD_PROJECT_ASPECT_RATIO
           );
       });
 
@@ -726,7 +685,7 @@ for (const coreContractName of coreContractsToTest) {
           .to.emit(config.genArt721Core, "ProjectUpdated")
           .withArgs(
             config.projectZero,
-            ethers.utils.formatBytes32String("baseURI")
+            PROJECT_UPDATED_FIELDS.FIELD_PROJECT_BASE_URI
           );
       });
     });

--- a/packages/contracts/test/util/common.ts
+++ b/packages/contracts/test/util/common.ts
@@ -99,6 +99,83 @@ export type T_Config = {
   weth?: Contract;
 };
 
+export const PLATFORM_UPDATED_FIELDS = {
+  FIELD_NEXT_PROJECT_ID: ethers.utils.hexZeroPad(ethers.utils.hexlify(0), 32),
+  FIELD_NEW_PROJECTS_FORBIDDEN: ethers.utils.hexZeroPad(
+    ethers.utils.hexlify(1),
+    32
+  ),
+  FIELD_DEFAULT_BASE_URI: ethers.utils.hexZeroPad(ethers.utils.hexlify(2), 32),
+  FIELD_RANDOMIZER_ADDRESS: ethers.utils.hexZeroPad(
+    ethers.utils.hexlify(3),
+    32
+  ),
+  FIELD_NEXT_CORE_CONTRACT: ethers.utils.hexZeroPad(
+    ethers.utils.hexlify(4),
+    32
+  ),
+  FIELD_ARTBLOCKS_DEPENDENCY_REGISTRY_ADDRESS: ethers.utils.hexZeroPad(
+    ethers.utils.hexlify(5),
+    32
+  ),
+  FIELD_ARTBLOCKS_ON_CHAIN_GENERATOR_ADDRESS: ethers.utils.hexZeroPad(
+    ethers.utils.hexlify(6),
+    32
+  ),
+  FIELD_PROVIDER_SALES_ADDRESSES: ethers.utils.hexZeroPad(
+    ethers.utils.hexlify(7),
+    32
+  ),
+  FIELD_PROVIDER_PRIMARY_SALES_PERCENTAGES: ethers.utils.hexZeroPad(
+    ethers.utils.hexlify(8),
+    32
+  ),
+  FIELD_PROVIDER_SECONDARY_SALES_BPS: ethers.utils.hexZeroPad(
+    ethers.utils.hexlify(9),
+    32
+  ),
+};
+
+export const PROJECT_UPDATED_FIELDS = {
+  FIELD_PROJECT_COMPLETED: ethers.utils.hexZeroPad(ethers.utils.hexlify(0), 32),
+  FIELD_PROJECT_ACTIVE: ethers.utils.hexZeroPad(ethers.utils.hexlify(1), 32),
+  FIELD_PROJECT_ARTIST_ADDRESS: ethers.utils.hexZeroPad(
+    ethers.utils.hexlify(2),
+    32
+  ),
+  FIELD_PROJECT_PAUSED: ethers.utils.hexZeroPad(ethers.utils.hexlify(3), 32),
+  FIELD_PROJECT_CREATED: ethers.utils.hexZeroPad(ethers.utils.hexlify(4), 32),
+  FIELD_PROJECT_NAME: ethers.utils.hexZeroPad(ethers.utils.hexlify(5), 32),
+  FIELD_PROJECT_ARTIST_NAME: ethers.utils.hexZeroPad(
+    ethers.utils.hexlify(6),
+    32
+  ),
+  FIELD_PROJECT_SECONDARY_MARKET_ROYALTY_PERCENTAGE: ethers.utils.hexZeroPad(
+    ethers.utils.hexlify(7),
+    32
+  ),
+  FIELD_PROJECT_DESCRIPTION: ethers.utils.hexZeroPad(
+    ethers.utils.hexlify(8),
+    32
+  ),
+  FIELD_PROJECT_WEBSITE: ethers.utils.hexZeroPad(ethers.utils.hexlify(9), 32),
+  FIELD_PROJECT_LICENSE: ethers.utils.hexZeroPad(ethers.utils.hexlify(10), 32),
+  FIELD_PROJECT_MAX_INVOCATIONS: ethers.utils.hexZeroPad(
+    ethers.utils.hexlify(11),
+    32
+  ),
+  FIELD_PROJECT_SCRIPT: ethers.utils.hexZeroPad(ethers.utils.hexlify(12), 32),
+  FIELD_PROJECT_SCRIPT_TYPE: ethers.utils.hexZeroPad(
+    ethers.utils.hexlify(13),
+    32
+  ),
+  FIELD_PROJECT_ASPECT_RATIO: ethers.utils.hexZeroPad(
+    ethers.utils.hexlify(14),
+    32
+  ),
+  FIELD_PROJECT_BASE_URI: ethers.utils.hexZeroPad(ethers.utils.hexlify(15), 32),
+};
+
 export async function getAccounts(): Promise<TestAccountsArtBlocks> {
   const [
     deployer,


### PR DESCRIPTION
## Description of the change

Use enums in event fields for Project and Platform updated events to reduce contract bytecode size.

This update introduces minimal contract changes to reduce V3 core contract bytecode sizes by ~0.75kb, for which more margin is required to add all v3.2 updates.

This update requires subgraph changes downstream, but changes will be minimal and are straightforward.
