### PR TITLE
Add v3.2 function used by subgraph to interface

### DIFF
--- a/packages/contracts/contracts/interfaces/v0.8.x/IGenArt721CoreContractV3_Engine.sol
+++ b/packages/contracts/contracts/interfaces/v0.8.x/IGenArt721CoreContractV3_Engine.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.0;
 
 import "./IAdminACLV0.sol";
 import "./IGenArt721CoreContractV3_Base.sol";
+import "./ISplitProviderV0.sol";
 
 /**
  * @notice Struct representing Engine contract configuration.
@@ -136,4 +137,10 @@ interface IGenArt721CoreContractV3_Engine is IGenArt721CoreContractV3_Base {
         external
         view
         returns (uint256);
+
+    /**
+     * @notice The address of the current split provider being used by the contract.
+     * @return The address of the current split provider.
+     */
+    function splitProvider() external view returns (ISplitProviderV0);
 }

--- a/packages/contracts/contracts/interfaces/v0.8.x/integration-refs/splits-0x-v2/ISplitFactoryV2.sol
+++ b/packages/contracts/contracts/interfaces/v0.8.x/integration-refs/splits-0x-v2/ISplitFactoryV2.sol
@@ -4,7 +4,7 @@
 //  - https://github.com/0xSplits/splits-contracts-monorepo/blob/main/packages/splits-v2/src/libraries/SplitV2.sol
 //  - https://github.com/0xSplits/splits-contracts-monorepo/blob/main/packages/splits-v2/src/splitters/SplitFactoryV2.sol
 
-pragma solidity 0.8.22;
+pragma solidity ^0.8.0;
 
 interface ISplitFactoryV2 {
     /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
## Description of the change

Add function `splitProvider` used by Subgraph to Engine interface.

reference this subgraph PR: https://github.com/ArtBlocks/artblocks-subgraph/pull/298
