### PR TITLE
Update dependency registry with three new script fields

### DIFF
--- a/packages/contracts/contracts/generator/GenArt721GeneratorV0.sol
+++ b/packages/contracts/contracts/generator/GenArt721GeneratorV0.sol
@@ -821,17 +821,16 @@ contract GenArt721GeneratorV0 is Initializable, IGenArt721GeneratorV0 {
         HTMLTag memory htmlTag
     ) internal view {
         // Get script count and preferred CDN for the dependency.
-        (
-            ,
-            ,
-            string memory preferredCDN,
-            ,
-            ,
-            ,
-            ,
-            ,
-            uint24 scriptCount
-        ) = dependencyRegistry.getDependencyDetails(dependencyNameAndVersion);
+        string memory preferredCDN;
+        uint24 scriptCount;
+        // block scope to avoid stack too deep error
+        {
+            IDependencyRegistryV0.DependencyDetails
+                memory dependencyDetails = dependencyRegistry
+                    .getDependencyDetails(dependencyNameAndVersion);
+            preferredCDN = dependencyDetails.preferredCDN;
+            scriptCount = dependencyDetails.scriptCount;
+        }
 
         // If no scripts on-chain, load the script from the preferred CDN.
         if (scriptCount == 0) {
@@ -1021,8 +1020,11 @@ contract GenArt721GeneratorV0 is Initializable, IGenArt721GeneratorV0 {
             return true;
         }
         // query and return result of dependency registry for on-chain status
-        (, , , , , , , availableOnChain, ) = dependencyRegistry
-            .getDependencyDetails(dependencyNameAndVersion);
+        IDependencyRegistryV0.DependencyDetails
+            memory dependencyDetails = dependencyRegistry.getDependencyDetails(
+                dependencyNameAndVersion
+            );
+        return dependencyDetails.availableOnChain;
     }
 
     /**

--- a/packages/contracts/contracts/interfaces/v0.8.x/IDependencyRegistryV0.sol
+++ b/packages/contracts/contracts/interfaces/v0.8.x/IDependencyRegistryV0.sol
@@ -87,6 +87,61 @@ interface IDependencyRegistryV0 {
 
     event UniversalBytecodeStorageReaderUpdated(address indexed newReader);
 
+    event DependencyCanvasTagUpdated(
+        bytes32 indexed dependencyNameAndVersion,
+        CanvasTag canvasTag
+    );
+
+    event DependencyLoadAsModuleUpdated(
+        bytes32 indexed dependencyNameAndVersion,
+        bool loadAsModule
+    );
+
+    event DependencyProjectScriptSpecialTypeUpdated(
+        bytes32 indexed dependencyNameAndVersion,
+        string projectScriptSpecialType
+    );
+
+    /**
+     * @notice Enum representing the canvas tag requirements for a dependency.
+     * @dev This enum is used to convey the canvas tag for a dependency.
+     * @dev NoCanvasTag is the default value. No canvas tag is required to be added to the html when generating the project outputs.
+     * @dev CanvasBeforeProjectScript is used for dependencies that require a canvas tag to be added before the project script.
+     * @dev CanvasAfterProjectScript is used for dependencies that require a canvas tag to be added after the project script.
+     */
+    enum CanvasTag {
+        NoCanvasTag, // default
+        CanvasBeforeProjectScript,
+        CanvasAfterProjectScript
+    }
+
+    struct DependencyDetails {
+        // name and version of dependency (i.e. "name@version") used to identify dependency
+        string nameAndVersion;
+        // type of license, MIT, GPL, etc.
+        string licenseType;
+        // preferred CDN URL for dependency
+        string preferredCDN;
+        // count of additional CDN URLs for dependency
+        uint24 additionalCDNCount;
+        // preferred code repository URL for dependency
+        string preferredRepository;
+        // count of additional repository URLs for dependency
+        uint24 additionalRepositoryCount;
+        // project website URL for dependency
+        string dependencyWebsite;
+        // whether the dependency is available on chain
+        bool availableOnChain;
+        // count of on-chain scripts for dependency
+        uint24 scriptCount;
+        // canvas tag for the dependency
+        CanvasTag canvasTag;
+        // whether the dependency should be loaded as a module
+        bool loadAsModule;
+        // project script special type for the dependency
+        string projectScriptSpecialType;
+    }
+
     /**
      * @notice Returns the count of scripts for dependency `dependencyNameAndVersion`.
      * @param dependencyNameAndVersion Dependency type to be queried.
@@ -117,33 +172,11 @@ interface IDependencyRegistryV0 {
     /**
      * @notice Returns details for a given dependency type `dependencyNameAndVersion`.
      * @param dependencyNameAndVersion Name and version of dependency (i.e. "name@version") used to identify dependency.
-     * @return nameAndVersion String representation of `dependencyNameAndVersion`.
-     *                        (e.g. "p5js(atSymbol)1.0.0")
-     * @return licenseType License type for dependency
-     * @return preferredCDN Preferred CDN URL for dependency
-     * @return additionalCDNCount Count of additional CDN URLs for dependency
-     * @return preferredRepository Preferred repository URL for dependency
-     * @return additionalRepositoryCount Count of additional repository URLs for dependency
-     * @return dependencyWebsite Project website URL for dependency
-     * @return availableOnChain Whether dependency is available on chain
-     * @return scriptCount Count of on-chain scripts for dependency
+     * @return dependencyDetails Details for a given dependency type.
      */
     function getDependencyDetails(
         bytes32 dependencyNameAndVersion
-    )
-        external
-        view
-        returns (
-            string memory nameAndVersion,
-            string memory licenseType,
-            string memory preferredCDN,
-            uint24 additionalCDNCount,
-            string memory preferredRepository,
-            uint24 additionalRepositoryCount,
-            string memory dependencyWebsite,
-            bool availableOnChain,
-            uint24 scriptCount
-        );
+    ) external view returns (DependencyDetails memory dependencyDetails);
 
     /**
      * @notice Returns the dependency name and version for a given project (`projectId`)

--- a/packages/contracts/contracts/libs/v0.8.x/DependencyRegistryStorageLib.sol
+++ b/packages/contracts/contracts/libs/v0.8.x/DependencyRegistryStorageLib.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.19;
 import "../../interfaces/v0.8.x/IAdminACLV0.sol";
 import "../../interfaces/v0.8.x/ICoreRegistryV1.sol";
 import "../../interfaces/v0.8.x/IUniversalBytecodeStorageReader.sol";
+import {IDependencyRegistryV0} from "../../interfaces/v0.8.x/IDependencyRegistryV0.sol";
+
 import "@openzeppelin-4.7/contracts/utils/structs/EnumerableSet.sol";
 
 /**
@@ -51,6 +53,12 @@ library DependencyRegistryStorageLib {
         uint24 additionalRepositoryCount;
         // count of scripts that make up the dependency, if the dependency is available on-chain
         uint24 scriptCount;
+        // canvas tag for the dependency
+        IDependencyRegistryV0.CanvasTag canvasTag;
+        // whether the dependency should be loaded as a module
+        bool loadAsModule;
+        // project script special type for the dependency
+        string projectScriptSpecialType;
     }
 
     /**

--- a/packages/contracts/test/dependency-registry/DependencyRegistryV0.test.ts
+++ b/packages/contracts/test/dependency-registry/DependencyRegistryV0.test.ts
@@ -374,6 +374,9 @@ describe(`DependencyRegistryV0`, async function () {
           dependencyWebsite, // dependencyWebsite
           false, // availableOnChain
           0, // scriptCount
+          0, // canvas tag enum
+          false, // loadAsModule
+          "", // projectScriptSpecialType
         ]);
       });
     });

--- a/packages/contracts/test/dependency-registry/DependencyRegistryV0.test.ts
+++ b/packages/contracts/test/dependency-registry/DependencyRegistryV0.test.ts
@@ -32,6 +32,13 @@ const ONLY_NON_EMPTY_STRING_ERROR = "Must input non-empty string";
 const ONLY_NON_ZERO_ADDRESS_ERROR = "Must input non-zero address";
 const INDEX_OUT_OF_RANGE_ERROR = "Index out of range";
 
+const CANVAS_TAG = {
+  NoCanvasTag: 0,
+  CanvasBeforeProjectScript: 1,
+  CanvasAfterProjectScript: 2,
+  InvalidCanvasTag: 3, // this is not a valid enum value
+};
+
 interface DependencyRegistryV0TestContext extends Mocha.Context {
   dependencyRegistry: DependencyRegistryV0;
   genArt721Core: GenArt721CoreV3;
@@ -1953,6 +1960,215 @@ describe(`DependencyRegistryV0`, async function () {
             0
           );
         expect(storedRepository).to.eq("https://bitbucket.com");
+      });
+    });
+
+    describe("updateDependencyCanvasTag", function () {
+      it("does not allow non-admins to update canvas tag", async function () {
+        // get config from beforeEach
+        const config = this.config;
+        await expectRevert(
+          config.dependencyRegistry
+            .connect(config.accounts.user)
+            .updateDependencyCanvasTag(
+              dependencyNameAndVersionBytes,
+              CANVAS_TAG.CanvasAfterProjectScript
+            ),
+          ONLY_ADMIN_ACL_ERROR
+        );
+      });
+
+      it("does not allow updating canvas tag for a dependency that does not exist", async function () {
+        // get config from beforeEach
+        const config = this.config;
+        await expectRevert(
+          config.dependencyRegistry.updateDependencyCanvasTag(
+            ethers.utils.formatBytes32String("nonExistentDependencyType"),
+            CANVAS_TAG.CanvasAfterProjectScript
+          ),
+          ONLY_EXISTING_DEPENDENCY_TYPE_ERROR
+        );
+      });
+
+      it("does not allow updating canvas tag to an invalid enum value", async function () {
+        // get config from beforeEach
+        const config = this.config;
+        await expectRevert.unspecified(
+          config.dependencyRegistry.updateDependencyCanvasTag(
+            dependencyNameAndVersionBytes,
+            CANVAS_TAG.InvalidCanvasTag
+          )
+        );
+      });
+
+      it("allows admin to update canvas tag", async function () {
+        // get config from beforeEach
+        const config = this.config;
+        await config.dependencyRegistry
+          .connect(config.accounts.deployer)
+          .updateDependencyCanvasTag(
+            dependencyNameAndVersionBytes,
+            CANVAS_TAG.CanvasAfterProjectScript
+          );
+
+        const dependencyDetails =
+          await config.dependencyRegistry.getDependencyDetails(
+            dependencyNameAndVersionBytes
+          );
+        expect(dependencyDetails.canvasTag).to.eq(
+          CANVAS_TAG.CanvasAfterProjectScript
+        );
+      });
+
+      it("emits the correct event", async function () {
+        // get config from beforeEach
+        const config = this.config;
+        await expect(
+          config.dependencyRegistry
+            .connect(config.accounts.deployer)
+            .updateDependencyCanvasTag(
+              dependencyNameAndVersionBytes,
+              CANVAS_TAG.CanvasBeforeProjectScript
+            )
+        )
+          .to.emit(config.dependencyRegistry, "DependencyCanvasTagUpdated")
+          .withArgs(
+            dependencyNameAndVersionBytes,
+            CANVAS_TAG.CanvasBeforeProjectScript
+          );
+      });
+    });
+
+    describe("updateDependencyLoadAsModule", function () {
+      it("does not allow non-admins to update loadAsModule", async function () {
+        // get config from beforeEach
+        const config = this.config;
+        await expectRevert(
+          config.dependencyRegistry
+            .connect(config.accounts.user)
+            .updateDependencyLoadAsModule(dependencyNameAndVersionBytes, true),
+          ONLY_ADMIN_ACL_ERROR
+        );
+      });
+
+      it("does not allow updating loadAsModule for a dependency that does not exist", async function () {
+        // get config from beforeEach
+        const config = this.config;
+        await expectRevert(
+          config.dependencyRegistry.updateDependencyLoadAsModule(
+            ethers.utils.formatBytes32String("nonExistentDependencyType"),
+            true
+          ),
+          ONLY_EXISTING_DEPENDENCY_TYPE_ERROR
+        );
+      });
+
+      it("allows admin to update loadAsModule", async function () {
+        // get config from beforeEach
+        const config = this.config;
+        await config.dependencyRegistry
+          .connect(config.accounts.deployer)
+          .updateDependencyLoadAsModule(dependencyNameAndVersionBytes, true);
+
+        const dependencyDetails =
+          await config.dependencyRegistry.getDependencyDetails(
+            dependencyNameAndVersionBytes
+          );
+        expect(dependencyDetails.loadAsModule).to.eq(true);
+      });
+
+      it("emits the correct event", async function () {
+        // get config from beforeEach
+        const config = this.config;
+        await expect(
+          config.dependencyRegistry
+            .connect(config.accounts.deployer)
+            .updateDependencyLoadAsModule(dependencyNameAndVersionBytes, true)
+        )
+          .to.emit(config.dependencyRegistry, "DependencyLoadAsModuleUpdated")
+          .withArgs(dependencyNameAndVersionBytes, true);
+      });
+    });
+
+    describe("updateDependencyProjectScriptSpecialType", function () {
+      it("does not allow non-admins to update project script special type", async function () {
+        // get config from beforeEach
+        const config = this.config;
+        await expectRevert(
+          config.dependencyRegistry
+            .connect(config.accounts.user)
+            .updateDependencyProjectScriptSpecialType(
+              dependencyNameAndVersionBytes,
+              "newSpecialType"
+            ),
+          ONLY_ADMIN_ACL_ERROR
+        );
+      });
+
+      it("does not allow updating project script special type for a dependency that does not exist", async function () {
+        // get config from beforeEach
+        const config = this.config;
+        await expectRevert(
+          config.dependencyRegistry.updateDependencyProjectScriptSpecialType(
+            ethers.utils.formatBytes32String("nonExistentDependencyType"),
+            "newSpecialType"
+          ),
+          ONLY_EXISTING_DEPENDENCY_TYPE_ERROR
+        );
+      });
+
+      it("allows admin to update project script special type", async function () {
+        // get config from beforeEach
+        const config = this.config;
+        await config.dependencyRegistry
+          .connect(config.accounts.deployer)
+          .updateDependencyProjectScriptSpecialType(
+            dependencyNameAndVersionBytes,
+            "newSpecialType"
+          );
+
+        const dependencyDetails =
+          await config.dependencyRegistry.getDependencyDetails(
+            dependencyNameAndVersionBytes
+          );
+        expect(dependencyDetails.projectScriptSpecialType).to.eq(
+          "newSpecialType"
+        );
+      });
+
+      it("emits the correct event", async function () {
+        // get config from beforeEach
+        const config = this.config;
+        await expect(
+          config.dependencyRegistry
+            .connect(config.accounts.deployer)
+            .updateDependencyProjectScriptSpecialType(
+              dependencyNameAndVersionBytes,
+              "newSpecialType"
+            )
+        )
+          .to.emit(
+            config.dependencyRegistry,
+            "DependencyProjectScriptSpecialTypeUpdated"
+          )
+          .withArgs(dependencyNameAndVersionBytes, "newSpecialType");
+      });
+
+      it("allows updating project script special type to empty string", async function () {
+        // get config from beforeEach
+        const config = this.config;
+        await config.dependencyRegistry
+          .connect(config.accounts.deployer)
+          .updateDependencyProjectScriptSpecialType(
+            dependencyNameAndVersionBytes,
+            ""
+          );
+
+        const dependencyDetails =
+          await config.dependencyRegistry.getDependencyDetails(
+            dependencyNameAndVersionBytes
+          );
+        expect(dependencyDetails.projectScriptSpecialType).to.eq("");
       });
     });
 


### PR DESCRIPTION
## Description of the change

Update dependency registry with three new script fields to fully prescribe generator behavior.

The three new fields enable the dependency registry to sufficiently prescribe how each project should be rendered in the generator. This will lead to the removal of any dependency-name-based logic from the on-chain generator in a subsequent PR.
