### PR TITLE
event data for PMP "changed by"

### DIFF
--- a/packages/contracts/contracts/interfaces/v0.8.x/IPMPV0.sol
+++ b/packages/contracts/contracts/interfaces/v0.8.x/IPMPV0.sol
@@ -52,11 +52,13 @@ interface IPMPV0 is IWeb3Call {
      * @param coreContract The address of the core contract.
      * @param tokenId The token ID for which parameters were configured.
      * @param pmpInputs Array of parameter inputs that were configured.
+     * @param authAddresses Array of addresses that authenticated the parameters. Aligned by index with pmpInputs.
      */
     event TokenParamsConfigured(
         address coreContract,
         uint256 tokenId,
-        PMPInput[] pmpInputs
+        PMPInput[] pmpInputs,
+        address[] authAddresses
     );
 
     /**
@@ -213,12 +215,12 @@ interface IPMPV0 is IWeb3Call {
      * @param wallet The wallet address to check.
      * @param coreContract The address of the core contract to call.
      * @param tokenId The tokenId of the token to check.
-     * @return isTokenOwnerOrDelegate True if the wallet is the owner or a delegate of the token,
+     * @return isTokenOwnerOrDelegate_ True if the wallet is the owner or a delegate of the token,
      * false otherwise.
      */
     function isTokenOwnerOrDelegate(
         address wallet,
         address coreContract,
         uint256 tokenId
-    ) external view returns (bool);
+    ) external view returns (bool isTokenOwnerOrDelegate_);
 }

--- a/packages/contracts/test/web3call/PMP/PMPV0_Events.test.ts
+++ b/packages/contracts/test/web3call/PMP/PMPV0_Events.test.ts
@@ -96,7 +96,7 @@ describe("PMPV0_Events", function () {
     it("emitted when token parameters are configured", async function () {
       const config = await loadFixture(_beforeEach);
       // artist configures project
-      const pmpConfig = getPMPInputConfig(
+      const pmpConfig1 = getPMPInputConfig(
         "param1",
         PMP_AUTH_ENUM.ArtistAndTokenOwner,
         PMP_PARAM_TYPE_ENUM.Uint256Range,
@@ -106,10 +106,35 @@ describe("PMPV0_Events", function () {
         "0x0000000000000000000000000000000000000000000000000000000000000001",
         "0x0000000000000000000000000000000000000000000000000000000000000010"
       );
+      // add pmpConfig2 to check artist auth
+      const pmpConfig2 = getPMPInputConfig(
+        "param2",
+        PMP_AUTH_ENUM.ArtistAndTokenOwnerAndAddress,
+        PMP_PARAM_TYPE_ENUM.Uint256Range,
+        0,
+        config.accounts.deployer.address,
+        [],
+        "0x0000000000000000000000000000000000000000000000000000000000000001",
+        "0x0000000000000000000000000000000000000000000000000000000000000010"
+      );
+      // add pmpConfig3 to check address auth
+      const pmpConfig3 = getPMPInputConfig(
+        "param3",
+        PMP_AUTH_ENUM.ArtistAndTokenOwnerAndAddress,
+        PMP_PARAM_TYPE_ENUM.Uint256Range,
+        0,
+        config.accounts.user2.address,
+        [],
+        "0x0000000000000000000000000000000000000000000000000000000000000001",
+        "0x0000000000000000000000000000000000000000000000000000000000000010"
+      );
+
       await config.pmp
         .connect(config.accounts.artist)
         .configureProject(config.genArt721Core.address, config.projectZero, [
-          pmpConfig,
+          pmpConfig1,
+          pmpConfig2,
+          pmpConfig3,
         ]);
       // token owner configures token parameters
       const pmpInput = getPMPInput(
@@ -140,6 +165,77 @@ describe("PMPV0_Events", function () {
       ); // pmpInput value
       expect(event?.args?.[2][0][3]).to.equal(false); // pmpInput configuringArtistString
       expect(event?.args?.[2][0][4]).to.deep.equal(""); // pmpInput configuredValueString
+      // verify auth addresses
+      expect(event?.args?.[3][0]).to.equal(config.accounts.user.address); // auth address for pmpInput is user, since user is token owner
+      // artist configures token param2
+      const pmpInput2 = getPMPInput(
+        "param2",
+        PMP_PARAM_TYPE_ENUM.Uint256Range,
+        "0x0000000000000000000000000000000000000000000000000000000000000002",
+        false,
+        ""
+      );
+      const tx2 = await config.pmp
+        .connect(config.accounts.artist)
+        .configureTokenParams(
+          config.genArt721Core.address,
+          config.projectZeroTokenZero,
+          [pmpInput2]
+        );
+      const receipt2 = await tx2.wait();
+      const event2 = receipt2.events?.find(
+        (e) => e.event === "TokenParamsConfigured"
+      );
+      expect(event2?.args?.[3][0]).to.equal(config.accounts.artist.address); // auth address for pmpInput2 is artist address, since artist called the function
+      // user2 configures token param3
+      const pmpInput3 = getPMPInput(
+        "param3",
+        PMP_PARAM_TYPE_ENUM.Uint256Range,
+        "0x0000000000000000000000000000000000000000000000000000000000000002",
+        false,
+        ""
+      );
+      const tx3 = await config.pmp
+        .connect(config.accounts.user2)
+        .configureTokenParams(
+          config.genArt721Core.address,
+          config.projectZeroTokenZero,
+          [pmpInput3]
+        );
+      const receipt3 = await tx3.wait();
+      const event3 = receipt3.events?.find(
+        (e) => e.event === "TokenParamsConfigured"
+      );
+      expect(event3?.args?.[3][0]).to.equal(config.accounts.user2.address); // auth address for pmpInput3 is user2, since user2 is address
+      // token owner delegates all permissions to deployer
+      await config.delegateRegistry
+        .connect(config.accounts.user)
+        .delegateAll(
+          config.accounts.deployer.address,
+          constants.HashZero,
+          true
+        );
+      // deployer configures token param 1
+      const pmpInput4 = getPMPInput(
+        "param1",
+        PMP_PARAM_TYPE_ENUM.Uint256Range,
+        "0x0000000000000000000000000000000000000000000000000000000000000002",
+        false,
+        ""
+      );
+      const tx4 = await config.pmp
+        .connect(config.accounts.deployer)
+        .configureTokenParams(
+          config.genArt721Core.address,
+          config.projectZeroTokenZero,
+          [pmpInput4]
+        );
+      const receipt4 = await tx4.wait();
+      const event4 = receipt4.events?.find(
+        (e) => e.event === "TokenParamsConfigured"
+      );
+      // auth address for event4 is user, not deployer, since deployer used user's auth only as a delegate
+      expect(event4?.args?.[3][0]).to.equal(config.accounts.user.address);
     });
   });
 });


### PR DESCRIPTION
## Description of the change

Add data to the event when a PMP is configured to indicate which authenticated address was used to perform the change.

This is important to provide provenance information about the change history of a token.

The changes here respect delegation - if a delegate executes a change on behalf of the token owner, the token owner's address will be indicated as the address that made the change, not the delegate.

## Gas Impacts

Gas tests indicate +1.8% gas to the 2x typical PMP gas test.

This is expected due to (first order) more event data being emitted, and (second order) a slightly less optimal order of typical auth checks.

## Test

Tests are updated to check for the new event data, including the case of a delegate making a change on behalf of a token owner.