### PR TITLE
On-Chain Generator support of Web3Call

### DIFF
--- a/packages/contracts/contracts/generator/GenArt721GeneratorV0.sol
+++ b/packages/contracts/contracts/generator/GenArt721GeneratorV0.sol
@@ -9,11 +9,14 @@ import "../interfaces/v0.8.x/IGenArt721CoreTokenHashProviderV1.sol";
 import "../interfaces/v0.8.x/IGenArt721GeneratorV0.sol";
 import {IGenArt721CoreContractV3_Engine_Flex} from "../interfaces/v0.8.x/IGenArt721CoreContractV3_Engine_Flex.sol";
 import {IUniversalBytecodeStorageReader} from "../interfaces/v0.8.x/IUniversalBytecodeStorageReader.sol";
+import {IWeb3Call} from "../interfaces/v0.8.x/IWeb3Call.sol";
+
 import "../libs/v0.8.x/Bytes32Strings.sol";
 import {JsonStatic} from "../libs/v0.8.x/JsonStatic.sol";
 import {ABHelpers} from "../libs/v0.8.x/ABHelpers.sol";
 import {AddressChunks} from "./AddressChunks.sol";
 
+import {Base64} from "@openzeppelin-5.0/contracts/utils/Base64.sol";
 import "@openzeppelin-4.7/contracts/utils/Strings.sol";
 import "@openzeppelin-4.8/contracts-upgradeable/proxy/utils/Initializable.sol";
 
