### PR TITLE
Update dependency registry with supported contract overrides

### DIFF
--- a/packages/contracts/contracts/interfaces/v0.8.x/IDependencyRegistryV0.sol
+++ b/packages/contracts/contracts/interfaces/v0.8.x/IDependencyRegistryV0.sol
@@ -3,9 +3,21 @@
 pragma solidity ^0.8.19;
 
 interface IDependencyRegistryV0 {
+    // legacy event used before deferring to core registry for allowlist
     event SupportedCoreContractAdded(address indexed coreContractAddress);
 
+    // legacy event used before deferring to core registry for allowlist
     event SupportedCoreContractRemoved(address indexed coreContractAddress);
+
+    // active event used to add additional supported contracts beyond what core registry allows
+    event SupportedCoreContractOverrideAdded(
+        address indexed coreContractAddress
+    );
+
+    // active event used to remove additional supported contracts beyond what core registry allows
+    event SupportedCoreContractOverrideRemoved(
+        address indexed coreContractAddress
+    );
 
     event ProjectDependencyOverrideAdded(
         address indexed coreContractAddress,
@@ -70,6 +82,8 @@ interface IDependencyRegistryV0 {
     );
 
     event DependencyScriptUpdated(bytes32 indexed dependencyNameAndVersion);
+
+    event CoreRegistryAddressUpdated(address indexed coreRegistryAddress);
 
     /**
      * @notice Returns the count of scripts for dependency `dependencyNameAndVersion`.

--- a/packages/contracts/contracts/libs/v0.8.x/DependencyRegistryStorageLib.sol
+++ b/packages/contracts/contracts/libs/v0.8.x/DependencyRegistryStorageLib.sol
@@ -70,7 +70,7 @@ library DependencyRegistryStorageLib {
         // @dev This set is vestigial and no longer used. It has been replaced by CoreRegistry functionality.
         // Cannot be removed due to storage layout requirements in upgradeable contracts.
         // See https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable#modifying-your-contracts
-        EnumerableSet.AddressSet supportedCoreContracts;
+        EnumerableSet.AddressSet DEPRECATED_supportedCoreContracts;
         // Mapping that allows for the overriding of project dependencies.
         // The first key is the address of the core contract, the second key is the project ID,
         // and the value is the bytes32 representation of the dependency name and version (i.e. name@version).
@@ -78,6 +78,10 @@ library DependencyRegistryStorageLib {
         mapping(address coreContractAddress => mapping(uint256 projectId => bytes32 dependencyNameAndVersion) projectToDependencyNameAndVersionMapping) projectDependencyOverrides;
         // address of the CoreRegistry contract
         ICoreRegistryV1 coreRegistryContract;
+        // enumerable set of core contract addresses supported by the DependencyRegistry, in addition to the set of core contracts
+        // that are supported by the CoreRegistry contract
+        // @dev possible there is overlap between the two sets, but not intentionally configured by admin.
+        EnumerableSet.AddressSet supportedCoreContractsOverride;
     }
 
     /**


### PR DESCRIPTION
## Description of the change

Update dependency registry with supported contract overrides.

fixes https://linear.app/art-blocks/issue/PLT-901/update-dependency-registry-with-supported-contract-overrides

This allows the dependency registry to add supported contracts in addition to what is defined on the core registry.

This supports the use case where a core contract is banned from minting on the shared minter suite, but has projects should be supported by the dependency registry (e.g. safe fallback if compromised partner admin keys).

Note: an event is also added when core registry is set, for future indexing capabilities.

## TODO

- [x] add tests for coverage of new logic
- [x] merge #1727 before merging this