### PR TITLE
support flex on generator

### DIFF
--- a/packages/contracts/contracts/generator/GenArt721GeneratorV0.sol
+++ b/packages/contracts/contracts/generator/GenArt721GeneratorV0.sol
@@ -385,11 +385,11 @@ contract GenArt721GeneratorV0 is Initializable, IGenArt721GeneratorV0 {
 
         // build tokenData json object
         string[] memory tokenDataKeys = isFlex
-            ? new string[](5)
-            : new string[](2);
+            ? JsonStatic.newKeysArray(5)
+            : JsonStatic.newKeysArray(2);
         JsonStatic.Json[] memory tokenDataValues = isFlex
-            ? new JsonStatic.Json[](5)
-            : new JsonStatic.Json[](2);
+            ? JsonStatic.newValuesArray(5)
+            : JsonStatic.newValuesArray(2);
 
         // token id
         tokenDataKeys[0] = "tokenId";
@@ -402,8 +402,8 @@ contract GenArt721GeneratorV0 is Initializable, IGenArt721GeneratorV0 {
         if (isV0CoreContract) {
             // @dev V0 contracts return an array of hashes, with only one hash
             tokenDataKeys[1] = "hashes";
-            JsonStatic.Json[]
-                memory tokenDataValuesHashes = new JsonStatic.Json[](1);
+            JsonStatic.Json[] memory tokenDataValuesHashes = JsonStatic
+                .newValuesArray(1);
             tokenDataValuesHashes[0] = JsonStatic.newStringElement({
                 value: Strings.toHexString(uint256(tokenHash)),
                 stringEncodingFlag: JsonStatic.StringEncodingFlag.NONE
@@ -444,15 +444,13 @@ contract GenArt721GeneratorV0 is Initializable, IGenArt721GeneratorV0 {
             uint256 externalAssetDependencyCount = IGenArt721CoreContractV3_Engine_Flex(
                     coreContract
                 ).projectExternalAssetDependencyCount(projectId);
-            JsonStatic.Json[]
-                memory externalAssetDependencies = new JsonStatic.Json[](
-                    externalAssetDependencyCount
-                );
+            JsonStatic.Json[] memory externalAssetDependencies = JsonStatic
+                .newValuesArray(externalAssetDependencyCount);
             for (uint256 i = 0; i < externalAssetDependencyCount; i++) {
                 // each external asset dependency has 3 fields, so pre-allocate array to avoid dynamic memory allocation
-                JsonStatic.Json[]
-                    memory dependencyValues = new JsonStatic.Json[](3);
-                string[] memory dependencyKeys = new string[](3);
+                JsonStatic.Json[] memory dependencyValues = JsonStatic
+                    .newValuesArray(3);
+                string[] memory dependencyKeys = JsonStatic.newKeysArray(3);
                 // get external asset dependency with data
                 IGenArt721CoreContractV3_Engine_Flex.ExternalAssetDependencyWithData
                     memory externalAssetDependencyWithData = IGenArt721CoreContractV3_Engine_Flex(

--- a/packages/contracts/contracts/generator/GenArt721GeneratorV0.sol
+++ b/packages/contracts/contracts/generator/GenArt721GeneratorV0.sol
@@ -411,8 +411,7 @@ contract GenArt721GeneratorV0 is Initializable, IGenArt721GeneratorV0 {
             tokenDataValues[1] = JsonStatic.Json({
                 jsonType: JsonStatic.JsonType.ARRAY,
                 objectKeys: new string[](0),
-                objectChildren: new JsonStatic.Json[](0),
-                arrayChildren: tokenDataValuesHashes,
+                values: tokenDataValuesHashes,
                 stringEncodingFlag: JsonStatic.StringEncodingFlag.NONE,
                 elementValueString: "",
                 elementValueUint: 0,
@@ -503,8 +502,7 @@ contract GenArt721GeneratorV0 is Initializable, IGenArt721GeneratorV0 {
                 externalAssetDependencies[i] = JsonStatic.Json({
                     jsonType: JsonStatic.JsonType.OBJECT, // type
                     objectKeys: dependencyKeys, // populated object
-                    objectChildren: dependencyValues, // populated object
-                    arrayChildren: new JsonStatic.Json[](0), // default
+                    values: dependencyValues, // populated object
                     stringEncodingFlag: JsonStatic.StringEncodingFlag.NONE, // default
                     elementValueString: "", // default
                     elementValueUint: 0, // default
@@ -517,8 +515,7 @@ contract GenArt721GeneratorV0 is Initializable, IGenArt721GeneratorV0 {
         JsonStatic.Json memory tokenData = JsonStatic.Json({
             jsonType: JsonStatic.JsonType.OBJECT, // type
             objectKeys: tokenDataKeys, // populated object
-            objectChildren: tokenDataValues, // populated object
-            arrayChildren: new JsonStatic.Json[](0), // default
+            values: tokenDataValues, // populated object
             stringEncodingFlag: JsonStatic.StringEncodingFlag.NONE, // default
             elementValueString: "", // default
             elementValueUint: 0, // default

--- a/packages/contracts/contracts/generator/GenArt721GeneratorV0.sol
+++ b/packages/contracts/contracts/generator/GenArt721GeneratorV0.sol
@@ -384,6 +384,25 @@ contract GenArt721GeneratorV0 is Initializable, IGenArt721GeneratorV0 {
     }
 
     /**
+     * @notice Get if a flex contract is a V2 flex contract.
+     * Assumes that the core contract is a flex contract.
+     * @param flexCoreContract The core contract address to check if it is a V2 flex contract.
+     * @return isV2Flex Whether the core contract is a V2 flex contract.
+     */
+    function _getIsV2Flex(
+        address flexCoreContract
+    ) internal view returns (bool) {
+        // @dev all flex (V2, V3) contracts have the function coreType(),
+        // and all V2 flex contracts have the coreType "GenArt721CoreV2_ENGINE_FLEX"
+        string memory coreType = IGenArt721CoreContractV3_Engine_Flex(
+            flexCoreContract
+        ).coreType();
+        return
+            keccak256(abi.encodePacked(coreType)) ==
+            keccak256(abi.encodePacked("GenArt721CoreV2_ENGINE_FLEX"));
+    }
+
+    /**
      * @notice Get the external asset dependency for a given project and index.
      * @dev This function handles both V2 and V3 flex contracts, and converts the legacy V2 external asset dependency
      * type to the V3 external asset dependency type, as the V3 type is a superset of the V2 type.
@@ -407,13 +426,7 @@ contract GenArt721GeneratorV0 is Initializable, IGenArt721GeneratorV0 {
         // check if a V2 flex contract
         // @dev acknowledge that this could be function input parameter to avoid one call per dependency, but
         // stack to deep error limits memoization opportunity in functions calling this function
-        // @dev all flex (V2, V3) contracts have the function coreType(),
-        // and all V2 flex contracts have the coreType "GenArt721CoreV2_ENGINE_FLEX"
-        string memory coreType = IGenArt721CoreContractV3_Engine_Flex(
-            coreContract
-        ).coreType();
-        bool isV2Flex = keccak256(abi.encodePacked(coreType)) ==
-            keccak256(abi.encodePacked("GenArt721CoreV2_ENGINE_FLEX"));
+        bool isV2Flex = _getIsV2Flex(coreContract);
 
         // pre-allocate generic externalAssetDependencyWithData to avoid dynamic memory allocation
         IGenArt721CoreContractV3_Engine_Flex.ExternalAssetDependencyWithData

--- a/packages/contracts/contracts/generator/GenArt721GeneratorV0.sol
+++ b/packages/contracts/contracts/generator/GenArt721GeneratorV0.sol
@@ -496,6 +496,10 @@ contract GenArt721GeneratorV0 is Initializable, IGenArt721GeneratorV0 {
                     values: dependencyValues
                 });
             }
+            // assign externalAssetDependencies array to tokenDataValues
+            tokenDataValues[4] = JsonStatic.newArrayElement(
+                externalAssetDependencies
+            );
         }
 
         // build tokenData json object

--- a/packages/contracts/contracts/generator/GenArt721GeneratorV0.sol
+++ b/packages/contracts/contracts/generator/GenArt721GeneratorV0.sol
@@ -408,14 +408,8 @@ contract GenArt721GeneratorV0 is Initializable, IGenArt721GeneratorV0 {
                 value: Strings.toHexString(uint256(tokenHash)),
                 stringEncodingFlag: JsonStatic.StringEncodingFlag.NONE
             });
-            tokenDataValues[1] = JsonStatic.Json({
-                jsonType: JsonStatic.JsonType.ARRAY,
-                objectKeys: new string[](0),
-                values: tokenDataValuesHashes,
-                stringEncodingFlag: JsonStatic.StringEncodingFlag.NONE,
-                elementValueString: "",
-                elementValueUint: 0,
-                elementValueBoolean: false
+            tokenDataValues[1] = JsonStatic.newArrayElement({
+                values: tokenDataValuesHashes
             });
         } else {
             tokenDataKeys[1] = "hash";
@@ -499,27 +493,17 @@ contract GenArt721GeneratorV0 is Initializable, IGenArt721GeneratorV0 {
                 }
                 // TODO: handle ART_BLOCKS_DEPENDENCY_REGISTRY dependency type
 
-                externalAssetDependencies[i] = JsonStatic.Json({
-                    jsonType: JsonStatic.JsonType.OBJECT, // type
-                    objectKeys: dependencyKeys, // populated object
-                    values: dependencyValues, // populated object
-                    stringEncodingFlag: JsonStatic.StringEncodingFlag.NONE, // default
-                    elementValueString: "", // default
-                    elementValueUint: 0, // default
-                    elementValueBoolean: false // default
+                externalAssetDependencies[i] = JsonStatic.newObjectElement({
+                    keys: dependencyKeys,
+                    values: dependencyValues
                 });
             }
         }
 
         // build tokenData json object
-        JsonStatic.Json memory tokenData = JsonStatic.Json({
-            jsonType: JsonStatic.JsonType.OBJECT, // type
-            objectKeys: tokenDataKeys, // populated object
-            values: tokenDataValues, // populated object
-            stringEncodingFlag: JsonStatic.StringEncodingFlag.NONE, // default
-            elementValueString: "", // default
-            elementValueUint: 0, // default
-            elementValueBoolean: false // default
+        JsonStatic.Json memory tokenData = JsonStatic.newObjectElement({
+            keys: tokenDataKeys,
+            values: tokenDataValues
         });
 
         // return tokenData as JSON string via write function

--- a/packages/contracts/contracts/generator/GenArt721GeneratorV0.sol
+++ b/packages/contracts/contracts/generator/GenArt721GeneratorV0.sol
@@ -423,11 +423,6 @@ contract GenArt721GeneratorV0 is Initializable, IGenArt721GeneratorV0 {
                 memory
         )
     {
-        // check if a V2 flex contract
-        // @dev acknowledge that this could be function input parameter to avoid one call per dependency, but
-        // stack to deep error limits memoization opportunity in functions calling this function
-        bool isV2Flex = _getIsV2Flex(coreContract);
-
         // pre-allocate generic externalAssetDependencyWithData to avoid dynamic memory allocation
         IGenArt721CoreContractV3_Engine_Flex.ExternalAssetDependencyWithData
             memory externalAssetDependencyWithData = IGenArt721CoreContractV3_Engine_Flex
@@ -441,7 +436,9 @@ contract GenArt721GeneratorV0 is Initializable, IGenArt721GeneratorV0 {
                 });
         // @dev flex V2 and V3 have different return types for the function projectExternalAssetDependencyByIndex - must branch logic
         // @dev reference change in return type between V2 and V3 here: https://github.com/ArtBlocks/artblocks-contracts/pull/450
-        if (isV2Flex) {
+        // @dev acknowledge that this could be function input parameter to avoid one call per dependency, but
+        // stack to deep error limits memoization opportunity in functions calling this function
+        if (_getIsV2Flex(coreContract)) {
             ILegacyGenArt721CoreV2_PBAB_Flex.LegacyExternalAssetDependencyWithoutData
                 memory legacyExternalAssetDependencyWithoutData = ILegacyGenArt721CoreV2_PBAB_Flex(
                     coreContract

--- a/packages/contracts/contracts/generator/GenArt721GeneratorV0.sol
+++ b/packages/contracts/contracts/generator/GenArt721GeneratorV0.sol
@@ -383,6 +383,15 @@ contract GenArt721GeneratorV0 is Initializable, IGenArt721GeneratorV0 {
         }
     }
 
+    /**
+     * @notice Get the external asset dependency for a given project and index.
+     * @dev This function handles both V2 and V3 flex contracts, and converts the legacy V2 external asset dependency
+     * type to the V3 external asset dependency type, as the V3 type is a superset of the V2 type.
+     * @param coreContract The core contract address the project belongs to.
+     * @param projectId The ID of the project to retrieve the external asset dependency for.
+     * @param index The index of the external asset dependency to retrieve.
+     * @return The external asset dependency for the project and index.
+     */
     function _getProjectExternalAssetDependencyByIndex(
         address coreContract,
         uint256 projectId,

--- a/packages/contracts/contracts/libs/v0.8.x/JsonStatic.sol
+++ b/packages/contracts/contracts/libs/v0.8.x/JsonStatic.sol
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Created By: Art Blocks Inc.
+
+import {Base64} from "@openzeppelin-5.0/contracts/utils/Base64.sol";
+import {Strings} from "@openzeppelin-5.0/contracts/utils/Strings.sol";
+
+pragma solidity ^0.8.22;
+
+/**
+ * @title Art Blocks Json Library
+ * @author Art Blocks Inc.
+ * @notice UNAUDITED
+ * A library for helping write static JSON metadata for Art Blocks projects.
+ * The library writes JSON data to a string within solidity, while remaining O(n) in gas and memory complexity,
+ * where n is the number of elements in an array or key:value pairs in an object. The library is O(m^2)
+ * in gas and memory complexity, where m is the depth of nested objects or arrays.
+ * When used in memory, the library only supports arrays and objects of fixed, pre-allocated size,
+ * in order to avoid dynamic memory allocation.
+ * The library supports an optional flag to write input string values as base64 encoded strings, in
+ * order to avoid the need for escaping characters in JSON strings.
+ * Keys are assumed to be valid key names in JSON.
+ * The library supports writing JSON objects, arrays, strings, uints, booleans, and null values.
+ * The library does not support writing floating point numbers.
+ */
+library JsonStatic {
+    using Strings for uint256;
+    using JsonStatic for JsonStatic.Json;
+
+    enum JsonType {
+        OBJECT,
+        ARRAY,
+        ELEMENT_STRING,
+        ELEMENT_UINT,
+        ELEMENT_BOOLEAN,
+        ELEMENT_NULL
+    }
+
+    enum StringEncodingFlag {
+        NONE,
+        BASE64
+    }
+
+    struct Json {
+        JsonType jsonType;
+        string[] objectKeys; // keys of children if type is OBJECT
+        Json[] objectChildren; // children if type is OBJECT
+        Json[] arrayChildren; // array of children if type is ARRAY
+        StringEncodingFlag stringEncodingFlag;
+        string elementValueString; // value if type is ELEMENT_STRING
+        uint256 elementValueUint; // value if type is ELEMENT_UINT
+        bool elementValueBoolean; // value if type is ELEMENT_BOOLEAN
+        // implied null if type is ELEMENT_NULL
+    }
+
+    /**
+     * Convenience function to create a new string element.
+     * If base64 encoding is set as the encoding flag, the passed value will be encoded on WRITE and
+     * should NOT already be encoded. Passing an already encoded value will result in double encoding.
+     * @param value the string value of the element.
+     * @param stringEncodingFlag the string encoding flag for the element.
+     */
+    function newStringElement(
+        string memory value,
+        StringEncodingFlag stringEncodingFlag
+    ) internal pure returns (Json memory) {
+        return
+            Json({
+                jsonType: JsonType.ELEMENT_STRING, // type
+                objectKeys: new string[](0), // default
+                objectChildren: new Json[](0), // default
+                arrayChildren: new Json[](0), // default
+                stringEncodingFlag: stringEncodingFlag, // input
+                elementValueString: value, // input
+                elementValueUint: 0, // default
+                elementValueBoolean: false // default
+            });
+    }
+
+    /**
+     * @notice writes a json struct to a string
+     * @param json the json struct to write
+     * @return the json string
+     */
+    function write(Json memory json) internal pure returns (string memory) {
+        if (json.jsonType == JsonType.OBJECT) {
+            return _writeObject(json);
+        } else if (json.jsonType == JsonType.ARRAY) {
+            return _writeArray(json);
+        } else if (json.jsonType == JsonType.ELEMENT_STRING) {
+            return
+                _writeString(json.elementValueString, json.stringEncodingFlag);
+        } else if (json.jsonType == JsonType.ELEMENT_UINT) {
+            return _writeUint(json.elementValueUint);
+        } else if (json.jsonType == JsonType.ELEMENT_BOOLEAN) {
+            return _writeBoolean(json.elementValueBoolean);
+        } else {
+            return _writeNull();
+        }
+    }
+
+    /**
+     * @notice writes a json struct of type JsonType.OBJECT to a string
+     * @param json the json struct of type JsonType.OBJECT to write
+     * @return the json string
+     */
+    function _writeObject(
+        Json memory json
+    ) private pure returns (string memory) {
+        // pre-allocate string array to avoid dynamic memory allocation
+        uint256 keysLength = json.objectKeys.length;
+        string[] memory children = new string[](keysLength);
+        for (uint256 i = 0; i < keysLength; i++) {
+            // only trailing comma if not last child, per JSON spec
+            string memory trailingChar = i < keysLength - 1 ? "," : "";
+            children[i] = string.concat(
+                '"',
+                json.objectKeys[i], // keys assumed to be valid JSON keys
+                '":',
+                json.objectChildren[i].write(),
+                trailingChar
+            );
+        }
+        // concat all children and return
+        return string.concat("{", _concatenateStrings(children), "}");
+    }
+
+    /**
+     * @notice writes a json struct of type JsonType.ARRAY to a string
+     * @param json the json struct of type JsonType.ARRAY to write
+     * @return the json string
+     */
+    function _writeArray(
+        Json memory json
+    ) private pure returns (string memory) {
+        // pre-allocate string array to avoid dynamic memory allocation
+        uint256 childrenLength = json.arrayChildren.length;
+        string[] memory children = new string[](childrenLength);
+        for (uint256 i = 0; i < childrenLength; i++) {
+            // only trailing comma if not last child, per JSON spec
+            string memory trailingChar = i < childrenLength - 1 ? "," : "";
+            children[i] = string.concat(
+                json.arrayChildren[i].write(),
+                trailingChar
+            );
+        }
+        // concat all children and return
+        return string.concat("[", _concatenateStrings(children), "]");
+    }
+
+    /**
+     * @notice writes a string value to a valid json string.
+     * If the string encoding flag is set to BASE64, the written value will be base64 encoded.
+     * @param value the string value to write
+     * @param stringEncodingFlag the string encoding flag for the value
+     * @return the json string
+     */
+    function _writeString(
+        string memory value,
+        StringEncodingFlag stringEncodingFlag
+    ) private pure returns (string memory) {
+        if (stringEncodingFlag == StringEncodingFlag.BASE64) {
+            return _writeBase64(value);
+        } else {
+            return _writePlainString(value);
+        }
+    }
+
+    /**
+     * @notice writes a string value to a valid json string
+     * @param value the string value to write
+     * @return the json string
+     */
+    function _writePlainString(
+        string memory value
+    ) private pure returns (string memory) {
+        return string.concat('"', value, '"');
+    }
+
+    /**
+     * @notice writes a base64 encoded string value to a valid json string
+     * @param value the string value to write
+     * @return the json string
+     */
+    function _writeBase64(
+        string memory value
+    ) private pure returns (string memory) {
+        return string.concat('"', Base64.encode(bytes(value)), '"');
+    }
+
+    /**
+     * @notice writes a uint value to a valid json string
+     * @param value the uint value to write
+     * @return the json string
+     */
+    function _writeUint(uint256 value) private pure returns (string memory) {
+        // @dev no quotes around numbers
+        return value.toString();
+    }
+
+    /**
+     * @notice writes a boolean value to a valid json string
+     * @param value the boolean value to write
+     * @return the json string
+     */
+    function _writeBoolean(bool value) private pure returns (string memory) {
+        // @dev no quotes around booleans
+        return value ? "true" : "false";
+    }
+
+    /**
+     * @notice writes a null value to a valid json string
+     * @return the json string
+     */
+    function _writeNull() private pure returns (string memory) {
+        return "null";
+    }
+
+    /**
+     * @notice Helper function to efficiently concatenate an array of strings.
+     * @dev portions of code generated with AI Assistance, modified and tested by human developers.
+     * @param strings The array of strings to concatenate.
+     * @return The concatenated string.
+     */
+    function _concatenateStrings(
+        string[] memory strings
+    ) private pure returns (string memory) {
+        uint totalLength = 0;
+
+        // Step 1: Calculate the total length of the result string
+        for (uint i = 0; i < strings.length; i++) {
+            totalLength += bytes(strings[i]).length;
+        }
+
+        // Step 2: Allocate memory for the resulting string
+        string memory result = new string(totalLength); // Allocate memory for the result, also defining its length
+        uint resultPtr;
+        assembly {
+            resultPtr := add(result, 0x20) // Point to the start of the string's data in memory
+        }
+
+        // Step 3: Copy each string into the result using assembly
+        for (uint i = 0; i < strings.length; i++) {
+            bytes memory currentString = bytes(strings[i]);
+            uint currentLength = currentString.length;
+            uint currentPtr;
+
+            assembly {
+                currentPtr := add(currentString, 0x20) // Start of current string's data
+            }
+
+            // Copy the full 32-byte chunks
+            uint chunks = currentLength / 32;
+            uint remainder = currentLength % 32;
+
+            for (uint j = 0; j < chunks; j++) {
+                assembly {
+                    let chunk := mload(currentPtr) // Load 32 bytes of the current string
+                    mstore(resultPtr, chunk) // Store the 32 bytes into the result
+                    resultPtr := add(resultPtr, 0x20) // Move the result pointer forward by 32 bytes
+                    currentPtr := add(currentPtr, 0x20) // Move the current string pointer forward by 32 bytes
+                }
+            }
+
+            // Handle remaining bytes (less than 32)
+            if (remainder > 0) {
+                assembly {
+                    let chunk := mload(currentPtr) // Load 32 bytes
+                    let mask := sub(shl(mul(8, sub(0x20, remainder)), 1), 1) // Create mask for the remainder
+                    let lastChunk := and(chunk, not(mask)) // Mask out the excess bits
+                    mstore(resultPtr, lastChunk) // Store the remaining bytes into the result
+                    resultPtr := add(resultPtr, remainder) // Move the result pointer forward by the remainder length
+                }
+            }
+        }
+
+        return result;
+    }
+}

--- a/packages/contracts/contracts/libs/v0.8.x/JsonStatic.sol
+++ b/packages/contracts/contracts/libs/v0.8.x/JsonStatic.sol
@@ -51,6 +51,28 @@ library JsonStatic {
     }
 
     /**
+     * Convenience function to create a new values array.
+     * @param length the length of the values array.
+     * @return the new values array.
+     */
+    function newValuesArray(
+        uint256 length
+    ) internal pure returns (Json[] memory) {
+        return new Json[](length);
+    }
+
+    /**
+     * Convenience function to create a new keys array.
+     * @param length the length of the keys array.
+     * @return the new keys array.
+     */
+    function newKeysArray(
+        uint256 length
+    ) internal pure returns (string[] memory) {
+        return new string[](length);
+    }
+
+    /**
      * Convenience function to create a new object element.
      * @param keys the keys of the object element.
      * @param values the values of the object element.

--- a/packages/contracts/contracts/libs/v0.8.x/JsonStatic.sol
+++ b/packages/contracts/contracts/libs/v0.8.x/JsonStatic.sol
@@ -42,9 +42,8 @@ library JsonStatic {
 
     struct Json {
         JsonType jsonType;
-        string[] objectKeys; // keys of children if type is OBJECT
-        Json[] objectChildren; // children if type is OBJECT
-        Json[] arrayChildren; // array of children if type is ARRAY
+        string[] objectKeys; // array of keys if type is OBJECT
+        Json[] values; // array of values if type is OBJECT, or array values if type is ARRAY
         StringEncodingFlag stringEncodingFlag;
         string elementValueString; // value if type is ELEMENT_STRING
         uint256 elementValueUint; // value if type is ELEMENT_UINT
@@ -67,8 +66,7 @@ library JsonStatic {
             Json({
                 jsonType: JsonType.ELEMENT_STRING, // type
                 objectKeys: new string[](0), // default
-                objectChildren: new Json[](0), // default
-                arrayChildren: new Json[](0), // default
+                values: new Json[](0), // default
                 stringEncodingFlag: stringEncodingFlag, // input
                 elementValueString: value, // input
                 elementValueUint: 0, // default
@@ -108,20 +106,20 @@ library JsonStatic {
     ) private pure returns (string memory) {
         // pre-allocate string array to avoid dynamic memory allocation
         uint256 keysLength = json.objectKeys.length;
-        string[] memory children = new string[](keysLength);
+        string[] memory valueStrings = new string[](keysLength);
         for (uint256 i = 0; i < keysLength; i++) {
             // only trailing comma if not last child, per JSON spec
             string memory trailingChar = i < keysLength - 1 ? "," : "";
-            children[i] = string.concat(
+            valueStrings[i] = string.concat(
                 '"',
                 json.objectKeys[i], // keys assumed to be valid JSON keys
                 '":',
-                json.objectChildren[i].write(),
+                json.values[i].write(),
                 trailingChar
             );
         }
-        // concat all children and return
-        return string.concat("{", _concatenateStrings(children), "}");
+        // concat all valueStrings and return
+        return string.concat("{", _concatenateStrings(valueStrings), "}");
     }
 
     /**
@@ -133,18 +131,18 @@ library JsonStatic {
         Json memory json
     ) private pure returns (string memory) {
         // pre-allocate string array to avoid dynamic memory allocation
-        uint256 childrenLength = json.arrayChildren.length;
-        string[] memory children = new string[](childrenLength);
-        for (uint256 i = 0; i < childrenLength; i++) {
+        uint256 valuesLength = json.values.length;
+        string[] memory valueStrings = new string[](valuesLength);
+        for (uint256 i = 0; i < valuesLength; i++) {
             // only trailing comma if not last child, per JSON spec
-            string memory trailingChar = i < childrenLength - 1 ? "," : "";
-            children[i] = string.concat(
-                json.arrayChildren[i].write(),
+            string memory trailingChar = i < valuesLength - 1 ? "," : "";
+            valueStrings[i] = string.concat(
+                json.values[i].write(),
                 trailingChar
             );
         }
-        // concat all children and return
-        return string.concat("[", _concatenateStrings(children), "]");
+        // concat all valueStrings and return
+        return string.concat("[", _concatenateStrings(valueStrings), "]");
     }
 
     /**

--- a/packages/contracts/test/generator/GenArt721GeneratorV0.test.ts
+++ b/packages/contracts/test/generator/GenArt721GeneratorV0.test.ts
@@ -267,7 +267,9 @@ describe(`GenArt721GeneratorV0`, async function () {
       const hashes = await genArt721CoreV0.showTokenHashes(0);
       const hash = hashes[0];
       expect(tokenHtml).to.include(
-        getScriptTag(`let tokenData = {"tokenId":"0","hashes":["${hash}"]}`)
+        getScriptTag(
+          `let tokenData = JSON.parse(\`{"tokenId":"0","hashes":["${hash}"]}\`, (key, value) => key === "data" && value !== null ? atob(value) : value);`
+        )
       );
 
       // Project script
@@ -363,7 +365,7 @@ describe(`GenArt721GeneratorV0`, async function () {
       const hash = await genArt721CoreV1.tokenIdToHash(tokenId);
       expect(tokenHtml).to.include(
         getScriptTag(
-          `let tokenData = {"tokenId":"${tokenId}","hash":"${hash}"}`
+          `let tokenData = JSON.parse(\`{"tokenId":"${tokenId}","hash":"${hash}"}\`, (key, value) => key === "data" && value !== null ? atob(value) : value);`
         )
       );
       // Project script
@@ -440,7 +442,7 @@ describe(`GenArt721GeneratorV0`, async function () {
       const hash = await genArt721CoreV2.tokenIdToHash(tokenId);
       expect(tokenHtml).to.include(
         getScriptTag(
-          `let tokenData = {"tokenId":"${tokenId}","hash":"${hash}"}`
+          `let tokenData = JSON.parse(\`{"tokenId":"${tokenId}","hash":"${hash}"}\`, (key, value) => key === "data" && value !== null ? atob(value) : value);`
         )
       );
       // Project script
@@ -531,7 +533,7 @@ describe(`GenArt721GeneratorV0`, async function () {
       const hash = await genArt721CoreV3.tokenIdToHash(tokenId);
       expect(tokenHtml).to.include(
         getScriptTag(
-          `let tokenData = {"tokenId":"${tokenId}","hash":"${hash}"}`
+          `let tokenData = JSON.parse(\`{"tokenId":"${tokenId}","hash":"${hash}"}\`, (key, value) => key === "data" && value !== null ? atob(value) : value);`
         )
       );
       // Project script
@@ -624,7 +626,7 @@ describe(`GenArt721GeneratorV0`, async function () {
       const hash = await genArt721CoreV3.tokenIdToHash(tokenId);
       expect(tokenHtml).to.include(
         getScriptTag(
-          `let tokenData = {"tokenId":"${tokenId}","hash":"${hash}"}`
+          `let tokenData = JSON.parse(\`{"tokenId":"${tokenId}","hash":"${hash}"}\`, (key, value) => key === "data" && value !== null ? atob(value) : value);`
         )
       );
       // Project script

--- a/packages/contracts/test/generator/GenArt721GeneratorV0.test.ts
+++ b/packages/contracts/test/generator/GenArt721GeneratorV0.test.ts
@@ -637,6 +637,137 @@ describe(`GenArt721GeneratorV0`, async function () {
         `data:text/html;base64,${Buffer.from(tokenHtml).toString("base64")}`
       );
     });
+
+    describe("flex", function () {
+      it("gets html for a V3 flex with all flex dependency types", async function () {
+        const config = await loadFixture(_beforeEach);
+
+        const {
+          genArt721Core: genArt721CoreV3,
+          minterFilter,
+          randomizer,
+        } = await deployCoreWithMinterFilter(
+          config,
+          "GenArt721CoreV3_Engine_Flex",
+          "MinterFilterV1"
+        );
+
+        const minter = (await deployAndGet(config, "MinterSetPriceV2", [
+          genArt721CoreV3.address,
+          minterFilter.address,
+        ])) as MinterSetPriceV2;
+
+        await minterFilter
+          .connect(config.accounts.deployer)
+          .addApprovedMinter(minter.address);
+
+        const projectId = await genArt721CoreV3.nextProjectId();
+        // Add and configure project
+        await genArt721CoreV3
+          .connect(config.accounts.deployer)
+          .addProject("name", config.accounts.artist.address);
+
+        const projectScript =
+          "console.log(tokenData); console.log(blah); console.log(bleh);";
+        const projectScriptCompressed =
+          await genArt721CoreV3.getCompressed(projectScript);
+        await genArt721CoreV3
+          .connect(config.accounts.artist)
+          .addProjectScriptCompressed(projectId, projectScriptCompressed);
+        await genArt721CoreV3
+          .connect(config.accounts.artist)
+          .updateProjectScriptType(projectId, p5NameAndVersionBytes);
+
+        // Mint token 0
+        await minterFilter
+          .connect(config.accounts.artist)
+          .setMinterForProject(projectId, minter.address);
+        await minter
+          .connect(config.accounts.artist)
+          .updatePricePerTokenInWei(projectId, 0);
+        await minter.connect(config.accounts.artist).purchase(projectId);
+
+        const tokenId = projectId.mul(ONE_MILLION);
+
+        // Add contract to dependency registry
+        await config.dependencyRegistry
+          .connect(config.accounts.deployer)
+          .addSupportedCoreContract(genArt721CoreV3.address);
+
+        // define preferred gateways
+        const preferredIpfsGateway = "https://ipfs.io/ipfs/";
+        const preferredArweaveGateway = "https://arweave.net/";
+        await genArt721CoreV3.updateIPFSGateway(preferredIpfsGateway);
+        await genArt721CoreV3.updateArweaveGateway(preferredArweaveGateway);
+        // add all flex dependencies
+        // 0 - IPFS
+        const ipfsCid = "cidIpfsTest";
+        await genArt721CoreV3.addProjectExternalAssetDependency(
+          projectId,
+          ipfsCid,
+          0 // IPFS
+        );
+        // 1 - ARWEAVE
+        const arweaveCid = "cidArweaveTest";
+        await genArt721CoreV3.addProjectExternalAssetDependency(
+          projectId,
+          arweaveCid,
+          1 // ARWEAVE
+        );
+        // 2 - ONCHAIN
+        const onchainData = "1234567890123456789012345678901234567890";
+        await genArt721CoreV3.addProjectExternalAssetDependency(
+          projectId,
+          onchainData,
+          2 // ONCHAIN
+        );
+        // 3 - ART_BLOCKS_DEPENDENCY_REGISTRY
+        const onchainLibraryName = "js@na";
+        await genArt721CoreV3.addProjectExternalAssetDependency(
+          projectId,
+          onchainLibraryName,
+          3 // ART_BLOCKS_DEPENDENCY_REGISTRY
+        );
+
+        // Get token html
+        const tokenHtml = await config.genArt721Generator.getTokenHtml(
+          genArt721CoreV3.address,
+          tokenId
+        );
+
+        const encodedTokenHtml =
+          await config.genArt721Generator.getTokenHtmlBase64EncodedDataUri(
+            genArt721CoreV3.address,
+            tokenId
+          );
+
+        // Default style
+        expect(tokenHtml).to.include(STYLE_TAG);
+        // Gzipped dependency script
+        expect(tokenHtml).to.include(
+          getGzipBase64DataUriScriptTag(compressedDepScript)
+        );
+        // Gunzip script
+        expect(tokenHtml).to.include(
+          getScriptBase64DataUriScriptTag(GUNZIP_SCRIPT_BASE64)
+        );
+        // Token data
+        const hash = await genArt721CoreV3.tokenIdToHash(tokenId);
+        console.log("TOKEN_HTML", tokenHtml);
+        expect(tokenHtml).to.include(
+          getScriptTag(
+            `let tokenData = JSON.parse(\`{"tokenId":"${tokenId}","hash":"${hash}","preferredArweaveGateway":"${preferredArweaveGateway}","preferredIPFSGateway":"${preferredIpfsGateway}","externalAssetDependencies":[{"dependency_type":"IPFS","cid":"${ipfsCid}","data":""},{"dependency_type":"ARWEAVE","cid":"${arweaveCid}","data":""},{"dependency_type":"ONCHAIN","cid":"","data":"${btoa(onchainData)}"},{"dependency_type":"ART_BLOCKS_DEPENDENCY_REGISTRY","cid":"${onchainLibraryName}","data":""}]}\`, (key, value) => key === "data" && value !== null ? atob(value) : value);`
+          )
+        );
+        // Project script
+        expect(tokenHtml).to.include(getScriptTag(projectScript));
+
+        // Base64 encoded data uri
+        expect(encodedTokenHtml).to.equal(
+          `data:text/html;base64,${Buffer.from(tokenHtml).toString("base64")}`
+        );
+      });
+    });
   });
 
   it("gets html for a given V3 core contract token with dependency script not on-chain", async function () {


### PR DESCRIPTION
## Description of the change

Support GenArt721Core Flex (V2 and V3) on the on-chain generator.

⚠️ This implementation does not fully support injection of flex dependency type `ART_BLOCKS_DEPENDENCY_REGISTRY` - support will be added in a follow-on PR.

fixes https://linear.app/art-blocks/issue/PLT-869/add-support-for-flex-contracts-to-on-chain-generator

## Design

The implementation remains gas and memory efficient in order to deal with potentially loading large on-chain assets. A new `JsonStatic` library is used to help abstract writing nested, dynamic json data, while remaining efficient. The library has a few features that are not used by the on-chain generator. Other open-source libraries were considered, but none were found to be better than O(n^2) in gas and memory management, which is not acceptable for our large on-chain assets. Our library is O(n) for relatively flat Json objects, which is how our `tokenData` is structured.

Optimizations beyond this implementation are certainly possible, but readability vs. optimization was considered.

## Tests

Tests are updated + added for the new functionality.

## TODO

- [x] Verify/Document compatibility with V2 PBAB Flex contracts
