### PR TITLE
Deploy PMP to prod

### DIFF
--- a/packages/contracts/.openzeppelin/mainnet.json
+++ b/packages/contracts/.openzeppelin/mainnet.json
@@ -416,6 +416,91 @@
         },
         "namespaces": {}
       }
+    },
+    "2edab7fd00882451ce04f40fbb7193b8e256f5a924969afcc467ba284ec27284": {
+      "address": "0x7380C14beCB82e50B7Bc22dF47fcf3bF505aa8b7",
+      "txHash": "0x3e38f3860c1609dd46b41ca5e8f26933bda58b6e7bfa7f43e3c91c983f3bf256",
+      "layout": {
+        "solcVersion": "0.8.22",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin-4.8/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin-4.8/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "dependencyRegistry",
+            "offset": 2,
+            "slot": "0",
+            "type": "t_contract(IDependencyRegistryV0)34562",
+            "contract": "GenArt721GeneratorV0",
+            "src": "contracts/generator/GenArt721GeneratorV0.sol:58"
+          },
+          {
+            "label": "scriptyBuilder",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_contract(IScriptyBuilderV2)68354",
+            "contract": "GenArt721GeneratorV0",
+            "src": "contracts/generator/GenArt721GeneratorV0.sol:59"
+          },
+          {
+            "label": "gunzipScriptBytecodeAddress",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_address",
+            "contract": "GenArt721GeneratorV0",
+            "src": "contracts/generator/GenArt721GeneratorV0.sol:60"
+          },
+          {
+            "label": "universalBytecodeStorageReader",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_contract(IUniversalBytecodeStorageReader)38175",
+            "contract": "GenArt721GeneratorV0",
+            "src": "contracts/generator/GenArt721GeneratorV0.sol:61"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(IDependencyRegistryV0)34562": {
+            "label": "contract IDependencyRegistryV0",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IScriptyBuilderV2)68354": {
+            "label": "contract IScriptyBuilderV2",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IUniversalBytecodeStorageReader)38175": {
+            "label": "contract IUniversalBytecodeStorageReader",
+            "numberOfBytes": "20"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {}
+      }
     }
   }
 }

