### PR TITLE
Fix allowlist upload

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artblocks/sdk",
-  "version": "0.1.30-9",
+  "version": "0.1.30-10",
   "description": "JavaScript SDK for configuring and using Art Blocks minters.",
   "main": "dist/index.js",
   "repository": "git@github.com:ArtBlocks/artblocks-sdk.git",

--- a/packages/sdk/src/minter-configuration/submission-processing/process-allowlist-file-to-merkle-root.test.ts
+++ b/packages/sdk/src/minter-configuration/submission-processing/process-allowlist-file-to-merkle-root.test.ts
@@ -83,7 +83,6 @@ describe("processAllowlistFileToMerkleRoot", () => {
     expect(global.fetch).toHaveBeenCalledWith("fake-url", {
       method: "PUT",
       headers: {
-        "x-amz-acl": "public-read",
         "Content-Type": "application/json",
       },
       body: JSON.stringify(["address1", "address2"]),

--- a/packages/sdk/src/minter-configuration/submission-processing/process-allowlist-file-to-merkle-root.test.ts
+++ b/packages/sdk/src/minter-configuration/submission-processing/process-allowlist-file-to-merkle-root.test.ts
@@ -50,7 +50,10 @@ describe("processAllowlistFileToMerkleRoot", () => {
     });
 
     // Mock the fetch request to upload the file to s3
-    (global.fetch as jest.Mock).mockResolvedValueOnce({});
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve(""),
+    });
 
     // Mock generating the merkle root
     (merkleUtils.getMerkleRoot as jest.Mock).mockReturnValue(

--- a/packages/sdk/src/minter-configuration/submission-processing/process-allowlist-file-to-merkle-root.ts
+++ b/packages/sdk/src/minter-configuration/submission-processing/process-allowlist-file-to-merkle-root.ts
@@ -71,14 +71,18 @@ export async function processAllowlistFileToMerkleRoot(
 
   try {
     // Upload allowlist file to s3 as a json file
-    await fetch(url, {
+    const res = await fetch(url, {
       method: "PUT",
       body: JSON.stringify(allowlist),
       headers: {
-        "x-amz-acl": "public-read",
         "Content-Type": "application/json",
       },
     });
+
+    if (!res.ok) {
+      console.error(await res.text());
+      throw new Error("Unexpected error uploading allowlist file");
+    }
   } catch (e) {
     console.error(e);
     throw new Error("Unexpected error uploading allowlist file");


### PR DESCRIPTION
## Description of the change

After updating the aws-sdk to v3 in `services-allowlist-service` a header (`x-amz-acl`) we were adding in our upload request was causing the upload to fail. Additionally since the failure response was a 403 and not a network error the fetch call did not throw and so the error would be swallowed, allowing the user to proceed to update the merkle root on-chain. This PR removes the `x-amz-acl` header and throws an error if the fetch call response does not have ok: true.

see: https://github.com/ArtBlocks/artblocks/pull/2753
