### PR TITLE
Minor changes to allow immediate action after a bid is submitted

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artblocks/sdk",
-  "version": "0.1.30-1",
+  "version": "0.1.30-4",
   "description": "JavaScript SDK for configuring and using Art Blocks minters.",
   "main": "dist/index.js",
   "repository": "git@github.com:ArtBlocks/artblocks-sdk.git",


### PR DESCRIPTION
## Description of the change
This PR is in support of new changes made to the curated ram bid flow which allow a user to move immediately to creating a new bid or top up a bid after a bid has successfully been created or topped up.

https://linear.app/art-blocks/issue/CUR-1529/ram-bid-slot-selector
