### PR TITLE
Emit standard ISeaDrop MaxSupplyUpdated event

### DIFF
--- a/packages/contracts/contracts/interfaces/v0.8.x/ISeaDropShimForContract.sol
+++ b/packages/contracts/contracts/interfaces/v0.8.x/ISeaDropShimForContract.sol
@@ -10,10 +10,4 @@ interface ISeaDropShimForContract {
      * @param nftContract The address of the NFT contract that this shim contract is compatible with
      */
     event SeaDropShimForContract(address nftContract);
-
-    /**
-     * @dev Emit event when the local max supply is updated
-     * @param newLocalMaxSupply The new local max supply
-     */
-    event LocalMaxSupplyUpdated(uint256 newLocalMaxSupply);
 }

--- a/packages/contracts/contracts/minter-suite/Minters/one-off/SeaDropXArtBlocksShim.sol
+++ b/packages/contracts/contracts/minter-suite/Minters/one-off/SeaDropXArtBlocksShim.sol
@@ -459,7 +459,7 @@ contract SeaDropXArtBlocksShim is
         // EFFECTS
         // set the local max supply
         localMaxSupply = newMaxSupply;
-        emit LocalMaxSupplyUpdated(newMaxSupply);
+        emit MaxSupplyUpdated(newMaxSupply);
     }
 
     /**

--- a/packages/contracts/test/minters-one-off/sea-drop-shim/events.test.ts
+++ b/packages/contracts/test/minters-one-off/sea-drop-shim/events.test.ts
@@ -124,14 +124,14 @@ runForEach.forEach((params) => {
       });
     });
 
-    describe("LocalMaxSupplyUpdated", async function () {
-      it("emits LocalMaxSupplyUpdated when local max supply is updated", async function () {
+    describe("MaxSupplyUpdated", async function () {
+      it("emits MaxSupplyUpdated when local max supply is updated", async function () {
         const config = await _beforeEach();
         const newSupply = 10;
         await expect(
           config.minter.connect(config.accounts.artist).setMaxSupply(newSupply)
         )
-          .to.emit(config.minter, "LocalMaxSupplyUpdated")
+          .to.emit(config.minter, "MaxSupplyUpdated")
           .withArgs(newSupply);
       });
     });


### PR DESCRIPTION
## Description of the change

Fix event bug to emit standard ISeaDrop MaxSupplyUpdated event on shim contract.

Resolves a bug introduced in the following commit where a custom "LocalMaxSupplyUpdated" event was emitted. This non-standard event was not caught in prior OS1 e2e testing, likely due to something ~OS1 may not entirely rely on the event for indexing. OS2 does fully rely on the event, so this non-standard event was observed during OS2 e2e testing of the shim integration.

previous commit: https://github.com/ArtBlocks/artblocks-contracts/pull/1637/commits/c12b981eff4b77a5d77b0b37c6d2231f4b672bc1
