### PR TITLE
Provision future Flex 💪 

### DIFF
--- a/packages/contracts/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
+++ b/packages/contracts/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
@@ -523,6 +523,33 @@ contract GenArt721CoreV3_Engine_Flex is
     }
 
     /**
+     * @notice Updates external asset dependency for project `_projectId` of type
+     * ONCHAIN using on-chain compression. This function stores the string
+     * in a compressed format on-chain. For reads, the compressed script is
+     * decompressed on-chain, ensuring the original text is reconstructed without
+     * external dependencies.
+     * @dev _compressedString in memory to minimize bytecode size.
+     * @param _projectId Project to be updated.
+     * @param _index Asset index.
+     * @param _compressedString Pre-compressed string asset to be added.
+     */
+    function updateProjectExternalAssetDependencyOnChainCompressed(
+        uint256 _projectId,
+        uint256 _index,
+        bytes memory _compressedString
+    ) external {
+        _onlyArtistOrAdminACL(
+            _projectId,
+            this.updateProjectExternalAssetDependencyOnChainCompressed.selector
+        );
+        V3FlexLib.updateProjectExternalAssetDependencyOnChainCompressed({
+            _projectId: _projectId,
+            _index: _index,
+            _compressedString: _compressedString
+        });
+    }
+
+    /**
      * @notice Updates external asset dependency for project `_projectId` at
      * index `_index`, with data at BytecodeStorage-compatible address
      * `_assetAddress`.
@@ -588,6 +615,30 @@ contract GenArt721CoreV3_Engine_Flex is
             _projectId: _projectId,
             _cidOrData: _cidOrData,
             _dependencyType: _dependencyType
+        });
+    }
+
+    /**
+     * @notice Adds external asset dependency for project `_projectId` of type
+     * ONCHAIN using on-chain compression. This function stores the string
+     * in a compressed format on-chain. For reads, the compressed script is
+     * decompressed on-chain, ensuring the original text is reconstructed without
+     * external dependencies.
+     * @dev _compressedString in memory to minimize bytecode size.
+     * @param _projectId Project to be updated.
+     * @param _compressedString Pre-compressed string asset to be added.
+     */
+    function addProjectExternalAssetDependencyOnChainCompressed(
+        uint256 _projectId,
+        bytes memory _compressedString
+    ) external {
+        _onlyArtistOrAdminACL(
+            _projectId,
+            this.addProjectExternalAssetDependencyOnChainCompressed.selector
+        );
+        V3FlexLib.addProjectExternalAssetDependencyOnChainCompressed({
+            _projectId: _projectId,
+            _compressedString: _compressedString
         });
     }
 

--- a/packages/contracts/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
+++ b/packages/contracts/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
@@ -523,6 +523,30 @@ contract GenArt721CoreV3_Engine_Flex is
     }
 
     /**
+     * @notice Updates external asset dependency for project `_projectId` at
+     * index `_index`, with data at BytecodeStorage-compatible address
+     * `_assetAddress`.
+     * @param _projectId Project to be updated.
+     * @param _index Asset index.
+     * @param _assetAddress Address of the on-chain asset.
+     */
+    function UpdateProjectAssetDependencyOnChainAtAddress(
+        uint256 _projectId,
+        uint256 _index,
+        address _assetAddress
+    ) external {
+        _onlyArtistOrAdminACL(
+            _projectId,
+            this.UpdateProjectAssetDependencyOnChainAtAddress.selector
+        );
+        V3FlexLib.UpdateProjectAssetDependencyOnChainAtAddress({
+            _projectId: _projectId,
+            _index: _index,
+            _assetAddress: _assetAddress
+        });
+    }
+
+    /**
      * @notice Removes external asset dependency for project `_projectId` at index `_index`.
      * Removal is done by swapping the element to be removed with the last element in the array, then deleting this last element.
      * Assets with indices higher than `_index` can have their indices adjusted as a result of this operation.
@@ -565,6 +589,27 @@ contract GenArt721CoreV3_Engine_Flex is
             _projectId: _projectId,
             _cidOrData: _cidOrData,
             _dependencyType: _dependencyType
+        });
+    }
+
+    /**
+     * @notice Adds an on-chain external asset dependency for project
+     * `_projectId`, with data at BytecodeStorage-compatible address
+     * `_assetAddress`.
+     * @param _projectId Project to be updated.
+     * @param _assetAddress Address of the BytecodeStorageReader-compatible on-chain asset.
+     */
+    function addProjectAssetDependencyOnChainAtAddress(
+        uint256 _projectId,
+        address _assetAddress
+    ) external {
+        _onlyArtistOrAdminACL(
+            _projectId,
+            this.addProjectAssetDependencyOnChainAtAddress.selector
+        );
+        V3FlexLib.addProjectAssetDependencyOnChainAtAddress({
+            _projectId: _projectId,
+            _assetAddress: _assetAddress
         });
     }
 

