### PR TITLE
Filter RAM from CD minter options if not curated

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artblocks/sdk",
-  "version": "0.1.30-7",
+  "version": "0.1.30-9",
   "description": "JavaScript SDK for configuring and using Art Blocks minters.",
   "main": "dist/index.js",
   "repository": "git@github.com:ArtBlocks/artblocks-sdk.git",

--- a/packages/sdk/src/minter-configuration/index.ts
+++ b/packages/sdk/src/minter-configuration/index.ts
@@ -152,7 +152,7 @@ async function generateSelectMinterForm({
   if (minterSelectionFormSchemaWithMinters.properties?.["minter.address"]) {
     const globallyAllowedMinters =
       project.contract.minter_filter.globally_allowed_minters ?? [];
-    const latestMinters = globallyAllowedMinters.reduce(
+    let latestMinters = globallyAllowedMinters.reduce(
       (dedupedMinters, minter) => {
         return dedupedMinters.filter((mntr) => {
           return (
@@ -164,6 +164,15 @@ async function generateSelectMinterForm({
         });
       },
       globallyAllowedMinters
+    );
+
+    // filter out RAM minters if not on curated mainnet, until supported on platform frontend
+    latestMinters = latestMinters.filter(
+      (minter) =>
+        !minter.type?.unversioned_type?.includes("MinterRAM") ||
+        project.project_id.startsWith(
+          "0xab0000000000aa06f89b268d604a9c1c41524ac6-"
+        )
     );
 
     minterSelectionFormSchemaWithMinters.properties["minter.address"].oneOf =


### PR DESCRIPTION
## Description of the change

Filter RAM from CD minter options if not curated.

This logic should be removed once RAM is supported on platform frontend.

sdk prerelease version is bumped.
