### PR TITLE
Example hook for block height + artist pmp overrides

### DIFF
--- a/packages/contracts/contracts/web3call/augment-hooks/InjectBlockHeightAndArtistProjectOverrides.sol
+++ b/packages/contracts/contracts/web3call/augment-hooks/InjectBlockHeightAndArtistProjectOverrides.sol
@@ -13,14 +13,17 @@ import {Strings} from "@openzeppelin-5.0/contracts/utils/Strings.sol";
 import {EnumerableMap} from "@openzeppelin-5.0/contracts/utils/structs/EnumerableMap.sol";
 
 /**
- * @title InjectBlockHeightAndArtistProjectPaletteOverride
+ * @title InjectBlockHeightAndArtistProjectOverrides
  * @author Art Blocks Inc.
- * @notice This hook injects the current block height into a token's PMPs.
- * It also allows the artist to set and clear project overrides.
+ * @notice This hook appends the current block height and artist project overrides into a token's PMPs.
+ * If an input PMP has a key that matches an artist project override, the artist project override value will be used.
+ * If an override value is not in the input PMPs, it will be appended to the output, ensuring that the output always contains all override values.
+ * @dev This contract is developed open-source, is lightly tested, and should be used at your own risk.
+ * The artist can set and clear overrides for a project via the `artistSetProjectOverride` and `artistClearProjectOverride` functions.
+ * The artist can only set and clear overrides for their own projects.
+ * This contract is not owned, and intended to integrate with Art Blocks core contracts that conform to IGenArt721CoreContractV3_Base.
  */
