### PR TITLE
Deploy curated mainnet

### DIFF
--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -160,25 +160,11 @@ Core contracts use the versioning schema below:
 | :-----------------------: | :-----------------------: | :-----------: | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 |        AB Core V0         |            V0             |      0-2      | `0x059EDD72Cd353dF5106D2B9cC5ab83a52287aC3a`                                                                                                                                                                     |
 |        AB Core V1         |            V1             |     3-373     | `0xa7d8d9ef8D8Ce8992Df33D8b8CF4Aebabd5bD270`                                                                                                                                                                     |
+|        AB Core V3         |            V3             |    374-493    | `0x99a9B7c1116f9ceEB1652de04d5969CcE509B069`                                                                                                                                                                     |
+|  AB Core V3.2 (current)   |           V3.2            |     494+      | `0xAB0000000000aa06f89B268D604a9c1C41524Ac6`                                                                                                                                                                     |
 |     Engine Cores (V2)     |          V2_PBAB          | All V2 Engine | Various - see `deployments/engine/` directory [DEPLOYMENTS.md files](https://github.com/search?q=repo%3Aartblocks%2Fartblocks-contracts+path%3A*.md+path%3A**%2FDEPLOYMENTS.md&type=Code&ref=advsearch&l=&l=)    |
 | Engine Partner Cores (V2) |         V2_PRTNR          | All V2 PRTNR  | Various - see `deployments/engine/` directory [DEPLOYMENTS.md files](https://github.com/search?q=repo%3Aartblocks%2Fartblocks-contracts+path%3A*.md+path%3A**%2FDEPLOYMENTS.md&type=Code&ref=advsearch&l=&l=)    |
-|   AB Core V3 (current)    |            V3             |     374+      | `0x99a9B7c1116f9ceEB1652de04d5969CcE509B069`                                                                                                                                                                     |
 | Engine_V3, Engine_V3_Flex | Engine_V3, Engine_V3_Flex | All V3 Engine | Various - see `deployments/engine/V3/` directory [DEPLOYMENTS.md](https://github.com/search?q=repo%3Aartblocks%2Fartblocks-contracts+path%3A*.md+path%3A**%2FDEPLOYMENTS.md&type=Code&ref=advsearch&l=&l=) files |
-
-> AB Core V3 [changelog here](./contracts/V3_CHANGELOG.md), and [performance metrics here](./contracts/V3_PERFORMANCE.md).
-
-### Testnet Contracts
-
-The following represents the current set of flagship core contracts deployed on the Goerli testnet, and their active Minter Filters:
-
-- Art Blocks Artist Staging (Goerli):
-
-  - V1 Core (deprecated): https://goerli.etherscan.io/address/0xDa62f67BE7194775A75BE91CBF9FEeDcC5776D4b
-  - V3 Core: https://goerli.etherscan.io/address/0xB614C578062a62714c927CD8193F0b8Bfb90055C
-
-- Art Blocks Dev (Goerli):
-  - V1 Core (deprecated): https://goerli.etherscan.io/address/0x1Bf03F29c4FEFFFe4eE26704aaA31d85c026aCE6
-  - V3 Core: https://goerli.etherscan.io/address/0xF396C180bb2f92EE28535D23F5224A5b9425ceca
 
 ## Art Blocks Engine Core Contracts
 

--- a/packages/contracts/deployments/flagship/V3/mainnet/AdminACLV0/AdminACLV0.md
+++ b/packages/contracts/deployments/flagship/V3/mainnet/AdminACLV0/AdminACLV0.md
@@ -32,6 +32,6 @@ Deploys to address: `0x000000abB7A99780820c87c850Af7fD1Bc5e6788`
 
 Update superAdmin from OwnedCreate2FactoryV0 to mainnet admin (`0xCF00eC2B327BCfA2bee2D8A5Aee0A7671d08A283`):
 
-- etherscan_tbd
+- https://etherscan.io/tx/0x74e9ebb1cd3b36b0dc2cb046a7876268fc4bf12b6102e8065ff1fc1d48031587
 
 note: easy to get appropriate calldata from a failed tx generated on etherscan, then use gnosis tx builder to execute the call

--- a/packages/contracts/deployments/flagship/V3/mainnet/AdminACLV0/AdminACLV0.md
+++ b/packages/contracts/deployments/flagship/V3/mainnet/AdminACLV0/AdminACLV0.md
@@ -26,7 +26,7 @@ Deploys to address: `0x000000abB7A99780820c87c850Af7fD1Bc5e6788`
 
 ### Deployment transactions:
 
-- etherscan_tbd
+- https://etherscan.io/tx/0xebda574125f830642eee70f75978b8fe3427ae657db55a81826eb96362bdfe69
 
 ## Follow-on transactions:
 

--- a/packages/contracts/deployments/flagship/V3/mainnet/AdminACLV0/AdminACLV0.md
+++ b/packages/contracts/deployments/flagship/V3/mainnet/AdminACLV0/AdminACLV0.md
@@ -1,0 +1,37 @@
+# Deployments: AdminACLV0
+
+## Description
+
+The owned create2 factory was used to deploy a new AdminACLV0 contract.
+
+This was for the mainnet environment.
+
+**important**: AdminACLV0 sets superAdmin to msg.sender, which is the deployer, which in this case is the OwnedCreate2FactoryV0 contract.
+Therefore, a follow-on transaction to the OwnedCreate2FactoryV0 contract was required to update the superAdmin to the admin's multisig, using the `execCalls` function.
+That transaction is included in the deployment transactions below, for reference.
+
+The following were the inputs used to get initcode for deployment, via `scripts/get-init-code.ts`:
+
+```typescript
+const inputs: T_Inputs = {
+  contractName: "AdminACLV0",
+  args: [],
+  libraries: {},
+};
+```
+
+## Results:
+
+Deploys to address: `0x000000abB7A99780820c87c850Af7fD1Bc5e6788`
+
+### Deployment transactions:
+
+- etherscan_tbd
+
+## Follow-on transactions:
+
+Update superAdmin from OwnedCreate2FactoryV0 to mainnet admin (`0xCF00eC2B327BCfA2bee2D8A5Aee0A7671d08A283`):
+
+- etherscan_tbd
+
+note: easy to get appropriate calldata from a failed tx generated on etherscan, then use gnosis tx builder to execute the call

--- a/packages/contracts/deployments/flagship/V3/mainnet/GenArt721CoreV3_Curated/GenArt721CoreV3_Curated.md
+++ b/packages/contracts/deployments/flagship/V3/mainnet/GenArt721CoreV3_Curated/GenArt721CoreV3_Curated.md
@@ -68,17 +68,22 @@ args:
 
 Registration tx:
 
-- etherscan_tbd
+- 0x6b5f48538e70ec624ae592bc2d82bc8d7976a3b9b83d9e48795703964729b8f1
 
 II. Re-Call `updateMinterContract` on `GenArt721CoreV3_Curated` to set `MinterFilter` contract:
 
 > Note: This fixes an indexing quirk associated with not approving the core in same block as deployment. It does not alter on-chain state.
 
+- https://etherscan.io/tx/0x91f7530374cd00f87c174a655e9e09973db860149032e3495915fbbad20f5919
+
+III. Follow-on configuring:
+
+- update dependency registry
+- set render provider primary and secondary sales addresses
+
 - etherscan_tbd
 
-## Follow-on steps:
-
-- create image bucket on s3: `art-blocks-curated-mainnet`
+## Off-chain steps:
 
 - hasura metadata update to contracts_metadata:
   - `bucket_name` = `artblocks-mainnet`

--- a/packages/contracts/deployments/flagship/V3/mainnet/GenArt721CoreV3_Curated/GenArt721CoreV3_Curated.md
+++ b/packages/contracts/deployments/flagship/V3/mainnet/GenArt721CoreV3_Curated/GenArt721CoreV3_Curated.md
@@ -1,0 +1,86 @@
+# Deployments: GenArt721CoreV3_Curated
+
+## Description
+
+The owned create2 factory was used to deploy a new GenArt721CoreV3_Curated contract.
+
+This was for the mainnet environment.
+
+The following were the inputs used to get initcode for deployment, via `scripts/get-init-code.ts`:
+
+> Note: `newSuperAdminAddress` input param is not used in curated core contract
+
+```typescript
+const engineConfiguration = {
+  tokenName: "Art Blocks",
+  tokenSymbol: "BLOCKS",
+  renderProviderAddress: "0x21A89ef8c577ebaCfe8198644222B49DFD9284F9",
+  platformProviderAddress: "0x0000000000000000000000000000000000000000",
+  // @dev newSuperAdminAddress input param is not used in curated core contract
+  newSuperAdminAddress: "0x0000000000000000000000000000000000000000",
+  randomizerContract: "0x13178A7a8A1A9460dBE39f7eCcEbD91B31752b91",
+  splitProviderAddress: "0x0000000004B100B47f061968a387c82702AFe946",
+  minterFilterAddress: "0xa2ccfE293bc2CDD78D8166a82D1e18cD2148122b",
+  startingProjectId: 494,
+  autoApproveArtistSplitProposals: false,
+  nullPlatformProvider: true,
+  allowArtistProjectActivation: false,
+};
+const adminACLContractAddress = "0x000000abB7A99780820c87c850Af7fD1Bc5e6788";
+const defaultBaseURIHost = "https://token.artblocks.io/";
+const bytecodeStorageReaderContract =
+  "0x000000000000A791ABed33872C44a3D215a3743B";
+
+const inputs: T_Inputs = {
+  contractName: "GenArt721CoreV3_Curated",
+  args: [
+    engineConfiguration,
+    adminACLContractAddress,
+    defaultBaseURIHost,
+    bytecodeStorageReaderContract,
+  ],
+  libraries: {
+    "contracts/libs/v0.8.x/BytecodeStorageV2.sol:BytecodeStorageReader":
+      "0x000000000016A5A5ff2FA7799C4BEe89bA59B74e",
+  },
+};
+```
+
+## Results:
+
+Deploys to address: `0xAB0000000000aa06f89B268D604a9c1C41524Ac6`
+
+### Deployment transactions:
+
+- etherscan_tbd
+
+## Follow-on transactions:
+
+I. Add `GenArt721CoreV3_Curated` to `CoreRegistry` through `EngineFactory` call to `registerMultipleContracts`:
+
+> Note: Must be queued via gnosis safe tx builder and executed by multisig
+
+args:
+
+- `0xAB0000000000aa06f89B268D604a9c1C41524Ac6` // core address
+- `0x76332e322e360000000000000000000000000000000000000000000000000000` // core version = "v3.2.6"
+- `0x47656e417274373231436f726556335f456e67696e6500000000000000000000` // core type = "GenArt721CoreV3_Engine"
+
+Registration tx:
+
+- etherscan_tbd
+
+III. Re-Call `updateMinterContract` on `GenArt721CoreV3_Curated` to set `MinterFilter` contract:
+
+> Note: This fixes an indexing quirk associated with not approving the core in same block as deployment. It does not alter on-chain state.
+
+- etherscan_tbd
+
+## Follow-on steps:
+
+- create image bucket on s3: `art-blocks-curated-mainnet`
+
+- hasura metadata update to contracts_metadata:
+  - `bucket_name` = `artblocks-mainnet`
+  - `name` = "artblocks"
+  - `default_vertical_name` = "curated"

--- a/packages/contracts/deployments/flagship/V3/mainnet/GenArt721CoreV3_Curated/GenArt721CoreV3_Curated.md
+++ b/packages/contracts/deployments/flagship/V3/mainnet/GenArt721CoreV3_Curated/GenArt721CoreV3_Curated.md
@@ -82,7 +82,7 @@ III. Follow-on configuring:
 - set render provider primary and secondary sales addresses
 - update render provider primary sales percentage
 
-- etherscan_tbd
+- https://etherscan.io/tx/0x94f7d8aa80738179a5ec981ca5937815d12a9d353b0486191d9050b718735fdc
 
 ## Off-chain steps:
 

--- a/packages/contracts/deployments/flagship/V3/mainnet/GenArt721CoreV3_Curated/GenArt721CoreV3_Curated.md
+++ b/packages/contracts/deployments/flagship/V3/mainnet/GenArt721CoreV3_Curated/GenArt721CoreV3_Curated.md
@@ -52,7 +52,7 @@ Deploys to address: `0xAB0000000000aa06f89B268D604a9c1C41524Ac6`
 
 ### Deployment transactions:
 
-- etherscan_tbd
+- https://etherscan.io/tx/0x875d301f99a48593010704730d0fa3eb020f3d29de9d38bc59d13818e4a0ccb7
 
 ## Follow-on transactions:
 
@@ -70,7 +70,7 @@ Registration tx:
 
 - etherscan_tbd
 
-III. Re-Call `updateMinterContract` on `GenArt721CoreV3_Curated` to set `MinterFilter` contract:
+II. Re-Call `updateMinterContract` on `GenArt721CoreV3_Curated` to set `MinterFilter` contract:
 
 > Note: This fixes an indexing quirk associated with not approving the core in same block as deployment. It does not alter on-chain state.
 

--- a/packages/contracts/deployments/flagship/V3/mainnet/GenArt721CoreV3_Curated/GenArt721CoreV3_Curated.md
+++ b/packages/contracts/deployments/flagship/V3/mainnet/GenArt721CoreV3_Curated/GenArt721CoreV3_Curated.md
@@ -80,6 +80,7 @@ III. Follow-on configuring:
 
 - update dependency registry
 - set render provider primary and secondary sales addresses
+- update render provider primary sales percentage
 
 - etherscan_tbd
 

--- a/packages/contracts/deployments/owned-create2-factory/mainnet/OwnedCreate2FactoryV0.md
+++ b/packages/contracts/deployments/owned-create2-factory/mainnet/OwnedCreate2FactoryV0.md
@@ -1,0 +1,25 @@
+# Deployments: OwnedCreate2FactoryV0
+
+## Description
+
+The keyless create2 factory was used to deterministically and permissionlessly deploy the OwnedCreate2FactoryV0 contract.
+
+This was for mainnet environment.
+
+The following were the inputs used to get initcode for deployment, via `scripts/get-init-code.ts`:
+
+```typescript
+const inputs: T_Inputs = {
+  contractName: "OwnedCreate2FactoryV0",
+  args: ["0x52119BB73Ac8bdbE59aF0EEdFd4E4Ee6887Ed2EA"], // admin's deployer multisig
+  libraries: {},
+};
+```
+
+## Results:
+
+Deploys to address: `0x000000AB6881DbbBD231dB99D69134FEA2385Bf8`
+
+### Deployment transactions:
+
+- etherscan_tbd

--- a/packages/contracts/deployments/owned-create2-factory/mainnet/OwnedCreate2FactoryV0.md
+++ b/packages/contracts/deployments/owned-create2-factory/mainnet/OwnedCreate2FactoryV0.md
@@ -22,4 +22,4 @@ Deploys to address: `0x000000AB6881DbbBD231dB99D69134FEA2385Bf8`
 
 ### Deployment transactions:
 
-- etherscan_tbd
+- https://etherscan.io/tx/0x5157bf60406f10bfdbf381e5c1873319393657b9ed2fc4df8384df258e68ec13


### PR DESCRIPTION
## Description of the change

Deploy new v3.2.6 Curated core contract.

This process includes:

- [x] deploy owned create2 factory
- [x] deploy adminACL
- [x] deploy properly configured GenArt721CoreV3_Curated core via owned create2 factory
- [x] register the new curated core on the current mainnet CoreRegistry

Additionally, contracts readme is updated with the new deployment info.