### PR TITLE
deploy pmpv0 dev

### DIFF
--- a/packages/contracts/.openzeppelin/sepolia.json
+++ b/packages/contracts/.openzeppelin/sepolia.json
@@ -572,6 +572,91 @@
         },
         "namespaces": {}
       }
+    },
+    "2edab7fd00882451ce04f40fbb7193b8e256f5a924969afcc467ba284ec27284": {
+      "address": "0xcD1Ba8a8733c6d5004629aEA6fe9faDEb1457CcA",
+      "txHash": "0xe280347073e2defd3cd298ff95afcc4bd01aa8cde3508dacd729a77150c9d077",
+      "layout": {
+        "solcVersion": "0.8.22",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin-4.8/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin-4.8/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "dependencyRegistry",
+            "offset": 2,
+            "slot": "0",
+            "type": "t_contract(IDependencyRegistryV0)34550",
+            "contract": "GenArt721GeneratorV0",
+            "src": "contracts/generator/GenArt721GeneratorV0.sol:58"
+          },
+          {
+            "label": "scriptyBuilder",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_contract(IScriptyBuilderV2)67166",
+            "contract": "GenArt721GeneratorV0",
+            "src": "contracts/generator/GenArt721GeneratorV0.sol:59"
+          },
+          {
+            "label": "gunzipScriptBytecodeAddress",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_address",
+            "contract": "GenArt721GeneratorV0",
+            "src": "contracts/generator/GenArt721GeneratorV0.sol:60"
+          },
+          {
+            "label": "universalBytecodeStorageReader",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_contract(IUniversalBytecodeStorageReader)38157",
+            "contract": "GenArt721GeneratorV0",
+            "src": "contracts/generator/GenArt721GeneratorV0.sol:61"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(IDependencyRegistryV0)34550": {
+            "label": "contract IDependencyRegistryV0",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IScriptyBuilderV2)67166": {
+            "label": "contract IScriptyBuilderV2",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IUniversalBytecodeStorageReader)38157": {
+            "label": "contract IUniversalBytecodeStorageReader",
+            "numberOfBytes": "20"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {}
+      }
     }
   }
 }