-contract InjectBlockHeightAndArtistProjectPaletteOverride is
-    AbstractPMPAugmentHook
-{
+contract InjectBlockHeightAndArtistProjectOverrides is AbstractPMPAugmentHook {
     using Strings for uint256;
     using EnumerableMap for EnumerableMap.Bytes32ToBytes32Map;
 
@@ -137,7 +140,10 @@ contract InjectBlockHeightAndArtistProjectPaletteOverride is
 
     /**
      * @notice Augment the token parameters for a given token.
-     * Appends the block height into a tokens PMPs.
+     * Appends the block height into a tokens PMPs, and injects artist project overrides.
+     * If an input PMP has a key that matches an artist project override, the artist project override value will be used.
+     * If an input PMP has a key that does not match an artist project override, the input PMP will be unaffected in the output.
+     * All overrides are appended to the output, ensuring that the output always contains all override values.
      * @dev This hook is called when a token's PMPs are read.
      * @dev This must return all desired tokenParams, not just additional data.
      * @param tokenParams The token parameters for the queried token.

--- a/packages/contracts/contracts/web3call/augment-hooks/InjectBlockHeightAndArtistProjectOverrides.sol
+++ b/packages/contracts/contracts/web3call/augment-hooks/InjectBlockHeightAndArtistProjectOverrides.sol
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Created By: Art Blocks Inc.
+
+pragma solidity ^0.8.0;
+
+import {AbstractPMPAugmentHook} from "./AbstractPMPAugmentHook.sol";
+
+import {IWeb3Call} from "../../interfaces/v0.8.x/IWeb3Call.sol";
+import {IGenArt721CoreContractV3_Base} from "../../interfaces/v0.8.x/IGenArt721CoreContractV3_Base.sol";
+
+import {Strings} from "@openzeppelin-5.0/contracts/utils/Strings.sol";
+
+/**
+ * @title InjectBlockHeightAndArtistProjectPaletteOverride
+ * @author Art Blocks Inc.
+ * @notice This hook injects the current block height into a token's PMPs.
+ */
+contract InjectBlockHeightAndArtistProjectPaletteOverride is
+    AbstractPMPAugmentHook
+{
+    using Strings for uint256;
+
+    // mapping of project to artist pmp overrides - empty string indicates no override
+    mapping(address coreContract => mapping(uint256 projectId => mapping(string key => string value)))
+        public artistProjectOverrides;
+
+    /**
+     * @notice Set a palette override for a project.
+     * Only the artist of the project can set the palette override.
+     * @dev intentionally does not emit events - artist overrides are intended to be not indexed.
+     * @param coreContract The address of the core contract.
+     * @param projectId The ID of the project.
+     * @param palette The palette to set.
+     */
+    function artistSetProjectPaletteOverride(
+        address coreContract,
+        uint256 projectId,
+        string memory palette
+    ) external {
+        // CHECKS
+        _onlyArtist({
+            caller: msg.sender,
+            coreContract: coreContract,
+            projectId: projectId
+        });
+
+        // EFFECTS
+        artistProjectOverrides[coreContract][projectId]["Palette"] = palette;
+    }
+
+    /**
+     * @notice Clear a palette override for a project.
+     * Only the artist of the project can clear the palette override.
+     * @dev intentionally does not emit events - artist overrides are intended to be not indexed.
+     * @param coreContract The address of the core contract.
+     * @param projectId The ID of the project.
+     */
+    function artistClearProjectPaletteOverride(
+        address coreContract,
+        uint256 projectId
+    ) external {
+        // CHECKS
+        _onlyArtist({
+            caller: msg.sender,
+            coreContract: coreContract,
+            projectId: projectId
+        });
+
+        // EFFECTS
+        artistProjectOverrides[coreContract][projectId]["Palette"] = "";
+    }
+
+    /**
+     * @notice Augment the token parameters for a given token.
+     * Appends the block height into a tokens PMPs.
+     * @dev This hook is called when a token's PMPs are read.
+     * @dev This must return all desired tokenParams, not just additional data.
+     * @param tokenParams The token parameters for the queried token.
+     * @return augmentedTokenParams The augmented token parameters.
+     */
+    function onTokenPMPReadAugmentation(
+        address coreContract,
+        uint256 tokenId,
+        IWeb3Call.TokenParam[] calldata tokenParams
+    )
+        external
+        view
+        override
+        returns (IWeb3Call.TokenParam[] memory augmentedTokenParams)
+    {
+        // create a new tokenParam array with one extra element
+        uint256 originalLength = tokenParams.length;
+        uint256 newLength = originalLength + 1;
+        augmentedTokenParams = new IWeb3Call.TokenParam[](newLength);
+
+        // copy the original tokenParams into the new array
+        for (uint256 i = 0; i < originalLength; i++) {
+            string memory overrideValue = artistProjectOverrides[coreContract][
+                tokenId
+            ][tokenParams[i].key];
+
+            // if the artist has set a project-level override for this key, use that instead of the original
+            if (bytes(overrideValue).length > 0) {
+                // use the artist's override
+                augmentedTokenParams[i] = IWeb3Call.TokenParam({
+                    key: tokenParams[i].key,
+                    value: artistProjectOverrides[coreContract][tokenId][
+                        tokenParams[i].key
+                    ]
+                });
+            } else {
+                // use the original
+                augmentedTokenParams[i] = tokenParams[i];
+            }
+        }
+
+        // get + inject the block height into the new array
+        uint256 currentBlock = block.number;
+        augmentedTokenParams[originalLength] = IWeb3Call.TokenParam({
+            key: "blockHeight",
+            value: currentBlock.toString()
+        });
+
+        // return the augmented tokenParams
+        return augmentedTokenParams;
+    }
+
+    /**
+     * @notice Only the artist of the project can call the function.
+     * @dev reverts if the caller is not the artist of the project.
+     * @param caller The address of the caller.
+     * @param coreContract The address of the core contract.
+     * @param projectId The ID of the project.
+     */
+    function _onlyArtist(
+        address caller,
+        address coreContract,
+        uint256 projectId
+    ) internal view {
+        if (
+            caller !=
+            IGenArt721CoreContractV3_Base(coreContract)
+                .projectIdToArtistAddress(projectId)
+        ) {
+            revert("Only artist of project");
+        }
+    }
+}

--- a/packages/contracts/contracts/web3call/augment-hooks/InjectBlockHeightAndArtistProjectOverrides.sol
+++ b/packages/contracts/contracts/web3call/augment-hooks/InjectBlockHeightAndArtistProjectOverrides.sol
@@ -1,14 +1,16 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Created By: Art Blocks Inc.
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.22;
 
 import {AbstractPMPAugmentHook} from "./AbstractPMPAugmentHook.sol";
+import {ABHelpers} from "../../libs/v0.8.x/ABHelpers.sol";
 
 import {IWeb3Call} from "../../interfaces/v0.8.x/IWeb3Call.sol";
 import {IGenArt721CoreContractV3_Base} from "../../interfaces/v0.8.x/IGenArt721CoreContractV3_Base.sol";
 
 import {Strings} from "@openzeppelin-5.0/contracts/utils/Strings.sol";
+import {EnumerableMap} from "@openzeppelin-5.0/contracts/utils/structs/EnumerableMap.sol";
 
 /**
  * @title InjectBlockHeightAndArtistProjectPaletteOverride
@@ -19,23 +21,40 @@ contract InjectBlockHeightAndArtistProjectPaletteOverride is
     AbstractPMPAugmentHook
 {
     using Strings for uint256;
+    using EnumerableMap for EnumerableMap.Bytes32ToBytes32Map;
 
-    // mapping of project to artist pmp overrides - empty string indicates no override
-    mapping(address coreContract => mapping(uint256 projectId => mapping(string key => string value)))
-        public artistProjectOverrides;
+    event ArtistProjectOverrideSet(
+        address indexed coreContract,
+        uint256 indexed projectId,
+        string key,
+        string value
+    );
+
+    event ArtistProjectOverrideCleared(
+        address indexed coreContract,
+        uint256 indexed projectId,
+        string key
+    );
+
+    // enumerable mapping of project to artist pmp overrides
+    // @dev key/value pairs are stored as bytes32 values for gas efficiency and standard library compatibility
+    mapping(address coreContract => mapping(uint256 projectId => EnumerableMap.Bytes32ToBytes32Map enumerableOverrides))
+        private artistProjectOverrides;
 
     /**
-     * @notice Set a palette override for a project.
-     * Only the artist of the project can set the palette override.
+     * @notice Set a project override for a given key.
+     * Only the artist of the project can set the project override.
      * @dev intentionally does not emit events - artist overrides are intended to be not indexed.
      * @param coreContract The address of the core contract.
      * @param projectId The ID of the project.
-     * @param palette The palette to set.
+     * @param key The key to set.
+     * @param value The value to set.
      */
-    function artistSetProjectPaletteOverride(
+    function artistSetProjectOverride(
         address coreContract,
         uint256 projectId,
-        string memory palette
+        string memory key,
+        string memory value
     ) external {
         // CHECKS
         _onlyArtist({
@@ -45,19 +64,30 @@ contract InjectBlockHeightAndArtistProjectPaletteOverride is
         });
 
         // EFFECTS
-        artistProjectOverrides[coreContract][projectId]["Palette"] = palette;
+        EnumerableMap.Bytes32ToBytes32Map
+            storage overrides = artistProjectOverrides[coreContract][projectId];
+        overrides.set(_toBytes32(key), _toBytes32(value));
+
+        emit ArtistProjectOverrideSet({
+            coreContract: coreContract,
+            projectId: projectId,
+            key: key,
+            value: value
+        });
     }
 
     /**
-     * @notice Clear a palette override for a project.
-     * Only the artist of the project can clear the palette override.
+     * @notice Clear a project override for a given key.
+     * Only the artist of the project can clear the project override.
      * @dev intentionally does not emit events - artist overrides are intended to be not indexed.
      * @param coreContract The address of the core contract.
      * @param projectId The ID of the project.
+     * @param key The key to clear.
      */
-    function artistClearProjectPaletteOverride(
+    function artistClearProjectOverride(
         address coreContract,
-        uint256 projectId
+        uint256 projectId,
+        string memory key
     ) external {
         // CHECKS
         _onlyArtist({
@@ -67,7 +97,41 @@ contract InjectBlockHeightAndArtistProjectPaletteOverride is
         });
 
         // EFFECTS
-        artistProjectOverrides[coreContract][projectId]["Palette"] = "";
+        EnumerableMap.Bytes32ToBytes32Map
+            storage overrides = artistProjectOverrides[coreContract][projectId];
+        require(overrides.remove(_toBytes32(key)), "Key not found");
+
+        emit ArtistProjectOverrideCleared({
+            coreContract: coreContract,
+            projectId: projectId,
+            key: key
+        });
+    }
+
+    /**
+     * @notice Get the artist project overrides for a given project.
+     * @dev This function is used to get the artist project overrides for a given project.
+     * @param coreContract The address of the core contract.
+     * @param projectId The ID of the project.
+     * @return projectOverrides The artist project overrides for the given project.
+     */
+    function getArtistProjectOverrides(
+        address coreContract,
+        uint256 projectId
+    ) external view returns (IWeb3Call.TokenParam[] memory projectOverrides) {
+        EnumerableMap.Bytes32ToBytes32Map
+            storage overrides = artistProjectOverrides[coreContract][projectId];
+        uint256 overrideCount = overrides.length();
+        // translate enumerable map to expected output format
+        projectOverrides = new IWeb3Call.TokenParam[](overrideCount);
+        for (uint256 i = 0; i < overrideCount; i++) {
+            (bytes32 key, bytes32 value) = overrides.at(i);
+            projectOverrides[i] = IWeb3Call.TokenParam({
+                key: _fromBytes32(key),
+                value: _fromBytes32(value)
+            });
+        }
+        // @dev implicitly return the projectOverrides array
     }
 
     /**
@@ -88,38 +152,67 @@ contract InjectBlockHeightAndArtistProjectPaletteOverride is
         override
         returns (IWeb3Call.TokenParam[] memory augmentedTokenParams)
     {
-        // create a new tokenParam array with one extra element
+        // get artist project overrides
+        EnumerableMap.Bytes32ToBytes32Map
+            storage overrides = artistProjectOverrides[coreContract][
+                ABHelpers.tokenIdToProjectId({tokenId: tokenId}) // project id
+            ];
+        uint256 overrideCount = overrides.length();
+
+        // create a new augmentedTokenParams array with maximum length of
+        // input tokenParams + overrideCount + one extra element for BlockHeight
         uint256 originalLength = tokenParams.length;
-        uint256 newLength = originalLength + 1;
-        augmentedTokenParams = new IWeb3Call.TokenParam[](newLength);
+        uint256 augmentedMaxLength = originalLength + overrideCount + 1;
+        augmentedTokenParams = new IWeb3Call.TokenParam[](augmentedMaxLength);
 
         // copy the original tokenParams into the new array
         for (uint256 i = 0; i < originalLength; i++) {
-            string memory overrideValue = artistProjectOverrides[coreContract][
-                tokenId
-            ][tokenParams[i].key];
-
-            // if the artist has set a project-level override for this key, use that instead of the original
-            if (bytes(overrideValue).length > 0) {
-                // use the artist's override
-                augmentedTokenParams[i] = IWeb3Call.TokenParam({
-                    key: tokenParams[i].key,
-                    value: artistProjectOverrides[coreContract][tokenId][
-                        tokenParams[i].key
-                    ]
-                });
-            } else {
-                // use the original
-                augmentedTokenParams[i] = tokenParams[i];
-            }
+            augmentedTokenParams[i] = tokenParams[i];
         }
 
         // get + inject the block height into the new array
-        uint256 currentBlock = block.number;
-        augmentedTokenParams[originalLength] = IWeb3Call.TokenParam({
-            key: "blockHeight",
-            value: currentBlock.toString()
-        });
+        // @dev block scope to avoid stack too deep error
+        {
+            uint256 currentBlock = block.number;
+            augmentedTokenParams[originalLength] = IWeb3Call.TokenParam({
+                key: "blockHeight",
+                value: currentBlock.toString()
+            });
+        }
+
+        // get + inject the artist project overrides into the new array, overriding any existing param values
+        uint256 nextIndex = originalLength + 1;
+        // @dev O(i*n) where i is the number of overrides and n is the number of original tokenParams, okay on read function
+        for (uint256 i = 0; i < overrideCount; i++) {
+            (bytes32 key, bytes32 value) = overrides.at(i);
+            // check if the key exists in the original tokenParams, and if so, override the value with artist override
+            bool found = false;
+            for (uint256 j = 0; j < originalLength; j++) {
+                if (_equalsStringAndBytes32({s: tokenParams[j].key, b: key})) {
+                    augmentedTokenParams[j] = IWeb3Call.TokenParam({
+                        key: tokenParams[j].key, // @dev key is not changed
+                        value: _fromBytes32(value) // @dev value is overridden
+                    });
+                    found = true;
+                    break;
+                }
+            }
+            // if the key did not exist in the original tokenParams, append it to the augmentedTokenParams array
+            if (!found) {
+                augmentedTokenParams[nextIndex++] = IWeb3Call.TokenParam({
+                    key: _fromBytes32(key),
+                    value: _fromBytes32(value)
+                });
+            }
+        }
+
+        // shorten the augmentedTokenParams array to the new length (which is nextIndex)
+        // @dev use assembly to efficiently modify in place
+        if (nextIndex < augmentedMaxLength) {
+            assembly {
+                mstore(augmentedTokenParams, nextIndex)
+            }
+        }
 
         // return the augmented tokenParams
         return augmentedTokenParams;
@@ -144,5 +237,67 @@ contract InjectBlockHeightAndArtistProjectPaletteOverride is
         ) {
             revert("Only artist of project");
         }
+    }
+
+    /**
+     * @notice Convert a string to a bytes32 value.
+     * Reverts if the string is longer than 32 bytes.
+     * @dev This is a helper function to convert a string to a bytes32 value.
+     * @param str The string to convert.
+     * @return result The bytes32 value of the string.
+     */
+    function _toBytes32(
+        string memory str
+    ) internal pure returns (bytes32 result) {
+        bytes memory temp = bytes(str);
+        if (temp.length > 32) {
+            revert("String too long");
+        }
+        // copy the string directly to the bytes32 result, skipping the first 32 bytes (string length)
+        assembly {
+            result := mload(add(str, 32))
+        }
+    }
+
+    /**
+     * @notice Convert a bytes32-encoded string value to a string.
+     * @dev This is a helper function to convert a bytes32-encoded string value to a string.
+     * @param b The bytes32 value to convert.
+     * @return The string value of the bytes32 value.
+     */
+    function _fromBytes32(bytes32 b) internal pure returns (string memory) {
+        // determine the length of the string
+        uint256 len = 0;
+        for (; len < 32; ++len) {
+            if (b[len] == 0) break;
+        }
+        // create a new string with the length of the string
+        // @dev solidity reserves 32 bytes for length, rounds up to full word for data portion
+        string memory result = new string(len);
+        assembly {
+            let resultData := add(result, 0x20) // skip length prefix (already populated)
+            mstore(resultData, b) // store full 32 bytes (write-ahead optimization, okay due to solidity reserving 32 bytes for data)
+        }
+        return result;
+    }
+
+    /**
+     * @notice Compare a string and a bytes32 value, assuming the bytes32 is an encoded string.
+     * @dev This is a helper function to compare a string and a bytes32 value.
+     * @param s The string to compare.
+     * @param b The bytes32 value to compare.
+     * @return true if the string and bytes32 value are equal, false otherwise.
+     */
+    function _equalsStringAndBytes32(
+        string memory s,
+        bytes32 b
+    ) internal pure returns (bool) {
+        bytes memory strBytes = bytes(s);
+        if (strBytes.length > 32) return false;
+        bytes32 strBytes32;
+        assembly {
+            strBytes32 := mload(add(s, 32))
+        }
+        return strBytes32 == b;
     }
 }

--- a/packages/contracts/contracts/web3call/augment-hooks/InjectBlockHeightAndArtistProjectOverrides.sol
+++ b/packages/contracts/contracts/web3call/augment-hooks/InjectBlockHeightAndArtistProjectOverrides.sol
@@ -16,6 +16,7 @@ import {EnumerableMap} from "@openzeppelin-5.0/contracts/utils/structs/Enumerabl
  * @title InjectBlockHeightAndArtistProjectPaletteOverride
  * @author Art Blocks Inc.
  * @notice This hook injects the current block height into a token's PMPs.
+ * It also allows the artist to set and clear project overrides.
  */
 contract InjectBlockHeightAndArtistProjectPaletteOverride is
     AbstractPMPAugmentHook

--- a/packages/contracts/test/web3call/PMP/augment-hooks/inject-block-height-and-artist-project-overrides/InjectBlockHeightAndArtistProjectOverrides.test.ts
+++ b/packages/contracts/test/web3call/PMP/augment-hooks/inject-block-height-and-artist-project-overrides/InjectBlockHeightAndArtistProjectOverrides.test.ts
@@ -1,0 +1,392 @@
+import { expectRevert } from "@openzeppelin/test-helpers";
+import { expect } from "chai";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { ethers } from "hardhat";
+import { constants } from "ethers";
+import {
+  PMP_AUTH_ENUM,
+  PMP_PARAM_TYPE_ENUM,
+  getPMPInput,
+  getPMPInputConfig,
+  int256ToBytes32,
+  uint256ToBytes32,
+  BigNumberToBytes32,
+  PMP_TIMESTAMP_MAX,
+  PMP_HEX_COLOR_MAX,
+  RIGHTS_POST_MINT_PARAMETERS,
+  PMPInput,
+} from "../../pmpTestUtils";
+import { PMPFixtureConfig, setupPMPFixture } from "../../pmpFixtures";
+import { InjectBlockHeightAndArtistProjectOverrides__factory } from "../../../../../scripts/contracts/factories/contracts/web3call/augment-hooks/InjectBlockHeightAndArtistProjectOverrides.sol/InjectBlockHeightAndArtistProjectOverrides__factory";
+import { InjectBlockHeightAndArtistProjectOverrides } from "../../../../../scripts/contracts/contracts/web3call/augment-hooks/InjectBlockHeightAndArtistProjectOverrides.sol/InjectBlockHeightAndArtistProjectOverrides";
+import { revertMessages } from "./constants";
+import { advanceTimeAndBlock } from "../../../../util/common";
+import { Logger } from "@ethersproject/logger";
+// hide nuisance logs about event overloading
+Logger.setLogLevel(Logger.levels.ERROR);
+
+export interface PMPFixtureConfigWithPMPInput extends PMPFixtureConfig {
+  pmpInput: PMPInput;
+}
+
+interface T_ConfigWithHook extends PMPFixtureConfig {
+  hook: InjectBlockHeightAndArtistProjectOverrides;
+}
+
+/**
+ * Test suite for InjectBlockHeightAndArtistProjectOverrides
+ */
+describe("InjectBlockHeightAndArtistProjectOverrides", function () {
+  // Test fixture with projects, tokens, and PMP contract setup
+  async function _beforeEach() {
+    const config = await loadFixture(setupPMPFixture);
+    // deploy the hook
+    const hookFactory = new InjectBlockHeightAndArtistProjectOverrides__factory(
+      config.accounts.deployer
+    );
+    const hook = await hookFactory.deploy();
+    // configure the hook
+    await config.pmp.connect(config.accounts.artist).configureProjectHooks(
+      config.genArt721Core.address,
+      config.projectZero,
+      constants.AddressZero, // tokenPMPPostConfigHook
+      hook.address // tokenPMPReadAugmentationHook
+    );
+    // return the config with the typed hook
+    return {
+      ...config,
+      hook: hook,
+    } as T_ConfigWithHook;
+  }
+
+  describe("artistSetProjectOverride", function () {
+    it("reverts when non-artist calls", async function () {
+      const config = await loadFixture(_beforeEach);
+      // call from non-artist
+      await expectRevert(
+        config.hook
+          .connect(config.accounts.deployer)
+          .artistSetProjectOverride(
+            config.genArt721Core.address,
+            config.projectZero,
+            "testKey",
+            "testValue"
+          ),
+        revertMessages.onlyArtist
+      );
+    });
+
+    it("sets the project override for single key", async function () {
+      const config = await loadFixture(_beforeEach);
+      // call from artist
+      await config.hook
+        .connect(config.accounts.artist)
+        .artistSetProjectOverride(
+          config.genArt721Core.address,
+          config.projectZero,
+          "testKey",
+          "testValue"
+        );
+      // verify the override was set
+      const override = await config.hook.getArtistProjectOverrides(
+        config.genArt721Core.address,
+        config.projectZero
+      );
+      expect(override[0].key).to.equal("testKey");
+      expect(override[0].value).to.equal("testValue");
+    });
+
+    it("sets the project override for multiple keys", async function () {
+      const config = await loadFixture(_beforeEach);
+      // call from artist
+      await config.hook
+        .connect(config.accounts.artist)
+        .artistSetProjectOverride(
+          config.genArt721Core.address,
+          config.projectZero,
+          "testKey1",
+          "testValue1"
+        );
+      await config.hook
+        .connect(config.accounts.artist)
+        .artistSetProjectOverride(
+          config.genArt721Core.address,
+          config.projectZero,
+          "testKey2",
+          "testValue2"
+        );
+      // verify the overrides were set
+      const overrides = await config.hook.getArtistProjectOverrides(
+        config.genArt721Core.address,
+        config.projectZero
+      );
+      expect(overrides[0].key).to.equal("testKey1");
+      expect(overrides[0].value).to.equal("testValue1");
+      expect(overrides[1].key).to.equal("testKey2");
+      expect(overrides[1].value).to.equal("testValue2");
+    });
+
+    it("reverts when key is too long", async function () {
+      const config = await loadFixture(_beforeEach);
+      // call from artist
+      await expectRevert(
+        config.hook
+          .connect(config.accounts.artist)
+          .artistSetProjectOverride(
+            config.genArt721Core.address,
+            config.projectZero,
+            "testKey".repeat(100),
+            "testValue"
+          ),
+        revertMessages.stringTooLong
+      );
+    });
+
+    it("reverts when value is too long", async function () {
+      const config = await loadFixture(_beforeEach);
+      // call from artist
+      await expectRevert(
+        config.hook
+          .connect(config.accounts.artist)
+          .artistSetProjectOverride(
+            config.genArt721Core.address,
+            config.projectZero,
+            "testKey",
+            "testValue".repeat(100)
+          ),
+        revertMessages.stringTooLong
+      );
+    });
+  });
+
+  describe("artistClearProjectOverride", function () {
+    it("reverts when non-artist calls", async function () {
+      const config = await loadFixture(_beforeEach);
+      // call from non-artist
+      await expectRevert(
+        config.hook
+          .connect(config.accounts.deployer)
+          .artistClearProjectOverride(
+            config.genArt721Core.address,
+            config.projectZero,
+            "testKey"
+          ),
+        revertMessages.onlyArtist
+      );
+    });
+
+    it("reverts when key does not exist", async function () {
+      const config = await loadFixture(_beforeEach);
+      // call from artist
+      await expectRevert(
+        config.hook
+          .connect(config.accounts.artist)
+          .artistClearProjectOverride(
+            config.genArt721Core.address,
+            config.projectZero,
+            "testKey"
+          ),
+        revertMessages.keyNotFound
+      );
+    });
+
+    it("clears the project override for a single key", async function () {
+      const config = await loadFixture(_beforeEach);
+      // call from artist
+      await config.hook
+        .connect(config.accounts.artist)
+        .artistSetProjectOverride(
+          config.genArt721Core.address,
+          config.projectZero,
+          "testKey",
+          "testValue"
+        );
+      // call from artist to clear the override
+      await config.hook
+        .connect(config.accounts.artist)
+        .artistClearProjectOverride(
+          config.genArt721Core.address,
+          config.projectZero,
+          "testKey"
+        );
+      // verify the override was cleared
+      const overrides = await config.hook.getArtistProjectOverrides(
+        config.genArt721Core.address,
+        config.projectZero
+      );
+      expect(overrides.length).to.equal(0);
+    });
+
+    it("clears project overrides for multiple keys", async function () {
+      const config = await loadFixture(_beforeEach);
+      // call from artist
+      await config.hook
+        .connect(config.accounts.artist)
+        .artistSetProjectOverride(
+          config.genArt721Core.address,
+          config.projectZero,
+          "testKey1",
+          "testValue1"
+        );
+      await config.hook
+        .connect(config.accounts.artist)
+        .artistSetProjectOverride(
+          config.genArt721Core.address,
+          config.projectZero,
+          "testKey2",
+          "testValue2"
+        );
+      // call from artist to clear the overrides
+      await config.hook
+        .connect(config.accounts.artist)
+        .artistClearProjectOverride(
+          config.genArt721Core.address,
+          config.projectZero,
+          "testKey1"
+        );
+      // verify the overrides were cleared
+      const overrides = await config.hook.getArtistProjectOverrides(
+        config.genArt721Core.address,
+        config.projectZero
+      );
+      expect(overrides.length).to.equal(1);
+      expect(overrides[0].key).to.equal("testKey2");
+      expect(overrides[0].value).to.equal("testValue2");
+    });
+
+    it("reverts when key is too long", async function () {
+      const config = await loadFixture(_beforeEach);
+      // call from artist
+      await expectRevert(
+        config.hook
+          .connect(config.accounts.artist)
+          .artistClearProjectOverride(
+            config.genArt721Core.address,
+            config.projectZero,
+            "testKey".repeat(100)
+          ),
+        revertMessages.stringTooLong
+      );
+    });
+  });
+
+  describe("onTokenPMPReadAugmentation", function () {
+    it("appends only block height when no overrides exist", async function () {
+      const config = await loadFixture(_beforeEach);
+      // record block number of the read call
+      const blockNumber = await ethers.provider.getBlockNumber();
+      const augmentedTokenParams = await config.hook.onTokenPMPReadAugmentation(
+        config.genArt721Core.address,
+        config.projectZero,
+        [
+          { key: "testKey1", value: "testValue1" },
+          { key: "testKey2", value: "testValue2" },
+        ]
+      );
+      expect(augmentedTokenParams.length).to.equal(3);
+      expect(augmentedTokenParams[0].key).to.equal("testKey1");
+      expect(augmentedTokenParams[0].value).to.equal("testValue1");
+      expect(augmentedTokenParams[1].key).to.equal("testKey2");
+      expect(augmentedTokenParams[1].value).to.equal("testValue2");
+      expect(augmentedTokenParams[2].key).to.equal("blockHeight");
+      expect(augmentedTokenParams[2].value).to.equal(blockNumber.toString());
+    });
+
+    it("appends block height and overrides when overrides exist (non-conflicting keys)", async function () {
+      const config = await loadFixture(_beforeEach);
+      // call from artist
+      await config.hook
+        .connect(config.accounts.artist)
+        .artistSetProjectOverride(
+          config.genArt721Core.address,
+          config.projectZero,
+          "testKey",
+          "testValue"
+        );
+      // record block number of the read call
+      const blockNumber = await ethers.provider.getBlockNumber();
+      const augmentedTokenParams = await config.hook.onTokenPMPReadAugmentation(
+        config.genArt721Core.address,
+        config.projectZero,
+        [
+          { key: "testKey1", value: "testValue1" },
+          { key: "testKey2", value: "testValue2" },
+        ]
+      );
+      expect(augmentedTokenParams.length).to.equal(4);
+      expect(augmentedTokenParams[0].key).to.equal("testKey1");
+      expect(augmentedTokenParams[0].value).to.equal("testValue1");
+      expect(augmentedTokenParams[1].key).to.equal("testKey2");
+      expect(augmentedTokenParams[1].value).to.equal("testValue2");
+      expect(augmentedTokenParams[2].key).to.equal("blockHeight");
+      expect(augmentedTokenParams[2].value).to.equal(blockNumber.toString());
+      expect(augmentedTokenParams[3].key).to.equal("testKey");
+      expect(augmentedTokenParams[3].value).to.equal("testValue");
+    });
+
+    it("replaces conflicting override values with new values", async function () {
+      const config = await loadFixture(_beforeEach);
+      // call from artist
+      await config.hook
+        .connect(config.accounts.artist)
+        .artistSetProjectOverride(
+          config.genArt721Core.address,
+          config.projectZero,
+          "testKey",
+          "testValueOverride"
+        );
+      // record block number of the read call
+      const blockNumber = await ethers.provider.getBlockNumber();
+      const augmentedTokenParams = await config.hook.onTokenPMPReadAugmentation(
+        config.genArt721Core.address,
+        config.projectZero,
+        [{ key: "testKey", value: "testValue" }]
+      );
+      expect(augmentedTokenParams.length).to.equal(2);
+      expect(augmentedTokenParams[0].key).to.equal("testKey");
+      expect(augmentedTokenParams[0].value).to.equal("testValueOverride");
+      expect(augmentedTokenParams[1].key).to.equal("blockHeight");
+      expect(augmentedTokenParams[1].value).to.equal(blockNumber.toString());
+    });
+
+    it("replaces conflicting override values with new values (multiple overrides)", async function () {
+      const config = await loadFixture(_beforeEach);
+      // call from artist
+      await config.hook
+        .connect(config.accounts.artist)
+        .artistSetProjectOverride(
+          config.genArt721Core.address,
+          config.projectZero,
+          "testKey",
+          "testValueOverride"
+        );
+      await config.hook
+        .connect(config.accounts.artist)
+        .artistSetProjectOverride(
+          config.genArt721Core.address,
+          config.projectZero,
+          "testKey2",
+          "testValue2Override"
+        );
+      // record block number of the read call
+      const blockNumber = await ethers.provider.getBlockNumber();
+      const augmentedTokenParams = await config.hook.onTokenPMPReadAugmentation(
+        config.genArt721Core.address,
+        config.projectZero,
+        [
+          { key: "testKey", value: "testValue" },
+          { key: "testNonDuplicateKey", value: "testNonDuplicateValue" },
+        ]
+      );
+      expect(augmentedTokenParams.length).to.equal(4);
+      expect(augmentedTokenParams[0].key).to.equal("testKey");
+      expect(augmentedTokenParams[0].value).to.equal("testValueOverride");
+      expect(augmentedTokenParams[1].key).to.equal("testNonDuplicateKey");
+      expect(augmentedTokenParams[1].value).to.equal("testNonDuplicateValue");
+      expect(augmentedTokenParams[2].key).to.equal("blockHeight");
+      expect(augmentedTokenParams[2].value).to.equal(blockNumber.toString());
+      expect(augmentedTokenParams[3].key).to.equal("testKey2");
+      expect(augmentedTokenParams[3].value).to.equal("testValue2Override");
+    });
+  });
+});

--- a/packages/contracts/test/web3call/PMP/augment-hooks/inject-block-height-and-artist-project-overrides/constants.ts
+++ b/packages/contracts/test/web3call/PMP/augment-hooks/inject-block-height-and-artist-project-overrides/constants.ts
@@ -1,0 +1,6 @@
+// expected revert messages
+export const revertMessages = {
+  onlyArtist: "Only artist of project",
+  stringTooLong: "String too long",
+  keyNotFound: "Key not found",
+};


### PR DESCRIPTION
## Description of the change

Add example hook for injecting block height and artist project overrides.

The overrides:
* overwrite any existing pmp values
* get written as new pmp values if their key was not included in the hook input

TODO

- [x] tests