@@ -562,12 +565,12 @@ contract GenArt721GeneratorV0 is Initializable, IGenArt721GeneratorV0 {
      * as well as any dependency name and version if the dependency is an
      * ART_BLOCKS_DEPENDENCY_REGISTRY dependency.
      * @param coreContract The core contract address the project belongs to.
-     * @param projectId The ID of the project to retrieve the external asset dependency for.
+     * @param tokenId The ID of the token to retrieve the external asset dependency for.
      * @param index The index of the external asset dependency to retrieve.
      */
     function _getExternalAssetDependencyKeysAndValues(
         address coreContract,
-        uint256 projectId,
+        uint256 tokenId,
         uint256 index
     )
         internal
@@ -578,6 +581,8 @@ contract GenArt721GeneratorV0 is Initializable, IGenArt721GeneratorV0 {
             bytes32 /*dependencyNameAndVersion*/
         )
     {
+        // get project id from token id
+        uint256 projectId = ABHelpers.tokenIdToProjectId(tokenId);
         // default as not an art blocks dependency registry dependency
         bytes32 dependencyNameAndVersion; // default as not an art blocks dependency registry dependency
         // each external asset dependency has 3 fields, so pre-allocate array to avoid dynamic memory allocation
@@ -612,10 +617,33 @@ contract GenArt721GeneratorV0 is Initializable, IGenArt721GeneratorV0 {
                 .ExternalAssetDependencyType
                 .ONCHAIN
         ) {
-            dependencyValues[2] = JsonStatic.newStringElement({
-                value: externalAssetDependencyWithData.data, // assign data for ONCHAIN dependencies
-                stringEncodingFlag: JsonStatic.StringEncodingFlag.BASE64
-            });
+            if (
+                keccak256(
+                    abi.encodePacked(externalAssetDependencyWithData.data)
+                ) == keccak256(abi.encodePacked("#web3call_contract#")) // @dev special string indicating a web3call contract
+            ) {
+                // treat as a web3call contract, inject token parameters based on the web3call contract
+                // @dev prepend with "#web3call#" to indicate that the data should be decoded as a web3call
+                // with base64 encoded key/value pairs
+                dependencyValues[2] = JsonStatic.newStringElement({
+                    value: string.concat(
+                        "#web3call#",
+                        _getWeb3CallParameters({
+                            web3callContract: externalAssetDependencyWithData
+                                .bytecodeAddress,
+                            coreContract: coreContract,
+                            tokenId: tokenId
+                        })
+                    ),
+                    stringEncodingFlag: JsonStatic.StringEncodingFlag.BASE64
+                });
+            } else {
+                // @dev typical ONCHAIN dependency, assign data for ONCHAIN dependencies
+                dependencyValues[2] = JsonStatic.newStringElement({
+                    value: externalAssetDependencyWithData.data,
+                    stringEncodingFlag: JsonStatic.StringEncodingFlag.BASE64
+                });
+            }
         } else {
             dependencyValues[2] = JsonStatic.newStringElement({
                 value: "", // empty string for non-ONCHAIN dependencies
@@ -744,7 +772,7 @@ contract GenArt721GeneratorV0 is Initializable, IGenArt721GeneratorV0 {
                     bytes32 dependencyNameAndVersion
                 ) = _getExternalAssetDependencyKeysAndValues({
                         coreContract: coreContract,
-                        projectId: projectId,
+                        tokenId: tokenId,
                         index: i
                     });
                 // handle ART_BLOCKS_DEPENDENCY_REGISTRY dependency type
@@ -870,7 +898,7 @@ contract GenArt721GeneratorV0 is Initializable, IGenArt721GeneratorV0 {
         headTags[1].tagContent = abi.encodePacked(
             "let tokenData = JSON.parse(`",
             tokenDataJson,
-            '`, (key, value) => key === "data" && value !== null ? atob(value) : value);'
+            '`, (key, value) => key === "data" && value !== null ? value.startsWith("#web3call#") ? Object.entries(JSON.parse(atob(value.slice(10)))).reduce((acc, [k, v]) => ((acc[atob(k)] = atob(v)), acc), {}) : atob(value) : value);'
         );
         headTags[1].tagType = HTMLTagType.script;
         for (
@@ -995,6 +1023,44 @@ contract GenArt721GeneratorV0 is Initializable, IGenArt721GeneratorV0 {
         // query and return result of dependency registry for on-chain status
         (, , , , , , , availableOnChain, ) = dependencyRegistry
             .getDependencyDetails(dependencyNameAndVersion);
+    }
+
+    /**
+     * @dev Helper function to get the web3call parameters for a given token.
+     * Assumes the contract supports the IWeb3Call interface.
+     * @param web3callContract The address of the contract to call.
+     * @param coreContract The address of the core contract.
+     * @param tokenId The ID of the token.
+     * @return The web3call parameters for the token.
+     */
+    function _getWeb3CallParameters(
+        address web3callContract,
+        address coreContract,
+        uint256 tokenId
+    ) internal view returns (string memory) {
+        // get the onchain data for the contract
+        IWeb3Call.TokenParam[] memory tokenParams = IWeb3Call(web3callContract)
+            .getTokenParams({coreContract: coreContract, tokenId: tokenId});
+        uint256 tokenParamsLength = tokenParams.length;
+        // build key/value arrays for the token params
+        string[] memory keys = JsonStatic.newKeysArray(tokenParamsLength);
+        JsonStatic.Json[] memory values = JsonStatic.newValuesArray(
+            tokenParamsLength
+        );
+        for (uint256 i = 0; i < tokenParamsLength; i++) {
+            // @dev encode the key and value as base64 strings, to handle any special characters
+            IWeb3Call.TokenParam memory tokenParam = tokenParams[i];
+            keys[i] = Base64.encode(bytes(tokenParam.key));
+            values[i].elementValueString = Base64.encode(
+                bytes(tokenParam.value)
+            ); // @dev encode base64 here instead of in the library, for clarity
+        }
+        // use JsonStatic to build a printable json object from the key/value arrays
+        JsonStatic.Json memory tokenParamsJson = JsonStatic.newObjectElement({
+            keys: keys,
+            values: values
+        });
+        return tokenParamsJson.write();
     }
 
     /**

--- a/packages/contracts/contracts/interfaces/v0.8.x/IWeb3Call.sol
+++ b/packages/contracts/contracts/interfaces/v0.8.x/IWeb3Call.sol
@@ -24,5 +24,5 @@ interface IWeb3Call {
     function getTokenParams(
         address coreContract,
         uint256 tokenId
-    ) external returns (TokenParam[] memory tokenParams);
+    ) external view returns (TokenParam[] memory tokenParams);
 }

--- a/packages/contracts/test/generator/GenArt721GeneratorV0.test.ts
+++ b/packages/contracts/test/generator/GenArt721GeneratorV0.test.ts
@@ -79,6 +79,10 @@ interface GenArt721GeneratorV0TestConfig extends T_Config {
   universalReader: UniversalBytecodeStorageReader;
 }
 
+// the json parser's reviver script used when parsing the token data
+const REVIVER_SCRIPT =
+  '(key, value) => key === "data" && value !== null ? value.startsWith("#web3call#") ? Object.entries(JSON.parse(atob(value.slice(10)))).reduce((acc, [k, v]) => ((acc[atob(k)] = atob(v)), acc), {}) : atob(value) : value)';
+
 describe(`GenArt721GeneratorV0`, async function () {
   const p5NameAndVersion = "p5js@1.0.0";
   const p5NameAndVersionBytes =
@@ -299,7 +303,7 @@ describe(`GenArt721GeneratorV0`, async function () {
       const hash = hashes[0];
       expect(tokenHtml).to.include(
         getScriptTag(
-          `let tokenData = JSON.parse(\`{"tokenId":"0","hashes":["${hash}"]}\`, (key, value) => key === "data" && value !== null ? value.startsWith("#web3call#") ? Object.entries(JSON.parse(atob(value.slice(10)))).reduce((acc, [k, v]) => ((acc[atob(k)] = atob(v)), acc), {}) : atob(value) : value);`
+          `let tokenData = JSON.parse(\`{"tokenId":"0","hashes":["${hash}"]}\`, ${REVIVER_SCRIPT};`
         )
       );
 
@@ -400,7 +404,7 @@ describe(`GenArt721GeneratorV0`, async function () {
       const hash = await genArt721CoreV1.tokenIdToHash(tokenId);
       expect(tokenHtml).to.include(
         getScriptTag(
-          `let tokenData = JSON.parse(\`{"tokenId":"${tokenId}","hash":"${hash}"}\`, (key, value) => key === "data" && value !== null ? value.startsWith("#web3call#") ? Object.entries(JSON.parse(atob(value.slice(10)))).reduce((acc, [k, v]) => ((acc[atob(k)] = atob(v)), acc), {}) : atob(value) : value);`
+          `let tokenData = JSON.parse(\`{"tokenId":"${tokenId}","hash":"${hash}"}\`, ${REVIVER_SCRIPT};`
         )
       );
       // Project script
@@ -481,7 +485,7 @@ describe(`GenArt721GeneratorV0`, async function () {
       const hash = await genArt721CoreV2.tokenIdToHash(tokenId);
       expect(tokenHtml).to.include(
         getScriptTag(
-          `let tokenData = JSON.parse(\`{"tokenId":"${tokenId}","hash":"${hash}"}\`, (key, value) => key === "data" && value !== null ? value.startsWith("#web3call#") ? Object.entries(JSON.parse(atob(value.slice(10)))).reduce((acc, [k, v]) => ((acc[atob(k)] = atob(v)), acc), {}) : atob(value) : value);`
+          `let tokenData = JSON.parse(\`{"tokenId":"${tokenId}","hash":"${hash}"}\`, ${REVIVER_SCRIPT};`
         )
       );
       // Project script
@@ -576,7 +580,7 @@ describe(`GenArt721GeneratorV0`, async function () {
       const hash = await genArt721CoreV3.tokenIdToHash(tokenId);
       expect(tokenHtml).to.include(
         getScriptTag(
-          `let tokenData = JSON.parse(\`{"tokenId":"${tokenId}","hash":"${hash}"}\`, (key, value) => key === "data" && value !== null ? value.startsWith("#web3call#") ? Object.entries(JSON.parse(atob(value.slice(10)))).reduce((acc, [k, v]) => ((acc[atob(k)] = atob(v)), acc), {}) : atob(value) : value);`
+          `let tokenData = JSON.parse(\`{"tokenId":"${tokenId}","hash":"${hash}"}\`, ${REVIVER_SCRIPT};`
         )
       );
       // Project script
@@ -673,7 +677,7 @@ describe(`GenArt721GeneratorV0`, async function () {
       const hash = await genArt721CoreV3.tokenIdToHash(tokenId);
       expect(tokenHtml).to.include(
         getScriptTag(
-          `let tokenData = JSON.parse(\`{"tokenId":"${tokenId}","hash":"${hash}"}\`, (key, value) => key === "data" && value !== null ? value.startsWith("#web3call#") ? Object.entries(JSON.parse(atob(value.slice(10)))).reduce((acc, [k, v]) => ((acc[atob(k)] = atob(v)), acc), {}) : atob(value) : value);`
+          `let tokenData = JSON.parse(\`{"tokenId":"${tokenId}","hash":"${hash}"}\`, ${REVIVER_SCRIPT};`
         )
       );
       // Project script
@@ -807,7 +811,7 @@ describe(`GenArt721GeneratorV0`, async function () {
         console.log("TOKEN_HTML", tokenHtml);
         expect(tokenHtml).to.include(
           getScriptTag(
-            `let tokenData = JSON.parse(\`{"tokenId":"${tokenId}","hash":"${hash}","preferredArweaveGateway":"${preferredArweaveGateway}","preferredIPFSGateway":"${preferredIpfsGateway}","externalAssetDependencies":[{"dependency_type":"IPFS","cid":"${ipfsCid}","data":""},{"dependency_type":"ARWEAVE","cid":"${arweaveCid}","data":""},{"dependency_type":"ONCHAIN","cid":"","data":"${btoa(onchainData)}"},{"dependency_type":"ART_BLOCKS_DEPENDENCY_REGISTRY","cid":"${onchainLibraryName}","data":""}]}\`, (key, value) => key === "data" && value !== null ? value.startsWith("#web3call#") ? Object.entries(JSON.parse(atob(value.slice(10)))).reduce((acc, [k, v]) => ((acc[atob(k)] = atob(v)), acc), {}) : atob(value) : value);`
+            `let tokenData = JSON.parse(\`{"tokenId":"${tokenId}","hash":"${hash}","preferredArweaveGateway":"${preferredArweaveGateway}","preferredIPFSGateway":"${preferredIpfsGateway}","externalAssetDependencies":[{"dependency_type":"IPFS","cid":"${ipfsCid}","data":""},{"dependency_type":"ARWEAVE","cid":"${arweaveCid}","data":""},{"dependency_type":"ONCHAIN","cid":"","data":"${btoa(onchainData)}"},{"dependency_type":"ART_BLOCKS_DEPENDENCY_REGISTRY","cid":"${onchainLibraryName}","data":""}]}\`, ${REVIVER_SCRIPT};`
           )
         );
         // flex Dependency Registry injected script was injected in the head element (whereas the project script was injected in the body element)

--- a/packages/contracts/test/generator/GenArt721GeneratorV0.test.ts
+++ b/packages/contracts/test/generator/GenArt721GeneratorV0.test.ts
@@ -14,7 +14,16 @@ import {
   GenArt721,
   BytecodeStorageV2Writer,
   UniversalBytecodeStorageReader,
+  PMPV0,
 } from "../../scripts/contracts";
+
+import { constants } from "ethers";
+import {
+  getPMPInputConfig,
+  getPMPInput,
+  PMP_AUTH_ENUM,
+  PMP_PARAM_TYPE_ENUM,
+} from "../web3call/PMP/pmpTestUtils";
 
 import {
   T_Config,
@@ -290,7 +299,7 @@ describe(`GenArt721GeneratorV0`, async function () {
       const hash = hashes[0];
       expect(tokenHtml).to.include(
         getScriptTag(
-          `let tokenData = JSON.parse(\`{"tokenId":"0","hashes":["${hash}"]}\`, (key, value) => key === "data" && value !== null ? atob(value) : value);`
+          `let tokenData = JSON.parse(\`{"tokenId":"0","hashes":["${hash}"]}\`, (key, value) => key === "data" && value !== null ? value.startsWith("#web3call#") ? Object.entries(JSON.parse(atob(value.slice(10)))).reduce((acc, [k, v]) => ((acc[atob(k)] = atob(v)), acc), {}) : atob(value) : value);`
         )
       );
 
@@ -391,7 +400,7 @@ describe(`GenArt721GeneratorV0`, async function () {
       const hash = await genArt721CoreV1.tokenIdToHash(tokenId);
       expect(tokenHtml).to.include(
         getScriptTag(
-          `let tokenData = JSON.parse(\`{"tokenId":"${tokenId}","hash":"${hash}"}\`, (key, value) => key === "data" && value !== null ? atob(value) : value);`
+          `let tokenData = JSON.parse(\`{"tokenId":"${tokenId}","hash":"${hash}"}\`, (key, value) => key === "data" && value !== null ? value.startsWith("#web3call#") ? Object.entries(JSON.parse(atob(value.slice(10)))).reduce((acc, [k, v]) => ((acc[atob(k)] = atob(v)), acc), {}) : atob(value) : value);`
         )
       );
       // Project script
@@ -472,7 +481,7 @@ describe(`GenArt721GeneratorV0`, async function () {
       const hash = await genArt721CoreV2.tokenIdToHash(tokenId);
       expect(tokenHtml).to.include(
         getScriptTag(
-          `let tokenData = JSON.parse(\`{"tokenId":"${tokenId}","hash":"${hash}"}\`, (key, value) => key === "data" && value !== null ? atob(value) : value);`
+          `let tokenData = JSON.parse(\`{"tokenId":"${tokenId}","hash":"${hash}"}\`, (key, value) => key === "data" && value !== null ? value.startsWith("#web3call#") ? Object.entries(JSON.parse(atob(value.slice(10)))).reduce((acc, [k, v]) => ((acc[atob(k)] = atob(v)), acc), {}) : atob(value) : value);`
         )
       );
       // Project script
@@ -567,7 +576,7 @@ describe(`GenArt721GeneratorV0`, async function () {
       const hash = await genArt721CoreV3.tokenIdToHash(tokenId);
       expect(tokenHtml).to.include(
         getScriptTag(
-          `let tokenData = JSON.parse(\`{"tokenId":"${tokenId}","hash":"${hash}"}\`, (key, value) => key === "data" && value !== null ? atob(value) : value);`
+          `let tokenData = JSON.parse(\`{"tokenId":"${tokenId}","hash":"${hash}"}\`, (key, value) => key === "data" && value !== null ? value.startsWith("#web3call#") ? Object.entries(JSON.parse(atob(value.slice(10)))).reduce((acc, [k, v]) => ((acc[atob(k)] = atob(v)), acc), {}) : atob(value) : value);`
         )
       );
       // Project script
@@ -664,7 +673,7 @@ describe(`GenArt721GeneratorV0`, async function () {
       const hash = await genArt721CoreV3.tokenIdToHash(tokenId);
       expect(tokenHtml).to.include(
         getScriptTag(
-          `let tokenData = JSON.parse(\`{"tokenId":"${tokenId}","hash":"${hash}"}\`, (key, value) => key === "data" && value !== null ? atob(value) : value);`
+          `let tokenData = JSON.parse(\`{"tokenId":"${tokenId}","hash":"${hash}"}\`, (key, value) => key === "data" && value !== null ? value.startsWith("#web3call#") ? Object.entries(JSON.parse(atob(value.slice(10)))).reduce((acc, [k, v]) => ((acc[atob(k)] = atob(v)), acc), {}) : atob(value) : value);`
         )
       );
       // Project script
@@ -798,7 +807,7 @@ describe(`GenArt721GeneratorV0`, async function () {
         console.log("TOKEN_HTML", tokenHtml);
         expect(tokenHtml).to.include(
           getScriptTag(
-            `let tokenData = JSON.parse(\`{"tokenId":"${tokenId}","hash":"${hash}","preferredArweaveGateway":"${preferredArweaveGateway}","preferredIPFSGateway":"${preferredIpfsGateway}","externalAssetDependencies":[{"dependency_type":"IPFS","cid":"${ipfsCid}","data":""},{"dependency_type":"ARWEAVE","cid":"${arweaveCid}","data":""},{"dependency_type":"ONCHAIN","cid":"","data":"${btoa(onchainData)}"},{"dependency_type":"ART_BLOCKS_DEPENDENCY_REGISTRY","cid":"${onchainLibraryName}","data":""}]}\`, (key, value) => key === "data" && value !== null ? atob(value) : value);`
+            `let tokenData = JSON.parse(\`{"tokenId":"${tokenId}","hash":"${hash}","preferredArweaveGateway":"${preferredArweaveGateway}","preferredIPFSGateway":"${preferredIpfsGateway}","externalAssetDependencies":[{"dependency_type":"IPFS","cid":"${ipfsCid}","data":""},{"dependency_type":"ARWEAVE","cid":"${arweaveCid}","data":""},{"dependency_type":"ONCHAIN","cid":"","data":"${btoa(onchainData)}"},{"dependency_type":"ART_BLOCKS_DEPENDENCY_REGISTRY","cid":"${onchainLibraryName}","data":""}]}\`, (key, value) => key === "data" && value !== null ? value.startsWith("#web3call#") ? Object.entries(JSON.parse(atob(value.slice(10)))).reduce((acc, [k, v]) => ((acc[atob(k)] = atob(v)), acc), {}) : atob(value) : value);`
           )
         );
         // flex Dependency Registry injected script was injected in the head element (whereas the project script was injected in the body element)
@@ -826,6 +835,132 @@ describe(`GenArt721GeneratorV0`, async function () {
         // Base64 encoded data uri
         expect(encodedTokenHtml).to.equal(
           `data:text/html;base64,${Buffer.from(tokenHtml).toString("base64")}`
+        );
+      });
+
+      it("injects web3call parameters for a web3call flex dependency", async function () {
+        const config = await loadFixture(_beforeEach);
+
+        const {
+          genArt721Core: genArt721CoreV3,
+          minterFilter,
+          randomizer,
+        } = await deployCoreWithMinterFilter(
+          config,
+          "GenArt721CoreV3_Engine_Flex",
+          "MinterFilterV1"
+        );
+
+        const minter = (await deployAndGet(config, "MinterSetPriceV2", [
+          genArt721CoreV3.address,
+          minterFilter.address,
+        ])) as MinterSetPriceV2;
+
+        await minterFilter
+          .connect(config.accounts.deployer)
+          .addApprovedMinter(minter.address);
+
+        const projectId = await genArt721CoreV3.nextProjectId();
+        // Add and configure project
+        await genArt721CoreV3
+          .connect(config.accounts.deployer)
+          .addProject("name", config.accounts.artist.address);
+
+        const projectScript =
+          "console.log(tokenData); console.log(blah); console.log(bleh);";
+        const projectScriptCompressed =
+          await genArt721CoreV3.getCompressed(projectScript);
+        await genArt721CoreV3
+          .connect(config.accounts.artist)
+          .addProjectScriptCompressed(projectId, projectScriptCompressed);
+        await genArt721CoreV3
+          .connect(config.accounts.artist)
+          .updateProjectScriptType(projectId, p5NameAndVersionBytes);
+
+        // Mint token 0
+        await minterFilter
+          .connect(config.accounts.artist)
+          .setMinterForProject(projectId, minter.address);
+        await minter
+          .connect(config.accounts.artist)
+          .updatePricePerTokenInWei(projectId, 0);
+        await minter.connect(config.accounts.artist).purchase(projectId);
+
+        const tokenId = projectId.mul(ONE_MILLION);
+
+        // Add contract to core registry
+        await config.coreRegistry
+          ?.connect(config.accounts.deployer)
+          .registerContract(
+            genArt721CoreV3.address,
+            ethers.utils.formatBytes32String("DUMMY_VERSION"),
+            ethers.utils.formatBytes32String("DUMMY_TYPE")
+          );
+
+        // deploy PMP contract as our web3call contract
+        const pmp = (await deployAndGet(config, "PMPV0", [])) as PMPV0;
+
+        // add PMP as a web3call contract
+        await genArt721CoreV3.addProjectAssetDependencyOnChainAtAddress(
+          projectId,
+          pmp.address
+        );
+
+        // get token html
+        const tokenHtml = await config.genArt721Generator.getTokenHtml(
+          genArt721CoreV3.address,
+          tokenId
+        );
+
+        // check that the token html includes empty web3call parameters, encoded as base64
+        // @dev "e30=" is the base64 encoded empty json object, "{}"
+        expect(tokenHtml).to.include('"data":"#web3call#e30="');
+
+        // artist configures project with PMP parameters
+        const pmpConfig1 = getPMPInputConfig(
+          "param1",
+          PMP_AUTH_ENUM.ArtistAndTokenOwner,
+          PMP_PARAM_TYPE_ENUM.String,
+          0,
+          constants.AddressZero,
+          [],
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "0x0000000000000000000000000000000000000000000000000000000000000000"
+        );
+        await pmp
+          .connect(config.accounts.artist)
+          .configureProject(genArt721CoreV3.address, projectId, [pmpConfig1]);
+
+        // should still be empty object because unconfigured for tokens
+        // get token html
+        const tokenHtml2 = await config.genArt721Generator.getTokenHtml(
+          genArt721CoreV3.address,
+          tokenId
+        );
+        // check that the token html includes the web3call parameters
+        expect(tokenHtml2).to.include('"data":"#web3call#e30="');
+
+        // artist configures PMP for token 0
+        const pmpInput = getPMPInput(
+          "param1",
+          PMP_PARAM_TYPE_ENUM.String,
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+          false,
+          `]Handle This {[,'"@#$@#%@#$%#%$%`
+        );
+        await pmp
+          .connect(config.accounts.artist)
+          .configureTokenParams(genArt721CoreV3.address, tokenId, [pmpInput]);
+
+        // get token html
+        const tokenHtml3 = await config.genArt721Generator.getTokenHtml(
+          genArt721CoreV3.address,
+          tokenId
+        );
+        // verify that the token html includes the web3call parameters
+        // @dev eyJjR0Z5WVcweCI6IlhVaGhibVJzWlNCVWFHbHpJSHRiTENjaVFDTWtRQ01sUUNNa0pTTWxKQ1U9In0= is base64 encoded json object of prescribed base64 encoded key/value pair
+        expect(tokenHtml3).to.include(
+          '"externalAssetDependencies":[{"dependency_type":"ONCHAIN","cid":"","data":"#web3call#eyJjR0Z5WVcweCI6IlhVaGhibVJzWlNCVWFHbHpJSHRiTENjaVFDTWtRQ01sUUNNa0pTTWxKQ1U9In0="}]'
         );
       });
     });


### PR DESCRIPTION
## Description of the change

Update the On-Chain generator to support Web3Call capabilities.

This updates the on-chain generator to inject web3call data if detected via the special string `#web3call_contract#` returned from the universal reader/bytecode storage reader contracts.

## Design

All key/value pairs are base64 encoded to support special characters, and all decoding is done automatically via updated reviver function.

## Tests

Tests are added to ensure backwards compatibility + support of new web3call cases.
