### PR TITLE
Dependency Registry Bytecode Storage Universal Reader

### DIFF
--- a/packages/contracts/contracts/interfaces/v0.8.x/IDependencyRegistryV0.sol
+++ b/packages/contracts/contracts/interfaces/v0.8.x/IDependencyRegistryV0.sol
@@ -85,6 +85,8 @@ interface IDependencyRegistryV0 {
 
     event CoreRegistryAddressUpdated(address indexed coreRegistryAddress);
 
+    event UniversalBytecodeStorageReaderUpdated(address indexed newReader);
+
     /**
      * @notice Returns the count of scripts for dependency `dependencyNameAndVersion`.
      * @param dependencyNameAndVersion Dependency type to be queried.

--- a/packages/contracts/contracts/interfaces/v0.8.x/IUniversalBytecodeStorageReader.sol
+++ b/packages/contracts/contracts/interfaces/v0.8.x/IUniversalBytecodeStorageReader.sol
@@ -25,4 +25,9 @@ interface IUniversalBytecodeStorageReader is IBytecodeStorageReader_Base {
     function updateBytecodeStorageReaderContract(
         IBytecodeStorageReader_Base newBytecodeStorageReaderContract
     ) external;
+
+    function activeBytecodeStorageReaderContract()
+        external
+        view
+        returns (IBytecodeStorageReader_Base);
 }

--- a/packages/contracts/contracts/libs/v0.8.x/DependencyRegistryStorageLib.sol
+++ b/packages/contracts/contracts/libs/v0.8.x/DependencyRegistryStorageLib.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.19;
 
 import "../../interfaces/v0.8.x/IAdminACLV0.sol";
 import "../../interfaces/v0.8.x/ICoreRegistryV1.sol";
+import "../../interfaces/v0.8.x/IUniversalBytecodeStorageReader.sol";
 import "@openzeppelin-4.7/contracts/utils/structs/EnumerableSet.sol";
 
 /**
@@ -82,6 +83,8 @@ library DependencyRegistryStorageLib {
         // that are supported by the CoreRegistry contract
         // @dev possible there is overlap between the two sets, but not intentionally configured by admin.
         EnumerableSet.AddressSet supportedCoreContractsOverride;
+        // address of the UniversalBytecodeStorageReader contract
+        IUniversalBytecodeStorageReader universalReader;
     }
 
     /**

--- a/packages/contracts/test/dependency-registry/DependencyRegistryV0.test.ts
+++ b/packages/contracts/test/dependency-registry/DependencyRegistryV0.test.ts
@@ -2885,4 +2885,41 @@ describe(`DependencyRegistryV0`, async function () {
       );
     });
   });
+
+  describe("updateUniversalBytecodeStorageReader", function () {
+    it("does not allow non-admins to update universal reader", async function () {
+      const config = await loadFixture(_beforeEach);
+      const dummyAddress = ethers.Wallet.createRandom().address;
+      await expectRevert(
+        config.dependencyRegistry
+          .connect(config.accounts.artist)
+          .updateUniversalBytecodeStorageReader(dummyAddress),
+        ONLY_ADMIN_ACL_ERROR
+      );
+    });
+
+    it("does not allow updating to zero address", async function () {
+      const config = await loadFixture(_beforeEach);
+      await expectRevert(
+        config.dependencyRegistry
+          .connect(config.accounts.deployer)
+          .updateUniversalBytecodeStorageReader(constants.ZERO_ADDRESS),
+        ONLY_NON_ZERO_ADDRESS_ERROR
+      );
+    });
+
+    it("allows admin to update universal reader", async function () {
+      const config = await loadFixture(_beforeEach);
+      await expect(
+        config.dependencyRegistry
+          .connect(config.accounts.deployer)
+          .updateUniversalBytecodeStorageReader(config.universalReader.address)
+      )
+        .to.emit(
+          config.dependencyRegistry,
+          "UniversalBytecodeStorageReaderUpdated"
+        )
+        .withArgs(config.universalReader.address);
+    });
+  });
 });


### PR DESCRIPTION
## Description of the change

Upgrade the dependency registry to use the universal reader.

Issue: Dependency registry is currently reading with versioned (V1) reader.

This is causing it not being able to read recently uploaded cannon-es data, or any other new data.

Upgrade it to use the universal reader abstraction to fix + automatically update going forward.