--- a/packages/contracts/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
+++ b/packages/contracts/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
@@ -548,8 +548,7 @@ contract GenArt721CoreV3_Engine_Flex is
 
     /**
      * @notice Removes external asset dependency for project `_projectId` at index `_index`.
-     * Removal is done by swapping the element to be removed with the last element in the array, then deleting this last element.
-     * Assets with indices higher than `_index` can have their indices adjusted as a result of this operation.
+     * As of v3.2, only allow removal of dependency at last index, for UX purposes.
      * @param _projectId Project to be updated.
      * @param _index Asset index
      */

--- a/packages/contracts/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
+++ b/packages/contracts/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
@@ -521,17 +521,17 @@ contract GenArt721CoreV3_Engine_Flex is
             _projectId: _projectId,
             _index: _index,
             _cidOrData: _cidOrData,
-            _dependencyType: _dependencyType,
-            _artblocksDependencyRegistryAddress: artblocksDependencyRegistryAddress
+            _dependencyType: _dependencyType
         });
     }
 
     /**
      * @notice Updates external asset dependency for project `_projectId` of type
-     * ONCHAIN using on-chain compression. This function stores the string
-     * in a compressed format on-chain. For reads, the compressed script is
-     * decompressed on-chain, ensuring the original text is reconstructed without
-     * external dependencies.
+     * ONCHAIN using on-chain compression. The string should be compressed using
+     * `getCompressed`.
+     * This function stores the string in a compressed format on-chain.
+     * For reads, the compressed script is decompressed on-chain, ensuring the
+     * original text is reconstructed without external dependencies.
      * @dev _compressedString in memory to minimize bytecode size.
      * @param _projectId Project to be updated.
      * @param _index Asset index.
@@ -621,17 +621,17 @@ contract GenArt721CoreV3_Engine_Flex is
         V3FlexLib.addProjectExternalAssetDependency({
             _projectId: _projectId,
             _cidOrData: _cidOrData,
-            _dependencyType: _dependencyType,
-            _artblocksDependencyRegistryAddress: artblocksDependencyRegistryAddress
+            _dependencyType: _dependencyType
         });
     }
 
     /**
      * @notice Adds external asset dependency for project `_projectId` of type
-     * ONCHAIN using on-chain compression. This function stores the string
-     * in a compressed format on-chain. For reads, the compressed script is
-     * decompressed on-chain, ensuring the original text is reconstructed without
-     * external dependencies.
+     * ONCHAIN using on-chain compression. The string should be compressed using
+     * `getCompressed`.
+     * This function stores the string in a compressed format on-chain.
+     * For reads, the compressed script is decompressed on-chain, ensuring the
+     * original text is reconstructed without external dependencies.
      * @dev _compressedString in memory to minimize bytecode size.
      * @param _projectId Project to be updated.
      * @param _compressedString Pre-compressed string asset to be added.
@@ -2305,6 +2305,9 @@ contract GenArt721CoreV3_Engine_Flex is
      * If the dependencyType is ONCHAIN, the `data` field will contain the extrated bytecode data and `cid`
      * will be an empty string. Conversly, for any other dependencyType, the `data` field will be an empty string
      * and the `bytecodeAddress` will point to the zero address.
+     * If the dependencyType is ART_BLOCKS_DEPENDENCY_REGISTRY, the `cid` field will contain the string
+     * representation of the dependencyNameAndVersion bytes32 value stored in the dependency registry (
+     * at public address `artblocksDependencyRegistryAddress`)
      */
     function projectExternalAssetDependencyByIndex(
         uint256 _projectId,

--- a/packages/contracts/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
+++ b/packages/contracts/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
@@ -498,11 +498,14 @@ contract GenArt721CoreV3_Engine_Flex is
      * @notice Updates external asset dependency for project `_projectId`.
      * @param _projectId Project to be updated.
      * @param _index Asset index.
-     * @param _cidOrData Asset cid (Content identifier) or data string to be translated into bytecode.
+     * @param _cidOrData Field that contains the CID of the dependency if IPFS or ARWEAVE,
+     * empty string of ONCHAIN, or a string representation of the Art Blocks Dependency
+     * Registry's `dependencyNameAndVersion` if ART_BLOCKS_DEPENDENCY_REGISTRY.
      * @param _dependencyType Asset dependency type.
      *  0 - IPFS
      *  1 - ARWEAVE
      *  2 - ONCHAIN
+     *  3 - ART_BLOCKS_DEPENDENCY_REGISTRY
      */
     function updateProjectExternalAssetDependency(
         uint256 _projectId,
@@ -518,7 +521,8 @@ contract GenArt721CoreV3_Engine_Flex is
             _projectId: _projectId,
             _index: _index,
             _cidOrData: _cidOrData,
-            _dependencyType: _dependencyType
+            _dependencyType: _dependencyType,
+            _artblocksDependencyRegistryAddress: artblocksDependencyRegistryAddress
         });
     }
 
