### PR TITLE
Use universal reader in on-chain generator

### DIFF
--- a/packages/contracts/contracts/generator/AddressChunks.sol
+++ b/packages/contracts/contracts/generator/AddressChunks.sol
@@ -4,15 +4,45 @@
 pragma solidity ^0.8.17;
 
 library AddressChunks {
+    /**
+     * @notice Merge multiple chunks of contract code into a single bytes array.
+     * Offloads details of reading contract code to UniversalBytecodeStorageReader contract, but efficiently
+     * merges staticcall responses into a single bytes array using assembly.
+     * @dev This could become more gas efficient by implementing logic in the bytecode storage reader contracts
+     * here instead of moving large amounts of data through return data, but this implementation is much simpler
+     * and maintainable.
+     * @param chunks Array of contract addresses to merge
+     * @param universalReaderContract Address of the UniversalBytecodeStorageReader contract to use for reading
+     * stored bytecode (Art Blocks BytecodeStorage library)
+     * @return o_code Merged contract code
+     */
     function mergeChunks(
         address[] memory chunks,
-        uint256 offset
+        address universalReaderContract
     ) internal view returns (bytes memory o_code) {
         unchecked {
-            assembly {
+            assembly ("memory-safe") {
+                // part 1: provision memory for calldata to universal reader's readFromBytecode function
+                // 4 bytes for function selector, 32 bytes for address
+                let readerCalldata := mload(0x40)
+                mstore(readerCalldata, 0x75662f38) // function selector for readFromBytecode(address)
+                // calldata in memory will look like:
+                //  000000000000000000000000000000000000000000000000000000006e242d7f
+                //  000000000000000000000000<-------------chunk-address------------>
+                // @dev do not populate address yet - do in call loop
+                // update free memory pointer two words ahead, past end reserved for calldata
+                mstore(0x40, add(readerCalldata, 0x40))
+                // update calldata to point to the start of the function selector
+                readerCalldata := add(readerCalldata, 28)
+
+                // part 2: reserve space 0x20 bytes representing the returned string length data for each call in loop
+                let returnDataStringLength := mload(0x40)
+                // update free memory pointer one word ahead, past end of returnDataStringLength
+                mstore(0x40, add(returnDataStringLength, 0x20))
+
+                // part 3: build o_code while looping through chunks
                 let len := mload(chunks)
                 let totalSize := 0x20
-                let size := 0
                 o_code := mload(0x40)
 
                 // loop through all chunk addresses
@@ -27,20 +57,49 @@ library AddressChunks {
                     i := add(i, 1)
                 } {
                     targetChunk := mload(add(chunks, add(0x20, mul(i, 0x20))))
-                    size := sub(extcodesize(targetChunk), offset)
-                    extcodecopy(
-                        targetChunk,
-                        add(o_code, totalSize),
-                        offset,
-                        size
+                    // update calldata with targetChunk address
+                    mstore(add(readerCalldata, 0x04), targetChunk) // offset by 4-byte function selector
+                    // call the readFromBytecode(address) function of contract targetChunk and don't store the result
+                    if iszero(
+                        staticcall(
+                            gas(), // forward all gas
+                            universalReaderContract, // target address with the data stored as bytecode
+                            readerCalldata, // start of calldata
+                            0x24, // calldata size is 0x04 (function selector) + 0x20 (abi-encoded address)
+                            0x00, // 0x00 (do not store return data)
+                            0x00 // 0x00 (do not store return data)
+                        )
+                    ) {
+                        revert(0, 0) // call failed, revert
+                    }
+
+                    // store return data string length
+                    returndatacopy(
+                        returnDataStringLength,
+                        0x20, // start of return data's string length (ABI spec)
+                        0x20 // size of length data (ABI spec)
                     )
-                    totalSize := add(totalSize, size)
+
+                    // store the return string data in memory starting at o_code + totalSize
+                    // first 0x20 bytes of return data points to the location of the string data (ABI spec)
+                    // second 0x20 bytes of return data is the length of the data (ABI spec)
+                    // the actual string data contents begin at returndata + 0x40
+                    let storedReturnSize := mload(returnDataStringLength)
+                    returndatacopy(
+                        add(o_code, totalSize), // offset by totalSize
+                        0x40, // skip the 0x40 bytes of length data at the start of the expected return data
+                        storedReturnSize // return data size, as gathered above
+                    )
+                    totalSize := add(totalSize, storedReturnSize) // update total size
                 }
 
-                // update o_code size
+                // update o_code length in memory
                 mstore(o_code, sub(totalSize, 0x20))
-                // store o_code
-                mstore(0x40, add(o_code, and(add(totalSize, 0x1f), not(0x1f))))
+                // new "memory end" including padding
+                mstore(
+                    0x40,
+                    add(o_code, and(add(add(totalSize, 0x20), 0x1f), not(0x1f)))
+                )
             }
         }
     }

--- a/packages/contracts/contracts/generator/AddressChunks.sol
+++ b/packages/contracts/contracts/generator/AddressChunks.sol
@@ -27,7 +27,7 @@ library AddressChunks {
                 let readerCalldata := mload(0x40)
                 mstore(readerCalldata, 0x75662f38) // function selector for readFromBytecode(address)
                 // calldata in memory will look like:
-                //  000000000000000000000000000000000000000000000000000000006e242d7f
+                //  0000000000000000000000000000000000000000000000000000000075662f38
                 //  000000000000000000000000<-------------chunk-address------------>
                 // @dev do not populate address yet - do in call loop
                 // update free memory pointer two words ahead, past end reserved for calldata

--- a/packages/contracts/contracts/interfaces/v0.8.x/IGenArt721GeneratorV0.sol
+++ b/packages/contracts/contracts/interfaces/v0.8.x/IGenArt721GeneratorV0.sol
@@ -8,4 +8,7 @@ interface IGenArt721GeneratorV0 {
     event GunzipScriptBytecodeAddressUpdated(
         address indexed _gunzipScriptBytecodeAddress
     );
+    event UniversalBytecodeStorageReaderUpdated(
+        address indexed _universalBytecodeStorageReader
+    );
 }


### PR DESCRIPTION
## Description of the change

Update on-chain generator to use universal reader to expand compatibility and simplify code.

This is intended to fold into #1320 

Updating the on-chain generator to use the universal reader improves maintainability of the on-chain generator by delegating compatibility responsibilities to the universal reader contract.

Some gas-efficiency is traded for broader support + maintainability in the PR. There are now more data being passed through contract calls. However, the concatenation of all script chunks is still performed in assembly, preventing any gas costs that scale faster than `n`, where `n` is number of script chunks/dependency chunks.

A test is added to validate support of BytecodeStorageV2 on-chain compression.

fixes https://linear.app/art-blocks/issue/PLT-829/add-on-chain-compression-capability-to-gen
