### PR TITLE
view core registry on dependency registry

### DIFF
--- a/packages/contracts/contracts/DependencyRegistryV0.sol
+++ b/packages/contracts/contracts/DependencyRegistryV0.sol
@@ -1330,6 +1330,14 @@ contract DependencyRegistryV0 is
     }
 
     /**
+     * @notice returns the address of the core registry currently being used by the dependency registry.
+     * @return address Address of the core registry contract.
+     */
+    function currentCoreRegistry() external view returns (address) {
+        return address(DependencyRegistryStorageLib.s().coreRegistryContract);
+    }
+
+    /**
      * @notice utility function to convert from string to bytes32.
      * Useful when a human is calling functions that take bytes32 as input.
      * Reverts if input string does not fit within 32 bytes.

--- a/packages/contracts/test/dependency-registry/DependencyRegistryV0.test.ts
+++ b/packages/contracts/test/dependency-registry/DependencyRegistryV0.test.ts
@@ -1981,6 +1981,17 @@ describe(`DependencyRegistryV0`, async function () {
       this.config = config;
     });
 
+    describe("currentCoreRegistry", function () {
+      it("returns the correct core registry address", async function () {
+        // get config from beforeEach
+        const config = this.config;
+        const currentCoreRegistry =
+          await config.dependencyRegistry.currentCoreRegistry();
+        // should be the same as the one set in beforeEach
+        expect(currentCoreRegistry).to.eq(config.coreRegistry.address);
+      });
+    });
+
     describe("addSupportedCoreContractOverride", function () {
       it("does not allow non-admins to add supported core contract", async function () {
         // get config from beforeEach


### PR DESCRIPTION
## Description of the change

Add view to dependency registry that exposes current core registry.

This is important for configuration introspection and validation without depending on indexing solutions.

This is NOT a major change and does not require a re-deployment and upgrade of the dependency registry.

linear: https://linear.app/art-blocks/issue/PLT-905/follow-on-add-view-function-on-dependency-registry-for-core-registry
