### PR TITLE
PMP Gas Optimizations

### DIFF
--- a/packages/contracts/contracts/interfaces/v0.8.x/IPMPV0.sol
+++ b/packages/contracts/contracts/interfaces/v0.8.x/IPMPV0.sol
@@ -7,6 +7,8 @@ import {IPMPConfigureHook} from "./IPMPConfigureHook.sol";
 import {IPMPAugmentHook} from "./IPMPAugmentHook.sol";
 import {IWeb3Call} from "./IWeb3Call.sol";
 
+import {ImmutableStringArray} from "../../libs/v0.8.x/ImmutableStringArray.sol";
+
 /**
  * @title Project Metadata Parameters (PMP) Interface, V0
  * @author Art Blocks Inc.
@@ -113,19 +115,21 @@ interface IPMPV0 is IWeb3Call {
     }
 
     /**
-     * @notice Storage structure for parameter configuration.
-     * @dev Includes additional field highestConfigNonce compared to PMPConfig.
+     * @notice View structure for a parameter configuration.
+     * @dev Used when reading a project's available parameters.
+     * @dev any populated select options are loaded and returned as a string array
+     * instead of remaining as a pointer to a data contract
      */
-    struct PMPConfigStorage {
-        // @dev highest config nonce for which this PMPConfig is valid (relative to projectConfig.configNonce)
-        uint8 highestConfigNonce; // slot 0: 1 byte
-        AuthOption authOption; // slot 0: 1 byte
-        ParamType paramType; // slot 0: 1 byte
-        uint48 pmpLockedAfterTimestamp; // slot 0: 6 bytes // @dev uint48 is sufficient to store ~2^48 seconds, ~8,900 years
-        address authAddress; // slot 0: 20 bytes
-        string[] selectOptions; // slot 1: 32 bytes
-        bytes32 minRange; // slot 2: 32 bytes
-        bytes32 maxRange; // slot 3: 32 bytes
+    struct PMPConfigView {
+        uint8 highestConfigNonce;
+        AuthOption authOption;
+        ParamType paramType;
+        uint48 pmpLockedAfterTimestamp;
+        address authAddress;
+        uint8 selectOptionsLength;
+        string[] selectOptions;
+        bytes32 minRange;
+        bytes32 maxRange;
     }
 
     /**

--- a/packages/contracts/test/web3call/PMP/PMPV0_Configure.test.ts
+++ b/packages/contracts/test/web3call/PMP/PMPV0_Configure.test.ts
@@ -513,9 +513,9 @@ describe("PMPV0_Configure", function () {
         }
       });
 
-      it("reverts when invalid pmpInputConfig: selectOptions is > 256 length", async function () {
+      it("reverts when invalid pmpInputConfig: selectOptions is > 255 length", async function () {
         const config = await loadFixture(_beforeEach);
-        const selectOptions = Array.from({ length: 257 }, (_, i) => `${i}`);
+        const selectOptions = Array.from({ length: 256 }, (_, i) => `${i}`);
         for (const paramType of [PMP_PARAM_TYPE_ENUM.Select]) {
           // call with invalid input
           const pmpConfig = getPMPInputConfig(
@@ -524,7 +524,7 @@ describe("PMPV0_Configure", function () {
             paramType,
             0,
             constants.AddressZero,
-            selectOptions, // selectOptions is > 256 length
+            selectOptions, // selectOptions is > 255 length
             "0x0000000000000000000000000000000000000000000000000000000000000000",
             "0x0000000000000000000000000000000000000000000000000000000000000000"
           );

--- a/packages/contracts/test/web3call/PMP/PMPV0_Events.test.ts
+++ b/packages/contracts/test/web3call/PMP/PMPV0_Events.test.ts
@@ -131,7 +131,6 @@ describe("PMPV0_Events", function () {
       const event = receipt.events?.find(
         (e) => e.event === "TokenParamsConfigured"
       );
-      console.log("event", event);
       expect(event?.args?.[0]).to.equal(config.genArt721Core.address); // genArt721Core address
       expect(event?.args?.[1]).to.equal(config.projectZeroTokenZero); // project id
       expect(event?.args?.[2][0][0]).to.equal("param1"); // pmpInput key

--- a/packages/contracts/test/web3call/PMP/PMPV0_Gas.test.ts
+++ b/packages/contracts/test/web3call/PMP/PMPV0_Gas.test.ts
@@ -1,0 +1,168 @@
+import { expectRevert } from "@openzeppelin/test-helpers";
+import { expect } from "chai";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { ethers } from "hardhat";
+import { constants } from "ethers";
+import {
+  PMP_AUTH_ENUM,
+  PMP_PARAM_TYPE_ENUM,
+  getPMPInput,
+  getPMPInputConfig,
+  int256ToBytes32,
+  uint256ToBytes32,
+  BigNumberToBytes32,
+  PMP_TIMESTAMP_MAX,
+  PMP_HEX_COLOR_MAX,
+} from "./pmpTestUtils";
+import { setupPMPFixture } from "./pmpFixtures";
+import { revertMessages } from "./constants";
+import { advanceTimeAndBlock } from "../../util/common";
+import { Logger } from "@ethersproject/logger";
+// hide nuisance logs about event overloading
+Logger.setLogLevel(Logger.levels.ERROR);
+
+/**
+ * Test suite for PMPV0 gas tests
+ */
+describe("PMPV0_Gas", function () {
+  // Test fixture with projects, tokens, and PMP contract setup
+  async function _beforeEach() {
+    const config = await loadFixture(setupPMPFixture);
+    return config;
+  }
+
+  describe("configureProject", function () {
+    it("reports gas when configuring typical project", async function () {
+      const config = await loadFixture(_beforeEach);
+      const pmpConfig1 = getPMPInputConfig(
+        "Colors",
+        PMP_AUTH_ENUM.TokenOwner,
+        PMP_PARAM_TYPE_ENUM.Select,
+        0,
+        constants.AddressZero,
+        [
+          "Dark Lifestyle",
+          "Party Time",
+          "White on Cream",
+          "Luxe-Derived",
+          "Cool",
+          "Rose",
+          "Black",
+          "AM",
+          "White Mono",
+          "Baked",
+          "Politique",
+          "Rad",
+          "Golf Socks",
+          "Luxe",
+        ],
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "0x0000000000000000000000000000000000000000000000000000000000000000"
+      );
+      const pmpConfig2 = getPMPInputConfig(
+        "Spiral",
+        PMP_AUTH_ENUM.TokenOwner,
+        PMP_PARAM_TYPE_ENUM.Bool,
+        0,
+        constants.AddressZero,
+        [],
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "0x0000000000000000000000000000000000000000000000000000000000000000"
+      );
+
+      // measure gas to configure project
+      const tx = await config.pmp
+        .connect(config.accounts.artist)
+        .configureProject(config.genArt721Core.address, config.projectZero, [
+          pmpConfig1,
+          pmpConfig2,
+        ]);
+
+      const receipt = await tx.wait();
+      const gasUsed = receipt.gasUsed;
+      console.log(
+        "gasUsed in initial project 2x PMP config:",
+        gasUsed.toString()
+      );
+    });
+  });
+
+  describe("configureTokenParams", function () {
+    it("reports gas when configuring typical token param", async function () {
+      const config = await loadFixture(_beforeEach);
+      const pmpConfig1 = getPMPInputConfig(
+        "Colors",
+        PMP_AUTH_ENUM.TokenOwner,
+        PMP_PARAM_TYPE_ENUM.Select,
+        0,
+        constants.AddressZero,
+        [
+          "Dark Lifestyle",
+          "Party Time",
+          "White on Cream",
+          "Luxe-Derived",
+          "Cool",
+          "Rose",
+          "Black",
+          "AM",
+          "White Mono",
+          "Baked",
+          "Politique",
+          "Rad",
+          "Golf Socks",
+          "Luxe",
+        ],
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "0x0000000000000000000000000000000000000000000000000000000000000000"
+      );
+      const pmpConfig2 = getPMPInputConfig(
+        "Spiral",
+        PMP_AUTH_ENUM.TokenOwner,
+        PMP_PARAM_TYPE_ENUM.Bool,
+        0,
+        constants.AddressZero,
+        [],
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "0x0000000000000000000000000000000000000000000000000000000000000000"
+      );
+
+      // configure project
+      await config.pmp
+        .connect(config.accounts.artist)
+        .configureProject(config.genArt721Core.address, config.projectZero, [
+          pmpConfig1,
+          pmpConfig2,
+        ]);
+
+      // measure gas to configure token params
+      const pmpParam1 = getPMPInput(
+        "Colors",
+        PMP_PARAM_TYPE_ENUM.Select,
+        "0x0000000000000000000000000000000000000000000000000000000000000004",
+        false,
+        ""
+      );
+      const pmpParam2 = getPMPInput(
+        "Spiral",
+        PMP_PARAM_TYPE_ENUM.Bool,
+        "0x0000000000000000000000000000000000000000000000000000000000000001",
+        false,
+        ""
+      );
+      const tx = await config.pmp
+        .connect(config.accounts.user)
+        .configureTokenParams(
+          config.genArt721Core.address,
+          config.projectZero,
+          [pmpParam1, pmpParam2]
+        );
+
+      const receipt = await tx.wait();
+      const gasUsed = receipt.gasUsed;
+      console.log(
+        "gas used in initial token 2x token param config:",
+        gasUsed.toString()
+      );
+    });
+  });
+});

--- a/packages/contracts/test/web3call/PMP/constants.ts
+++ b/packages/contracts/test/web3call/PMP/constants.ts
@@ -17,7 +17,7 @@ export const revertMessages = {
   minRangeNonZeroForNonRangeParamType: "PMP: minRange is not empty",
   maxRangeNonZeroForNonRangeParamType: "PMP: maxRange is not empty",
   selectOptionsEmptyForSelectParamType: "PMP: selectOptions is empty",
-  selectOptionsLengthGreaterThan256: "PMP: selectOptions length > 256",
+  selectOptionsLengthGreaterThan256: "PMP: selectOptions length > 255",
   minRangeNonZeroForSelectParamType: "PMP: minRange is not empty",
   maxRangeNonZeroForSelectParamType: "PMP: maxRange is not empty",
   minRangeGreaterThanMaxRange: "PMP: minRange >= maxRange",


### PR DESCRIPTION
## Description of the change

Improve PMP gas costs by optimizing storage patterns.

## Summary

(typical) configureProject Gas Reduction
* Before: 572,274 gas
* After: 403,079 gas
* Change: 🔽 169,195 less gas (~29.6% reduction)

(typical) configureTokenParams Gas Reduction
* Before: 154,304 gas
* After: 152,324 gas
* Change: 🔽 1,980 less gas (~1.3% reduction)

## Changes

The primary way gas costs are reduced are by using the new Immutable Strings library to store select options.

Additionally, because only the array length of select options is used when configuring a token, the array length is (redundantly) stored packed as a uint8 in an already-hot slot to remove a costly SLOAD on a cold slot.