--- a/packages/contracts/INFRASTRUCTURE.md
+++ b/packages/contracts/INFRASTRUCTURE.md
@@ -8,10 +8,12 @@ Art Blocks has deployed infrastructure on different networks that support our sm
 
 The following contracts are deployed to all Art Blocks supported networks and are not permissioned. They also may be safely deployed by any wallet on any network, thanks to the use of the [keyless create2 factory system of contracts](./README.md#keyless-create2-factory).
 
+> note: the Web3Call version of the BytecodeStorageReaderContractV2 is currently used on sepolia - prod networks are still the previous version during the transition period.
+
 | Contract/Library                                     | Address                                      |
 | ---------------------------------------------------- | -------------------------------------------- |
 | Library: BytecodeStorageV2:BytecodeStorageReader     | `0x000000000016A5A5ff2FA7799C4BEe89bA59B74e` |
-| BytecodeStorageReaderContractV2                      | `0x00000000163FA16098800B2B2e4A5F96949F413b` |
+| BytecodeStorageReaderContractV2_Web3Call             | `0x000000000005e4192e8789423aEC2FA32E4D52a0` |
 | V3FlexLib (used v3.2.5 - current)                    | `0x00000000Db6f2EBe627260e411E6c973B7c48A62` |
 | SplitProviderV0                                      | `0x000000000ef75C77F6bd0b2Ee166501FbBDb40c8` |
 | Implementation: GenArt721CoreV3_Engine (v3.2.4)      | `0x00000000559cA3F3f1279C0ec121c302ed010457` |
@@ -151,6 +153,7 @@ They are included here for reference purposes.
 
 | Contract/Library                                     | Address                                      |
 | ---------------------------------------------------- | -------------------------------------------- |
+| BytecodeStorageReaderContractV2                      | `0x00000000163FA16098800B2B2e4A5F96949F413b` |
 | V3FlexLib (used v3.2.1 - v3.2.3)                     | `0x0000000006FD94B22fb33164322019750E854f96` |
 | Implementation: GenArt721CoreV3_Engine (v3.2.2)      | `0x000000F74f006CE6480042f001c45c928D1Ae6E7` |
 | Implementation: GenArt721CoreV3_Engine_Flex (v3.2.3) | `0x0066009B13b8DfDabbE07800ee00004b008257D9` |

--- a/packages/contracts/deployments/readers/deprecated/BytecodeStorageReaderContractV2_Web3Call.md
+++ b/packages/contracts/deployments/readers/deprecated/BytecodeStorageReaderContractV2_Web3Call.md
@@ -1,0 +1,30 @@
+# Deployments: BytecodeStorageReaderContractV2_Web3Call
+
+## Description
+
+The keyless create2 factory was used to deterministically and permissionlessly deploy the BytecodeStorageReaderV2_Web3Call contract to any network.
+
+The following were the inputs used to get initcode for deployment, via `scripts/get-init-code.ts`:
+
+```typescript
+const inputs: T_Inputs = {
+  contractName: "BytecodeStorageReaderContractV2_Web3Call",
+  args: [],
+  libraries: {
+    "contracts/libs/v0.8.x/BytecodeStorageV2.sol:BytecodeStorageReader":
+      "0x000000000016A5A5ff2FA7799C4BEe89bA59B74e",
+  },
+};
+```
+
+## Results:
+
+salt: `0x0000000000000000000000000000000000000000fd73cd4749c72a204b340088
+Deploys to address: `0x000000000005e4192e8789423aEC2FA32E4D52a0`
+
+### Deployment transactions:
+
+- sepolia: https://sepolia.etherscan.io/tx/0xb66f8f5d37c2b10aa581aa6b6be6b7cd12247449a0f4247f0e937c19d71f935d
+- arbitrum: https://arbiscan.io/tx/
+- base: https://basescan.org/tx/
+- mainnet: https://etherscan.io/tx/

--- a/packages/contracts/deployments/web3call/PMPV0-sepolia-dev.md
+++ b/packages/contracts/deployments/web3call/PMPV0-sepolia-dev.md
@@ -1,0 +1,24 @@
+# Deployments: PMPV0 (sepolia dev)
+
+## Description
+
+The keyless create2 factory was used to deterministically and permissionlessly deploy the PMPV0 contract to sepolia dev.
+
+The following were the inputs used to get initcode for deployment, via `scripts/get-init-code.ts`:
+
+```typescript
+const inputs: T_Inputs = {
+  contractName: "PMPV0",
+  args: ["0x00000000000000447e69651d841bd8d104bed493"],
+  libraries: {},
+};
+```
+
+## Results:
+
+salt: `0x0000000000000000000000000000000000000000000000000000000000000000`
+Deploys to address: `0x59e6F582C4671d5aBDB0F1787Fa9bEE347BB5667`
+
+### Deployment transactions:
+
+- sepolia dev: https://sepolia.etherscan.io/tx/0xabaa60a6d2c3a57411638739f81f46615de76a2cc933caf3806a1710b7c12c0b

--- a/packages/contracts/scripts/on-chain-generator/2_reference_upgrade-sepolia-on-chain-generator.ts
+++ b/packages/contracts/scripts/on-chain-generator/2_reference_upgrade-sepolia-on-chain-generator.ts
@@ -21,10 +21,7 @@ async function main() {
   console.log("Preparing upgrade...");
   const newImplementationAddress = await upgrades.prepareUpgrade(
     proxyAddress,
-    newImplementationFactory,
-    {
-      unsafeAllowRenames: true, // updated variable names on the new implementation
-    }
+    newImplementationFactory
   );
   console.log("Deployed new implementation:", newImplementationAddress);
 


### PR DESCRIPTION
## Description of the change

Deploy PMPV0 and related web3call contracts to sepolia dev.

This includes:

* the Art Blocks supported PMP integration

* New web3call-compatible BytecodeStorageReaderV2_Web3Call

* Call UniversalReader to use new web3call-compatible versioned reader

* on-chain generator upgraded contracts (technically staging, but good to do)