@@ -557,16 +561,16 @@ contract GenArt721CoreV3_Engine_Flex is
      * @param _index Asset index.
      * @param _assetAddress Address of the on-chain asset.
      */
-    function UpdateProjectAssetDependencyOnChainAtAddress(
+    function updateProjectAssetDependencyOnChainAtAddress(
         uint256 _projectId,
         uint256 _index,
         address _assetAddress
     ) external {
         _onlyArtistOrAdminACL(
             _projectId,
-            this.UpdateProjectAssetDependencyOnChainAtAddress.selector
+            this.updateProjectAssetDependencyOnChainAtAddress.selector
         );
-        V3FlexLib.UpdateProjectAssetDependencyOnChainAtAddress({
+        V3FlexLib.updateProjectAssetDependencyOnChainAtAddress({
             _projectId: _projectId,
             _index: _index,
             _assetAddress: _assetAddress
@@ -596,11 +600,14 @@ contract GenArt721CoreV3_Engine_Flex is
     /**
      * @notice Adds external asset dependency for project `_projectId`.
      * @param _projectId Project to be updated.
-     * @param _cidOrData Asset cid (Content identifier) or data string to be translated into bytecode.
+     * @param _cidOrData Field that contains the CID of the dependency if IPFS or ARWEAVE,
+     * empty string of ONCHAIN, or a string representation of the Art Blocks Dependency
+     * Registry's `dependencyNameAndVersion` if ART_BLOCKS_DEPENDENCY_REGISTRY.
      * @param _dependencyType Asset dependency type.
      *  0 - IPFS
      *  1 - ARWEAVE
      *  2 - ONCHAIN
+     *  3 - ART_BLOCKS_DEPENDENCY_REGISTRY
      */
     function addProjectExternalAssetDependency(
         uint256 _projectId,
@@ -614,7 +621,8 @@ contract GenArt721CoreV3_Engine_Flex is
         V3FlexLib.addProjectExternalAssetDependency({
             _projectId: _projectId,
             _cidOrData: _cidOrData,
-            _dependencyType: _dependencyType
+            _dependencyType: _dependencyType,
+            _artblocksDependencyRegistryAddress: artblocksDependencyRegistryAddress
         });
     }
 

--- a/packages/contracts/contracts/interfaces/v0.8.x/IDependencyRegistryV0.sol
+++ b/packages/contracts/contracts/interfaces/v0.8.x/IDependencyRegistryV0.sol
@@ -97,35 +97,4 @@ interface IDependencyRegistryV0 {
         bytes32 dependencyNameAndVersion,
         uint256 index
     ) external view returns (string memory);
-
-    /**
-     * @notice Returns details for a given dependency type `dependencyNameAndVersion`.
-     * @param dependencyNameAndVersion Name and version of dependency (i.e. "name@version") used to identify dependency.
-     * @return nameAndVersion String representation of `dependencyNameAndVersion`.
-     *                        (e.g. "p5js(atSymbol)1.0.0")
-     * @return licenseType License type for dependency
-     * @return preferredCDN Preferred CDN URL for dependency
-     * @return additionalCDNCount Count of additional CDN URLs for dependency
-     * @return preferredRepository Preferred repository URL for dependency
-     * @return additionalRepositoryCount Count of additional repository URLs for dependency
-     * @return dependencyWebsite Project website URL for dependency
-     * @return availableOnChain Whether dependency is available on chain
-     * @return scriptCount Count of on-chain scripts for dependency
-     */
-    function getDependencyDetails(
-        bytes32 dependencyNameAndVersion
-    )
-        external
-        view
-        returns (
-            string memory nameAndVersion,
-            string memory licenseType,
-            string memory preferredCDN,
-            uint24 additionalCDNCount,
-            string memory preferredRepository,
-            uint24 additionalRepositoryCount,
-            string memory dependencyWebsite,
-            bool availableOnChain,
-            uint24 scriptCount
-        );
 }

--- a/packages/contracts/contracts/interfaces/v0.8.x/IDependencyRegistryV0.sol
+++ b/packages/contracts/contracts/interfaces/v0.8.x/IDependencyRegistryV0.sol
@@ -97,4 +97,35 @@ interface IDependencyRegistryV0 {
         bytes32 dependencyNameAndVersion,
         uint256 index
     ) external view returns (string memory);
+
+    /**
+     * @notice Returns details for a given dependency type `dependencyNameAndVersion`.
+     * @param dependencyNameAndVersion Name and version of dependency (i.e. "name@version") used to identify dependency.
+     * @return nameAndVersion String representation of `dependencyNameAndVersion`.
+     *                        (e.g. "p5js(atSymbol)1.0.0")
+     * @return licenseType License type for dependency
+     * @return preferredCDN Preferred CDN URL for dependency
+     * @return additionalCDNCount Count of additional CDN URLs for dependency
+     * @return preferredRepository Preferred repository URL for dependency
+     * @return additionalRepositoryCount Count of additional repository URLs for dependency
+     * @return dependencyWebsite Project website URL for dependency
+     * @return availableOnChain Whether dependency is available on chain
+     * @return scriptCount Count of on-chain scripts for dependency
+     */
+    function getDependencyDetails(
+        bytes32 dependencyNameAndVersion
+    )
+        external
+        view
+        returns (
+            string memory nameAndVersion,
+            string memory licenseType,
+            string memory preferredCDN,
+            uint24 additionalCDNCount,
+            string memory preferredRepository,
+            uint24 additionalRepositoryCount,
+            string memory dependencyWebsite,
+            bool availableOnChain,
+            uint24 scriptCount
+        );
 }

--- a/packages/contracts/contracts/interfaces/v0.8.x/IGenArt721CoreContractV3_Engine_Flex.sol
+++ b/packages/contracts/contracts/interfaces/v0.8.x/IGenArt721CoreContractV3_Engine_Flex.sol
@@ -18,8 +18,8 @@ interface IGenArt721CoreContractV3_Engine_Flex is
      * @notice When an external asset dependency is updated or added, this event is emitted.
      * @param _projectId The project ID of the project that was updated.
      * @param _index The index of the external asset dependency that was updated.
-     * @param _cid The content ID of the external asset dependency. This is an empty string
-     * if the dependency type is ONCHAIN.
+     * @param _cid Field that contains the CID of the dependency if IPFS or ARWEAVE, empty string of ONCHAIN, or a string representation
+     * of the Art Blocks Dependency Registry's `dependencyNameAndVersion` if ART_BLOCKS_DEPENDENCY_REGISTRY.
      * @param _dependencyType The type of the external asset dependency.
      * @param _externalAssetDependencyCount The number of external asset dependencies.
      */
@@ -54,12 +54,13 @@ interface IGenArt721CoreContractV3_Engine_Flex is
     event ProjectExternalAssetDependenciesLocked(uint256 indexed _projectId);
 
     /**
-     * @notice An external asset dependency type. Can be one of IPFS, ARWEAVE, or ONCHAIN.
+     * @notice An external asset dependency type. Can be one of IPFS, ARWEAVE, ONCHAIN, or ART_BLOCKS_DEPENDENCY_REGISTRY.
      */
     enum ExternalAssetDependencyType {
         IPFS,
         ARWEAVE,
-        ONCHAIN
+        ONCHAIN,
+        ART_BLOCKS_DEPENDENCY_REGISTRY
     }
 
     /**
@@ -72,8 +73,12 @@ interface IGenArt721CoreContractV3_Engine_Flex is
     }
 
     /**
-     * @notice An external asset dependency. This is a struct that contains the CID of the dependency,
-     * the type of the dependency, and the address of the bytecode for this dependency.
+     * @notice An external asset dependency, without the retrieved data of any ONCHAIN assets. This reflects what is
+     * stored in this contract's storage.
+     * @param CID field that contains the CID of the dependency if IPFS or ARWEAVE, empty string of ONCHAIN, or a string representation
+     * of the Art Blocks Dependency Registry's `dependencyNameAndVersion` if ART_BLOCKS_DEPENDENCY_REGISTRY.
+     * @param dependencyType field that contains the type of the dependency.
+     * @param bytecodeAddress field that contains the address of the bytecode for this dependency if ONCHAIN, null address otherwise.
      */
     struct ExternalAssetDependency {
         string cid;
@@ -82,8 +87,12 @@ interface IGenArt721CoreContractV3_Engine_Flex is
     }
 
     /**
-     * @notice An external asset dependency with data. This is a convenience struct that contains the CID of the dependency,
-     * the type of the dependency, the address of the bytecode for this dependency, and the data retrieved from this bytecode address.
+     * @notice An external asset dependency with data. This is a convenience struct.
+     * @param CID field that contains the CID of the dependency if IPFS or ARWEAVE, empty string of ONCHAIN, or a string representation
+     * of the Art Blocks Dependency Registry's `dependencyNameAndVersion` if ART_BLOCKS_DEPENDENCY_REGISTRY.
+     * @param dependencyType field that contains the type of the dependency.
+     * @param bytecodeAddress field that contains the address of the bytecode for this dependency if ONCHAIN, null address otherwise.
+     * @param data field that contains the data retrieved from this bytecode address if ONCHAIN, empty string otherwise.
      */
     struct ExternalAssetDependencyWithData {
         string cid;

--- a/packages/contracts/contracts/libs/v0.8.x/V3FlexLib.sol
+++ b/packages/contracts/contracts/libs/v0.8.x/V3FlexLib.sol
@@ -4,7 +4,6 @@
 pragma solidity ^0.8.0;
 
 import {IGenArt721CoreContractV3_Engine_Flex} from "../../interfaces/v0.8.x/IGenArt721CoreContractV3_Engine_Flex.sol";
-import {IDependencyRegistryV0} from "../../interfaces/v0.8.x/IDependencyRegistryV0.sol";
 
 import {BytecodeStorageWriter, BytecodeStorageReader} from "./BytecodeStorageV2.sol";
 
@@ -142,8 +141,7 @@ library V3FlexLib {
         uint256 _projectId,
         uint256 _index,
         string memory _cidOrData,
-        IGenArt721CoreContractV3_Engine_Flex.ExternalAssetDependencyType _dependencyType,
-        address _artblocksDependencyRegistryAddress
+        IGenArt721CoreContractV3_Engine_Flex.ExternalAssetDependencyType _dependencyType
     ) external {
         FlexProjectData storage flexProjectData = getFlexProjectData(
             _projectId
@@ -151,18 +149,9 @@ library V3FlexLib {
         _onlyUnlockedProjectExternalAssetDependencies(flexProjectData);
         uint24 assetCount = flexProjectData.externalAssetDependencyCount;
         require(_index < assetCount, "Asset index out of range");
-        // if Art Blocks Dependency Registry, validate dependencyNameAndVersion
-        if (
-            _dependencyType ==
-            IGenArt721CoreContractV3_Engine_Flex
-                .ExternalAssetDependencyType
-                .ART_BLOCKS_DEPENDENCY_REGISTRY
-        ) {
-            _validateDependencyNameAndVersion({
-                dependencyNameAndVersion: _cidOrData,
-                artblocksDependencyRegistryAddress: _artblocksDependencyRegistryAddress
-            });
-        }
+        // @dev dependencyNameAndVersion are not validated against the dependency registry
+        // due to limitations of L1 reads on L2 networks at this time
+
         IGenArt721CoreContractV3_Engine_Flex.ExternalAssetDependency
             storage _oldDependency = flexProjectData.externalAssetDependencies[
                 _index
@@ -355,25 +344,14 @@ library V3FlexLib {
     function addProjectExternalAssetDependency(
         uint256 _projectId,
         string memory _cidOrData,
-        IGenArt721CoreContractV3_Engine_Flex.ExternalAssetDependencyType _dependencyType,
-        address _artblocksDependencyRegistryAddress
+        IGenArt721CoreContractV3_Engine_Flex.ExternalAssetDependencyType _dependencyType
     ) external {
         FlexProjectData storage flexProjectData = getFlexProjectData(
             _projectId
         );
         _onlyUnlockedProjectExternalAssetDependencies(flexProjectData);
-        // if Art Blocks Dependency Registry, validate dependencyNameAndVersion
-        if (
-            _dependencyType ==
-            IGenArt721CoreContractV3_Engine_Flex
-                .ExternalAssetDependencyType
-                .ART_BLOCKS_DEPENDENCY_REGISTRY
-        ) {
-            _validateDependencyNameAndVersion({
-                dependencyNameAndVersion: _cidOrData,
-                artblocksDependencyRegistryAddress: _artblocksDependencyRegistryAddress
-            });
-        }
+        // @dev dependencyNameAndVersion are not validated against the dependency registry
+        // due to limitations of L1 reads on L2 networks at this time
 
         uint24 assetCount = flexProjectData.externalAssetDependencyCount;
         address _bytecodeAddress = address(0);
@@ -595,56 +573,5 @@ library V3FlexLib {
             !flexProjectData.externalAssetDependenciesLocked,
             "External dependencies locked"
         );
-    }
-
-    function _validateDependencyNameAndVersion(
-        string memory dependencyNameAndVersion,
-        address artblocksDependencyRegistryAddress
-    ) private view {
-        require(
-            bytes(dependencyNameAndVersion).length > 0,
-            "Dependency name and version cannot be empty"
-        );
-        // call the dependency registry to validate the dependency name and version
-        // @dev assume valid dependencyNameAndVersion was input - worst case validation fails if invalid
-        bytes32 dependencyNameAndVersionBytes32 = stringToBytes32(
-            dependencyNameAndVersion
-        );
-        (
-            string memory returnedNameAndVersion,
-            ,
-            ,
-            ,
-            ,
-            ,
-            ,
-            ,
-
-        ) = IDependencyRegistryV0(artblocksDependencyRegistryAddress)
-                .getDependencyDetails(dependencyNameAndVersionBytes32);
-        // verify that the returned name and version string matches the string being validated
-        require(
-            keccak256(abi.encodePacked(returnedNameAndVersion)) ==
-                keccak256(abi.encodePacked(dependencyNameAndVersion)),
-            "Invalid dependency name and version"
-        );
-    }
-
-    /**
-     * converts from a short string to a bytes32. Does not work with longer strings,
-     * so only use with strings intended to represent a bytes32-formatted string.
-     * @param source The short string to convert to bytes32
-     */
-    function stringToBytes32(
-        string memory source
-    ) private pure returns (bytes32 result) {
-        bytes memory tempString = bytes(source);
-        if (tempString.length == 0) {
-            return 0x0;
-        }
-
-        assembly {
-            result := mload(add(source, 32))
-        }
     }
 }

--- a/packages/contracts/contracts/libs/v0.8.x/V3FlexLib.sol
+++ b/packages/contracts/contracts/libs/v0.8.x/V3FlexLib.sol
@@ -247,14 +247,15 @@ library V3FlexLib {
             _projectId
         );
         _onlyUnlockedProjectExternalAssetDependencies(flexProjectData);
+        // ensure the index is within the range of the asset count
         uint24 assetCount = flexProjectData.externalAssetDependencyCount;
         require(_index < assetCount, "Asset index out of range");
-
+        // @dev solidity underflow will revert on the following statement if assetCount is 0
         uint24 lastElementIndex = assetCount - 1;
+        // for UX purposes, only allow removal of the last lastElementIndex
+        require(_index == lastElementIndex, "Only removal of last asset");
 
-        // copy last element to index of element to be removed
-        flexProjectData.externalAssetDependencies[_index] = flexProjectData
-            .externalAssetDependencies[lastElementIndex];
+        // @dev simply delete last element; no need to copy last to deleted index due to require statement above
 
         delete flexProjectData.externalAssetDependencies[lastElementIndex];
 

--- a/packages/contracts/contracts/libs/v0.8.x/V3FlexLib.sol
+++ b/packages/contracts/contracts/libs/v0.8.x/V3FlexLib.sol
@@ -26,8 +26,9 @@ library V3FlexLib {
      * @notice When an external asset dependency is updated or added, this event is emitted.
      * @param _projectId The project ID of the project that was updated.
      * @param _index The index of the external asset dependency that was updated.
-     * @param _cid The content ID of the external asset dependency. This is an empty string
-     * if the dependency type is ONCHAIN.
+     * @param _cid Field that contains the CID of the dependency if IPFS or ARWEAVE,
+     * empty string of ONCHAIN, or a string representation of the Art Blocks Dependency
+     * Registry's `dependencyNameAndVersion` if ART_BLOCKS_DEPENDENCY_REGISTRY.
      * @param _dependencyType The type of the external asset dependency.
      * @param _externalAssetDependencyCount The number of external asset dependencies.
      */

--- a/packages/contracts/contracts/libs/v0.8.x/V3FlexLib.sol
+++ b/packages/contracts/contracts/libs/v0.8.x/V3FlexLib.sol
@@ -191,10 +191,9 @@ library V3FlexLib {
             // the incoming cid or string representation of the dependencyNameAndVersion
             flexProjectData.externalAssetDependencies[_index].cid = _cidOrData;
             // clear any previously populated bytecode address
-            // @dev temporarily commented out to confirm that this new test exposes previous bug
-            // flexProjectData
-            //     .externalAssetDependencies[_index]
-            //     .bytecodeAddress = address(0);
+            flexProjectData
+                .externalAssetDependencies[_index]
+                .bytecodeAddress = address(0);
         }
         emit ExternalAssetDependencyUpdated(
             _projectId,

--- a/packages/contracts/contracts/libs/v0.8.x/V3FlexLib.sol
+++ b/packages/contracts/contracts/libs/v0.8.x/V3FlexLib.sol
@@ -191,9 +191,10 @@ library V3FlexLib {
             // the incoming cid or string representation of the dependencyNameAndVersion
             flexProjectData.externalAssetDependencies[_index].cid = _cidOrData;
             // clear any previously populated bytecode address
-            flexProjectData
-                .externalAssetDependencies[_index]
-                .bytecodeAddress = address(0);
+            // @dev temporarily commented out to confirm that this new test exposes previous bug
+            // flexProjectData
+            //     .externalAssetDependencies[_index]
+            //     .bytecodeAddress = address(0);
         }
         emit ExternalAssetDependencyUpdated(
             _projectId,

--- a/packages/contracts/contracts/libs/v0.8.x/V3FlexLib.sol
+++ b/packages/contracts/contracts/libs/v0.8.x/V3FlexLib.sol
@@ -178,7 +178,12 @@ library V3FlexLib {
             // we don't want to emit data, so we emit the cid as an empty string
             _cidOrData = "";
         } else {
+            // incoming dependency type is not ONCHAIN, so we need to set the cid directly
             flexProjectData.externalAssetDependencies[_index].cid = _cidOrData;
+            // clear any previously populated bytecode address
+            flexProjectData
+                .externalAssetDependencies[_index]
+                .bytecodeAddress = address(0);
         }
         emit ExternalAssetDependencyUpdated(
             _projectId,
@@ -209,12 +214,12 @@ library V3FlexLib {
         );
         _onlyUnlockedProjectExternalAssetDependencies(flexProjectData);
 
-        // assign the asset address to the bytecodeAddress directly
+        // check that the index is within the range of the asset count
         uint24 assetCount = flexProjectData.externalAssetDependencyCount;
         require(_index < assetCount, "Asset index out of range");
 
         // EFFECTS
-        // overwrite the relevant fields of the previous asset
+        // overwrite the relevant fields of the previous asset, assigning bytecodeAddress directly
         IGenArt721CoreContractV3_Engine_Flex.ExternalAssetDependency
             storage currentDependency = flexProjectData
                 .externalAssetDependencies[_index];

--- a/packages/contracts/test/core/V3/GenArt721CoreV3_ENGINE_FLEX_Integration.tests.ts
+++ b/packages/contracts/test/core/V3/GenArt721CoreV3_ENGINE_FLEX_Integration.tests.ts
@@ -309,6 +309,35 @@ for (const coreContractName of coreContractsToTest) {
         expect(externalAssetDependency2[1]).to.equal(1);
       });
 
+      it("clears stale fields when updating extenal asset dependency from on-chain to off-chain", async function () {
+        const config = await loadFixture(_beforeEach);
+        // add assets for project 0 at index 0
+        await config.genArt721Core
+          .connect(config.accounts.artist)
+          .addProjectExternalAssetDependency(config.projectZero, "", 2);
+        // replace asset at index 0 with off-chain asset
+        await config.genArt721Core
+          .connect(config.accounts.artist)
+          .updateProjectExternalAssetDependency(
+            config.projectZero,
+            0,
+            "QmbCdEwHebtpLZSRLGnELbJmmVVJQJPfMEVo1vq2QBEoEo",
+            0
+          );
+        // asset at index 0 should remove any on-chain data
+        const externalAssetDependency = await config.genArt721Core
+          .connect(config.accounts.artist)
+          .projectExternalAssetDependencyByIndex(config.projectZero, 0);
+        expect(externalAssetDependency.cid).to.equal(
+          "QmbCdEwHebtpLZSRLGnELbJmmVVJQJPfMEVo1vq2QBEoEo"
+        );
+        expect(externalAssetDependency.dependencyType).to.equal(0);
+        expect(externalAssetDependency.bytecodeAddress).to.equal(
+          constants.ZERO_ADDRESS
+        );
+        expect(externalAssetDependency.data).to.equal("");
+      });
+
       it("can update an external asset dependency (on-chain)", async function () {
         const config = await loadFixture(_beforeEach);
         // validating that an off-chain asset dependency can be updated to an on-chain asset dependency


### PR DESCRIPTION
## Description of the change

Provision the Flex contract with a few key items to unlock at a future date.

linear: https://linear.app/art-blocks/issue/PRO-194/provision-v32-core-wfuture-flex-capabilities

Provisions include: 

* Add ability to define on-chain from existing BytecodeStorage address
* Add new type that points to dependency registry type and version
* Add ability to perform on-chain compressed flex uploads

Additionally, for a cleaner UX, add guards to only allow removal of last Flex asset to prevent accidental script breaking (already constraining on CD)

Note: this also has a small bug-fix dealing with stale bytecode addresses not being properly cleared, which has existed on previous V3 Flex contracts, but doesn't meaningfully impact the function of the contract, in [520b0d4](https://github.com/ArtBlocks/artblocks-contracts/pull/1518/commits/520b0d41e600df5560236c1875bcc00193d7729b)

## Design

A few decisions to note:
* opted to NOT perform on-chain validation of input dependency name and version against what is populated on the contract's referenced on-chain dependency registry.
  * partially because L1 reads are not available from L2 contracts, partially because crafting a "dependency exists" function is a bit hacky at the moment.
* the existing cidOrData field was used to store a string representation of the dependency registry's `bytes32 dependencyNameAndVersion`
* new external functions were added for uploading existing on-chain assets and uploading compressed assets, instead of adding new optional args to existing asset upload functions
  * maintains backwards-compatible interface conformance
  * adds bytecode for the new external functions
* library functions were kept external, even when dealing with large quantities of data transfer, due to bytecode size limits

## Bytecode changes

These changes add roughly 0.53 kb of bytecode to the V3 Engine Flex contract, largely due to the new external functions.

## Tests

- [ ] Add tests for full coverage of new functionality
- [x] Confirm minor stale field bug fix behavior is resolved 

## Immediate follow-on

The following updates are required to avoid potential subgraph and general indexing failures when indexing these contracts:

- New enum type added to subgraph for FLEX_CONTRACT_EXTERNAL_ASSET_DEP_TYPES
- New enum type added to database

Other follow-on updates required include updating CD to provide interfaces to these new functions.