--- a/packages/contracts/contracts/web3call/augment-hooks/InjectPolyptychTokenHash.sol
+++ b/packages/contracts/contracts/web3call/augment-hooks/InjectPolyptychTokenHash.sol
@@ -43,13 +43,12 @@ contract InjectPolyptychTokenHash is AbstractPMPAugmentHook {
      * Appends the hash of a token on a different project into a tokens PMPs.
      * @dev This hook is called when a token's PMPs are read.
      * @dev This must return all desired tokenParams, not just additional data.
-     * @param coreContract The address of the core contract to call.
      * @param tokenId The tokenId of the token to get data for.
      * @param tokenParams The token parameters for the queried token.
      * @return augmentedTokenParams The augmented token parameters.
      */
     function onTokenPMPReadAugmentation(
-        address coreContract,
+        address /* coreContract */,
         uint256 tokenId,
         IWeb3Call.TokenParam[] calldata tokenParams
     )

--- a/packages/contracts/deployments/readers/BytecodeStorageReaderContractV2_Web3Call.md
+++ b/packages/contracts/deployments/readers/BytecodeStorageReaderContractV2_Web3Call.md
@@ -1,0 +1,30 @@
+# Deployments: BytecodeStorageReaderContractV2_Web3Call
+
+## Description
+
+The keyless create2 factory was used to deterministically and permissionlessly deploy the BytecodeStorageReaderV2_Web3Call contract to any network.
+
+The following were the inputs used to get initcode for deployment, via `scripts/get-init-code.ts`:
+
+```typescript
+const inputs: T_Inputs = {
+  contractName: "BytecodeStorageReaderContractV2_Web3Call",
+  args: [],
+  libraries: {
+    "contracts/libs/v0.8.x/BytecodeStorageV2.sol:BytecodeStorageReader":
+      "0x000000000016A5A5ff2FA7799C4BEe89bA59B74e",
+  },
+};
+```
+
+## Results:
+
+salt: `0x0000000000000000000000000000000000000000fd73cd4749c72a204b340088
+Deploys to address: `0x000000000005e4192e8789423aEC2FA32E4D52a0`
+
+### Deployment transactions:
+
+- sepolia: https://sepolia.etherscan.io/tx/0xb66f8f5d37c2b10aa581aa6b6be6b7cd12247449a0f4247f0e937c19d71f935d
+- arbitrum: https://arbiscan.io//tx/0xe0ec1df0d3f9b09f0fc5765113eb7392a9c6f703f88d98772f9720ebbc873188
+- base: https://basescan.org/tx/0x7a49781ff8bebac0ea682cd531921b88c9090dc68c922f26455efcd55bec39fe
+- mainnet: https://etherscan.io/tx/0x8bf53b6fe9e09e9f483b4bcc0c7bf313e61e2e9ead915d61f1af7ed582825fce

--- a/packages/contracts/deployments/web3call/PMPV0-arbitrum.md
+++ b/packages/contracts/deployments/web3call/PMPV0-arbitrum.md
@@ -1,0 +1,24 @@
+# Deployments: PMPV0 (arbitrum)
+
+## Description
+
+The keyless create2 factory was used to deterministically and permissionlessly deploy the PMPV0 contract to arbitrum.
+
+The following were the inputs used to get initcode for deployment, via `scripts/get-init-code.ts`:
+
+```typescript
+const inputs: T_Inputs = {
+  contractName: "PMPV0",
+  args: ["0x00000000000000447e69651d841bd8d104bed493"],
+  libraries: {},
+};
+```
+
+## Results:
+
+salt: `0x00000000000000000000000000000000000000008214b0affa812076ab2000e0`
+Deploys to address: `0x000000001AC1998e4A97d207915889f2B9Ced8e2`
+
+### Deployment transactions:
+
+- arbitrum: https://arbiscan.io//tx/0x264e410dc45c365f5a2307abcd142107e8bac2949a9a780666238be5c61eb30d

--- a/packages/contracts/deployments/web3call/PMPV0-base.md
+++ b/packages/contracts/deployments/web3call/PMPV0-base.md
@@ -1,0 +1,24 @@
+# Deployments: PMPV0 (base)
+
+## Description
+
+The keyless create2 factory was used to deterministically and permissionlessly deploy the PMPV0 contract to base.
+
+The following were the inputs used to get initcode for deployment, via `scripts/get-init-code.ts`:
+
+```typescript
+const inputs: T_Inputs = {
+  contractName: "PMPV0",
+  args: ["0x00000000000000447e69651d841bd8d104bed493"],
+  libraries: {},
+};
+```
+
+## Results:
+
+salt: `0x00000000000000000000000000000000000000008214b0affa812076ab2000e0`
+Deploys to address: `0x000000001AC1998e4A97d207915889f2B9Ced8e2`
+
+### Deployment transactions:
+
+- base: https://basescan.org/tx/0x6acac721619a76844aa31c22b6df888354db642509c2e17d1b1bc943364d6087

--- a/packages/contracts/deployments/web3call/PMPV0-mainnet.md
+++ b/packages/contracts/deployments/web3call/PMPV0-mainnet.md
@@ -1,0 +1,24 @@
+# Deployments: PMPV0 (mainnet)
+
+## Description
+
+The keyless create2 factory was used to deterministically and permissionlessly deploy the PMPV0 contract to mainnet.
+
+The following were the inputs used to get initcode for deployment, via `scripts/get-init-code.ts`:
+
+```typescript
+const inputs: T_Inputs = {
+  contractName: "PMPV0",
+  args: ["0x00000000000000447e69651d841bd8d104bed493"],
+  libraries: {},
+};
+```
+
+## Results:
+
+salt: `0x00000000000000000000000000000000000000008214b0affa812076ab2000e0`
+Deploys to address: `0x000000001AC1998e4A97d207915889f2B9Ced8e2`
+
+### Deployment transactions:
+
+- mainnet: https://etherscan.io/tx/0xb3cf3fc508a840f3d55c57c7e62cd6a42d40b8ce9cb76d70e469275ae6b61323

--- a/packages/contracts/deployments/web3call/PMPV0-sepolia-staging.md
+++ b/packages/contracts/deployments/web3call/PMPV0-sepolia-staging.md
@@ -1,0 +1,24 @@
+# Deployments: PMPV0 (sepolia staging)
+
+## Description
+
+The keyless create2 factory was used to deterministically and permissionlessly deploy the PMPV0 contract to sepolia staging.
+
+The following were the inputs used to get initcode for deployment, via `scripts/get-init-code.ts`:
+
+```typescript
+const inputs: T_Inputs = {
+  contractName: "PMPV0",
+  args: ["0x00000000000000447e69651d841bd8d104bed493"],
+  libraries: {},
+};
+```
+
+## Results:
+
+salt: `0x00000000000000000000000000000000000000008214b0affa812076ab2000e0`
+Deploys to address: `0x000000001AC1998e4A97d207915889f2B9Ced8e2`
+
+### Deployment transactions:
+
+- sepolia staging: https://sepolia.etherscan.io/tx/0x994c3851d51ca75ed3aebb3dd9b363653a14daa215177c89d6c7d76ebe113d3c

--- a/packages/contracts/scripts/on-chain-generator/2_reference_upgrade-mainnet-on-chain-generator.ts
+++ b/packages/contracts/scripts/on-chain-generator/2_reference_upgrade-mainnet-on-chain-generator.ts
@@ -21,10 +21,7 @@ async function main() {
   console.log("Preparing upgrade...");
   const newImplementationAddress = await upgrades.prepareUpgrade(
     proxyAddress,
-    newImplementationFactory,
-    {
-      unsafeAllowRenames: true, // updated variable names on the new implementation
-    }
+    newImplementationFactory
   );
   console.log("Deployed new implementation:", newImplementationAddress);
 


### PR DESCRIPTION
## Description of the change

Deploy PMP and related infrastructure to prod networks.

This includes:

* the Art Blocks supported PMP integration

* New web3call-compatible BytecodeStorageReaderV2_Web3Call

* Call UniversalReader to use new web3call-compatible versioned reader

* mainnet only: on-chain generator upgraded contracts
