### PR TITLE
New curated flex core contract

### DIFF
--- a/packages/contracts/contracts/GenArt721CoreV3_Curated_Flex.sol
+++ b/packages/contracts/contracts/GenArt721CoreV3_Curated_Flex.sol
@@ -9,7 +9,7 @@ import {EngineConfiguration} from "./interfaces/v0.8.x/IGenArt721CoreContractV3_
 import "./libs/v0.8.x/Bytes32Strings.sol";
 
 /**
- * @title Art Blocks Curated ERC-721 core contract, V3.2 Flex
+ * @title Art Blocks Curated ERC-721 core contract, V3.2 Flex (ONCHAIN only)
  * @author Art Blocks Inc.
  * @notice This contract derives from the Art Blocks Engine Flex contract and adds
  * some functionality to support curation of projects by Art Blocks.

--- a/packages/contracts/contracts/GenArt721CoreV3_Curated_Flex.sol
+++ b/packages/contracts/contracts/GenArt721CoreV3_Curated_Flex.sol
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity 0.8.22;
+
+// Created By: Art Blocks Inc.
+
+import {GenArt721CoreV3_Engine_Flex} from "./engine/V3/GenArt721CoreV3_Engine_Flex.sol";
+import {EngineConfiguration} from "./interfaces/v0.8.x/IGenArt721CoreContractV3_Engine.sol";
+
+import "./libs/v0.8.x/Bytes32Strings.sol";
+
+/**
+ * @title Art Blocks Curated ERC-721 core contract, V3.2 Flex
+ * @author Art Blocks Inc.
+ * @notice This contract derives from the Art Blocks Engine Flex contract and adds
+ * some functionality to support curation of projects by Art Blocks.
+ * It also performs initialization of the contract in the constructor, because
+ * the contract is not intended to use a clone proxy pattern, and is intended
+ * to be deployed without any required follow-on calls to initialize.
+ * Constraints are added to the contract to only allow ONCHAIN dependencies,
+ * ensuring that the Art Blocks Curated projects are only dependent on onchain
+ * data, consistent with previous Art Blocks Curated contracts.
+ * ----------------------------------------------------------------------------
+ * See the Art Blocks Engine Flex contract for additional applicable documentation.
+ */
+contract GenArt721CoreV3_Curated_Flex is GenArt721CoreV3_Engine_Flex {
+    using Bytes32Strings for bytes32;
+
+    /// override patch version of this core contract
+    // @dev this is a constant value that is used to override the inherited core version CORE_VERSION
+    bytes32 private constant _CORE_VERSION_OVERRIDE = "v3.2.7";
+
+    // @dev overridden core version is returned instead of the inherited core version
+    function coreVersion() external pure override returns (string memory) {
+        return _CORE_VERSION_OVERRIDE.toString();
+    }
+
+    /// metadata pointer to the previous associated Flagship Artblocks core contracts
+    // @dev not defined as constant because constant address arrays are not yet implemented in Solidity
+    address[] public PREVIOUS_ART_BLOCKS_CONTRACTS = [
+        0x059EDD72Cd353dF5106D2B9cC5ab83a52287aC3a,
+        0xa7d8d9ef8D8Ce8992Df33D8b8CF4Aebabd5bD270,
+        0x99a9B7c1116f9ceEB1652de04d5969CcE509B069,
+        0xAB0000000000aa06f89B268D604a9c1C41524Ac6
+    ];
+
+    /// Curation registry for Flagship projects, managed by Art Blocks
+    address public artblocksCurationRegistryAddress;
+
+    bool public constant IS_FLAGSHIP = true;
+
+    /**
+     * @notice Construct a new curated Art Blocks ERC-721 core contract.
+     * Performs all contract initialization in the constructor.
+     * @param engineConfiguration Configuration for the engine contract.
+     * note: parameter `engineConfiguration.newSuperAdminAddress` is not used or operated on in this contract.
+     * @param adminACLContract_ Address of the admin ACL contract.
+     * @param defaultBaseURIHost Default base URI host for token URIs, e.g. "https://token.artblocks.io/" for mainnet
+     * @param bytecodeStorageReaderContract_ Address of the bytecode storage reader contract to be used by this
+     * contract.
+     */
+    constructor(
+        EngineConfiguration memory engineConfiguration,
+        address adminACLContract_,
+        string memory defaultBaseURIHost,
+        address bytecodeStorageReaderContract_
+    ) GenArt721CoreV3_Engine_Flex() {
+        // input validation generally performed by the engine factory
+        _onlyNonZeroAddress(engineConfiguration.renderProviderAddress);
+        _onlyNonZeroAddress(engineConfiguration.randomizerContract);
+        _onlyNonZeroAddress(adminACLContract_);
+        _onlyNonZeroAddress(bytecodeStorageReaderContract_);
+        require(
+            bytes(defaultBaseURIHost).length > 0,
+            "GenArt721CoreV3_Curated_Flex: defaultBaseURIHost must be non-empty"
+        );
+
+        // input validation specific to the curated contract
+        require(
+            !engineConfiguration.autoApproveArtistSplitProposals,
+            "GenArt721CoreV3_Curated_Flex: autoApproveArtistSplitProposals must be false"
+        );
+        // @dev artblocks is listed as render provider, no party should be platform provider
+        require(
+            engineConfiguration.nullPlatformProvider,
+            "GenArt721CoreV3_Curated_Flex: nullPlatformProvider must be true"
+        );
+        require(
+            !engineConfiguration.allowArtistProjectActivation,
+            "GenArt721CoreV3_Curated_Flex: allowArtistProjectActivation must be false"
+        );
+        // @dev previous artblocks contracts exists, so only starting project ID > 0
+        require(
+            engineConfiguration.startingProjectId > 0,
+            "GenArt721CoreV3_Curated_Flex: startingProjectId must be greater than 0"
+        );
+
+        // initialize the contract
+        _initialize({
+            engineConfiguration: engineConfiguration,
+            adminACLContract_: adminACLContract_,
+            defaultBaseURIHost: defaultBaseURIHost,
+            bytecodeStorageReaderContract_: bytecodeStorageReaderContract_
+        });
+
+        // override default base URI to be curated format instead of Engine (no address required for curated)
+        _updateDefaultBaseURI(defaultBaseURIHost);
+    }
+
+    /**
+     * @notice Override of the Engine contract's initialize function.
+     * Immediately reverts, as initialization of this Curated contract is performed in the constructor.
+     */
+    function initialize(
+        EngineConfiguration memory /*engineConfiguration*/,
+        address /*adminACLContract_*/,
+        string memory /*defaultBaseURIHost*/,
+        address /*bytecodeStorageReaderContract_*/
+    ) external pure override {
+        // revert - initialization for this contract is performed in the constructor
+        // @dev note that the initialize function would revert without this override, but it is included for clarity
+        revert(
+            "GenArt721CoreV3_Curated_Flex: contract initialized in constructor"
+        );
+    }
+
+    /**
+     * @notice Updates reference to Art Blocks Curation Registry contract.
+     * @param _artblocksCurationRegistryAddress Address of Art Blocks Curation Registry contract.
+     */
+    function updateArtblocksCurationRegistryAddress(
+        address _artblocksCurationRegistryAddress
+    ) external {
+        _onlyAdminACL(this.updateArtblocksCurationRegistryAddress.selector);
+        artblocksCurationRegistryAddress = _artblocksCurationRegistryAddress;
+        emit ArtBlocksCurationRegistryContractUpdated(
+            _artblocksCurationRegistryAddress
+        );
+    }
+
+    function updateProjectExternalAssetDependency(
+        uint256 _projectId,
+        uint256 _index,
+        string memory _cidOrData,
+        ExternalAssetDependencyType _dependencyType
+    ) public override {
+        require(
+            _dependencyType == ExternalAssetDependencyType.ONCHAIN,
+            "GenArt721CoreV3_Curated_Flex: Curated dependency type must be ONCHAIN"
+        );
+        super.updateProjectExternalAssetDependency({
+            _projectId: _projectId,
+            _index: _index,
+            _cidOrData: _cidOrData,
+            _dependencyType: _dependencyType
+        });
+    }
+
+    function addProjectExternalAssetDependency(
+        uint256 _projectId,
+        string memory _cidOrData,
+        ExternalAssetDependencyType _dependencyType
+    ) public override {
+        require(
+            _dependencyType == ExternalAssetDependencyType.ONCHAIN,
+            "GenArt721CoreV3_Curated_Flex: Curated dependency type must be ONCHAIN"
+        );
+        super.addProjectExternalAssetDependency({
+            _projectId: _projectId,
+            _cidOrData: _cidOrData,
+            _dependencyType: _dependencyType
+        });
+    }
+}

--- a/packages/contracts/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
+++ b/packages/contracts/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
@@ -466,6 +466,7 @@ contract GenArt721CoreV3_Engine_Flex is
 
     /**
      * @notice Updates external asset dependency for project `_projectId`.
+     * @dev public virtual to allow for derived contracts to override this function
      * @param _projectId Project to be updated.
      * @param _index Asset index.
      * @param _cidOrData Field that contains the CID of the dependency if IPFS or ARWEAVE,
@@ -482,7 +483,7 @@ contract GenArt721CoreV3_Engine_Flex is
         uint256 _index,
         string memory _cidOrData,
         ExternalAssetDependencyType _dependencyType
-    ) external {
+    ) public virtual {
         _onlyArtistOrAdminACL(
             _projectId,
             this.updateProjectExternalAssetDependency.selector
@@ -571,6 +572,7 @@ contract GenArt721CoreV3_Engine_Flex is
 
     /**
      * @notice Adds external asset dependency for project `_projectId`.
+     * @dev public virtual to allow for derived contracts to override this function
      * @param _projectId Project to be updated.
      * @param _cidOrData Field that contains the CID of the dependency if IPFS or ARWEAVE,
      * empty string of ONCHAIN, or a string representation of the Art Blocks Dependency
@@ -585,7 +587,7 @@ contract GenArt721CoreV3_Engine_Flex is
         uint256 _projectId,
         string memory _cidOrData,
         ExternalAssetDependencyType _dependencyType
-    ) external {
+    ) public virtual {
         _onlyArtistOrAdminACL(
             _projectId,
             this.addProjectExternalAssetDependency.selector

--- a/packages/contracts/deployments/flagship/V3/mainnet/GenArt721CoreV3_Curated_Flex/GenArt721CoreV3_Curated_Flex.md
+++ b/packages/contracts/deployments/flagship/V3/mainnet/GenArt721CoreV3_Curated_Flex/GenArt721CoreV3_Curated_Flex.md
@@ -1,0 +1,94 @@
+# Deployments: GenArt721CoreV3_Curated_Flex
+
+## Description
+
+The owned create2 factory was used to deploy a new GenArt721CoreV3_Curated_Flex contract.
+
+This was for the mainnet environment.
+
+The following were the inputs used to get initcode for deployment, via `scripts/get-init-code.ts`:
+
+> Note: `newSuperAdminAddress` input param is not used in curated core contract
+
+```typescript
+const engineConfiguration = {
+  tokenName: "Art Blocks", // TODO - may want to update this to be unique...
+  tokenSymbol: "BLOCKS",
+  renderProviderAddress: "0x21A89ef8c577ebaCfe8198644222B49DFD9284F9", // for primary sales - after deployment, update secondary sales address
+  platformProviderAddress: "0x0000000000000000000000000000000000000000",
+  // @dev newSuperAdminAddress input param is not used in curated core contract
+  newSuperAdminAddress: "0x0000000000000000000000000000000000000000",
+  randomizerContract: "0x13178A7a8A1A9460dBE39f7eCcEbD91B31752b91",
+  splitProviderAddress: "0x00000000CE5EEBAB4B5C2d6Cc5E73eaafA634DB3",
+  minterFilterAddress: "0xa2ccfE293bc2CDD78D8166a82D1e18cD2148122b",
+  startingProjectId: 505,
+  autoApproveArtistSplitProposals: false,
+  nullPlatformProvider: true,
+  allowArtistProjectActivation: false,
+};
+const adminACLContractAddress = "0x000000abB7A99780820c87c850Af7fD1Bc5e6788";
+const defaultBaseURIHost = "https://token.artblocks.io/";
+const bytecodeStorageReaderContract =
+  "0x000000000000A791ABed33872C44a3D215a3743B";
+
+const inputs: T_Inputs = {
+  contractName: "GenArt721CoreV3_Curated",
+  args: [
+    engineConfiguration,
+    adminACLContractAddress,
+    defaultBaseURIHost,
+    bytecodeStorageReaderContract,
+  ],
+  libraries: {
+    "contracts/libs/v0.8.x/BytecodeStorageV2.sol:BytecodeStorageReader":
+      "0x000000000016A5A5ff2FA7799C4BEe89bA59B74e",
+    "contracts/libs/v0.8.x/V3FlexLib.sol:V3FlexLib":
+      "0x00000000Db6f2EBe627260e411E6c973B7c48A62",
+  },
+};
+```
+
+## Results:
+
+Deploys to address: `0xAB000TBD`
+
+### Deployment transactions:
+
+- TBD
+
+## Follow-on transactions:
+
+I. Add `GenArt721CoreV3_Curated` to `CoreRegistry` through `EngineFactory` call to `registerMultipleContracts`:
+
+> Note: Must be queued via gnosis safe tx builder and executed by multisig
+
+args:
+
+- `0xAB000TBD` // core address
+- `0x76332e322e370000000000000000000000000000000000000000000000000000` // core version = "v3.2.7"
+- `0x47656e417274373231436f726556335f456e67696e655f466c657800000000` // core type = "GenArt721CoreV3_Engine_Flex"
+
+Registration tx:
+
+- TBD
+
+II. Re-Call `updateMinterContract` on `GenArt721CoreV3_Curated` to set `MinterFilter` contract:
+
+> Note: This fixes an indexing quirk associated with not approving the core in same block as deployment. It does not alter on-chain state.
+
+- TBD
+
+III. Follow-on configuring:
+
+- update dependency registry
+- set render provider primary and secondary sales addresses (secondary sales address is different than primary sales address)
+- update render provider primary sales percentage
+
+- TBD
+
+## Off-chain steps:
+
+- hasura metadata update to contracts_metadata:
+  - `bucket_name` = `artblocks-mainnet` // TODO - we may need to update this to `artblocks-flex-onchain-mainnet`
+  - `name` = "artblocks" // TODO - we may need to update this to `artblocks-flex-onchain`
+  - `default_vertical_name` = "curated"

--- a/packages/contracts/deployments/flagship/V3/mainnet/GenArt721CoreV3_Curated_Flex/GenArt721CoreV3_Curated_Flex.md
+++ b/packages/contracts/deployments/flagship/V3/mainnet/GenArt721CoreV3_Curated_Flex/GenArt721CoreV3_Curated_Flex.md
@@ -12,7 +12,7 @@ The following were the inputs used to get initcode for deployment, via `scripts/
 
 ```typescript
 const engineConfiguration = {
-  tokenName: "Art Blocks", // TODO - may want to update this to be unique...
+  tokenName: "Art Blocks",
   tokenSymbol: "BLOCKS",
   renderProviderAddress: "0x21A89ef8c577ebaCfe8198644222B49DFD9284F9", // for primary sales - after deployment, update secondary sales address
   platformProviderAddress: "0x0000000000000000000000000000000000000000",
@@ -89,6 +89,6 @@ III. Follow-on configuring:
 ## Off-chain steps:
 
 - hasura metadata update to contracts_metadata:
-  - `bucket_name` = `artblocks-mainnet` // TODO - we may need to update this to `artblocks-flex-onchain-mainnet`
-  - `name` = "artblocks" // TODO - we may need to update this to `artblocks-flex-onchain`
+  - `bucket_name` = `artblocks-mainnet` // use same bucket as previous curated core contract
+  - `name` = "artblocks-curated-flex-onchain" // use different name from previous curated core contract due to db constraint
   - `default_vertical_name` = "curated"

--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -173,6 +173,7 @@ module.exports = {
     disambiguatePaths: false,
     only: [
       "GenArt721CoreV3_Curated$",
+      "GenArt721CoreV3_Curated_Flex$",
       "GenArt721CoreV3_Engine$",
       "GenArt721CoreV3_Engine_Flex$",
       "MinterRAM.*",

--- a/packages/contracts/test/core/V3/GenArt721CoreV3_Curated_Flex/configure.test.ts
+++ b/packages/contracts/test/core/V3/GenArt721CoreV3_Curated_Flex/configure.test.ts
@@ -1,0 +1,711 @@
+import { constants } from "@openzeppelin/test-helpers";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import {
+  AdminACLV0,
+  GenArt721CoreV3_Curated_Flex,
+  MinterFilterV2,
+  SharedRandomizerV0,
+  UniversalBytecodeStorageReader,
+} from "../../../../scripts/contracts";
+import { GenArt721CoreV3_Curated_Flex__factory } from "../../../../scripts/contracts/factories/contracts/GenArt721CoreV3_Curated_Flex.sol";
+import {
+  GENART721_ERROR_NAME,
+  GENART721_ERROR_CODES,
+} from "../../../util/common";
+import { DEFAULT_BASE_URI } from "../../../util/constants";
+
+import {
+  T_Config,
+  getAccounts,
+  assignDefaultConstants,
+  deployCoreWithMinterFilter,
+} from "../../../util/common";
+
+interface T_CuratedTestConfig extends T_Config {
+  genArt721Core: GenArt721CoreV3_Curated_Flex;
+  adminACL: AdminACLV0;
+  minterFilter: MinterFilterV2;
+  randomizer: SharedRandomizerV0;
+  universalReader: UniversalBytecodeStorageReader;
+}
+
+// test the following V3 core contract derivatives:
+const coreContractsToTest = [
+  "GenArt721CoreV3_Curated_Flex", // V3.2 core Curated Flex contract
+];
+
+const ExternalAssetDependencyType = {
+  IPFS: 0,
+  ARWEAVE: 1,
+  ONCHAIN: 2,
+  ART_BLOCKS_DEPENDENCY_REGISTRY: 3,
+};
+
+/**
+ * Tests for V3 core dealing with configuring the core contract.
+ */
+for (const coreContractName of coreContractsToTest) {
+  describe(`${coreContractName} Contract Configure`, async function () {
+    async function _beforeEach() {
+      let config: T_Config = {
+        accounts: await getAccounts(),
+      };
+      config = await assignDefaultConstants(config);
+
+      // deploy and configure minter filter and minter
+      ({
+        genArt721Core: config.genArt721Core,
+        minterFilter: config.minterFilter,
+        randomizer: config.randomizer,
+        adminACL: config.adminACL,
+      } = await deployCoreWithMinterFilter(
+        config,
+        coreContractName,
+        "MinterFilterV2"
+      ));
+      return config as T_CuratedTestConfig;
+    }
+
+    describe("constructor", async function () {
+      it("reverts when render provider address is zero", async function () {
+        const config = await loadFixture(_beforeEach);
+        const bytecodeStorageLibFactory = await ethers.getContractFactory(
+          "contracts/libs/v0.8.x/BytecodeStorageV2.sol:BytecodeStorageReader"
+        );
+        const library = await bytecodeStorageLibFactory
+          .connect(config.accounts.deployer)
+          .deploy(/* no args for library ever */);
+        const v3flexlibFactory = await ethers.getContractFactory(
+          "contracts/libs/v0.8.x/V3FlexLib.sol:V3FlexLib"
+        );
+        const v3flexlib = await v3flexlibFactory
+          .connect(config.accounts.deployer)
+          .deploy(/* no args for library ever */);
+        const curatedFactory = new GenArt721CoreV3_Curated_Flex__factory(
+          {
+            "contracts/libs/v0.8.x/BytecodeStorageV2.sol:BytecodeStorageReader":
+              library.address,
+            "contracts/libs/v0.8.x/V3FlexLib.sol:V3FlexLib": v3flexlib.address,
+          },
+          config.accounts.deployer
+        );
+        const invalidCuratedConfiguration = {
+          tokenName: config.name,
+          tokenSymbol: config.symbol,
+          renderProviderAddress: constants.ZERO_ADDRESS, // INVALID ZERO ADDRESS
+          platformProviderAddress: constants.ZERO_ADDRESS,
+          newSuperAdminAddress: constants.ZERO_ADDRESS,
+          minterFilterAddress: config.minterFilter.address,
+          randomizerContract: config.randomizer?.address,
+          splitProviderAddress: config.splitProvider.address,
+          startingProjectId: 999,
+          autoApproveArtistSplitProposals: false,
+          nullPlatformProvider: true,
+          allowArtistProjectActivation: false,
+        };
+        console.log(invalidCuratedConfiguration);
+        // deploy curated core
+        const deployTx = curatedFactory.getDeployTransaction(
+          invalidCuratedConfiguration,
+          config.adminACL.address,
+          DEFAULT_BASE_URI,
+          config.universalReader.address
+        );
+        await expect(config.accounts.deployer.sendTransaction(deployTx))
+          .to.be.revertedWithCustomError(
+            config.genArt721Core,
+            GENART721_ERROR_NAME
+          )
+          .withArgs(GENART721_ERROR_CODES.OnlyNonZeroAddress);
+      });
+
+      it("reverts when randomizer address is zero", async function () {
+        const config = await loadFixture(_beforeEach);
+        const bytecodeStorageLibFactory = await ethers.getContractFactory(
+          "contracts/libs/v0.8.x/BytecodeStorageV2.sol:BytecodeStorageReader"
+        );
+        const library = await bytecodeStorageLibFactory
+          .connect(config.accounts.deployer)
+          .deploy(/* no args for library ever */);
+        const v3flexlibFactory = await ethers.getContractFactory(
+          "contracts/libs/v0.8.x/V3FlexLib.sol:V3FlexLib"
+        );
+        const v3flexlib = await v3flexlibFactory
+          .connect(config.accounts.deployer)
+          .deploy(/* no args for library ever */);
+        const curatedFactory = new GenArt721CoreV3_Curated_Flex__factory(
+          {
+            "contracts/libs/v0.8.x/BytecodeStorageV2.sol:BytecodeStorageReader":
+              library.address,
+            "contracts/libs/v0.8.x/V3FlexLib.sol:V3FlexLib": v3flexlib.address,
+          },
+          config.accounts.deployer
+        );
+        const invalidCuratedConfiguration = {
+          tokenName: config.name,
+          tokenSymbol: config.symbol,
+          renderProviderAddress: config.accounts.deployer.address,
+          platformProviderAddress: constants.ZERO_ADDRESS,
+          newSuperAdminAddress: constants.ZERO_ADDRESS,
+          minterFilterAddress: config.minterFilter.address,
+          randomizerContract: constants.ZERO_ADDRESS, // INVALID ZERO ADDRESS
+          splitProviderAddress: config.splitProvider?.address,
+          startingProjectId: 999,
+          autoApproveArtistSplitProposals: false,
+          nullPlatformProvider: true,
+          allowArtistProjectActivation: false,
+        };
+        // deploy curated core
+        const deployTx = curatedFactory.getDeployTransaction(
+          invalidCuratedConfiguration,
+          config.adminACL.address,
+          DEFAULT_BASE_URI,
+          config.universalReader.address
+        );
+        await expect(config.accounts.deployer.sendTransaction(deployTx))
+          .to.be.revertedWithCustomError(
+            config.genArt721Core,
+            GENART721_ERROR_NAME
+          )
+          .withArgs(GENART721_ERROR_CODES.OnlyNonZeroAddress);
+      });
+
+      it("reverts when adminACL address is zero", async function () {
+        const config = await loadFixture(_beforeEach);
+        const bytecodeStorageLibFactory = await ethers.getContractFactory(
+          "contracts/libs/v0.8.x/BytecodeStorageV2.sol:BytecodeStorageReader"
+        );
+        const library = await bytecodeStorageLibFactory
+          .connect(config.accounts.deployer)
+          .deploy(/* no args for library ever */);
+        const v3flexlibFactory = await ethers.getContractFactory(
+          "contracts/libs/v0.8.x/V3FlexLib.sol:V3FlexLib"
+        );
+        const v3flexlib = await v3flexlibFactory
+          .connect(config.accounts.deployer)
+          .deploy(/* no args for library ever */);
+        const curatedFactory = new GenArt721CoreV3_Curated_Flex__factory(
+          {
+            "contracts/libs/v0.8.x/BytecodeStorageV2.sol:BytecodeStorageReader":
+              library.address,
+            "contracts/libs/v0.8.x/V3FlexLib.sol:V3FlexLib": v3flexlib.address,
+          },
+          config.accounts.deployer
+        );
+        const invalidCuratedConfiguration = {
+          tokenName: config.name,
+          tokenSymbol: config.symbol,
+          renderProviderAddress: config.accounts.deployer.address,
+          platformProviderAddress: constants.ZERO_ADDRESS,
+          newSuperAdminAddress: constants.ZERO_ADDRESS,
+          minterFilterAddress: config.minterFilter.address,
+          randomizerContract: config.randomizer.address,
+          splitProviderAddress: config.splitProvider?.address,
+          startingProjectId: 999,
+          autoApproveArtistSplitProposals: false,
+          nullPlatformProvider: true,
+          allowArtistProjectActivation: false,
+        };
+        // deploy curated core
+        const deployTx = curatedFactory.getDeployTransaction(
+          invalidCuratedConfiguration,
+          constants.ZERO_ADDRESS, // INVALID ZERO ADDRESS
+          DEFAULT_BASE_URI,
+          config.universalReader.address
+        );
+        await expect(config.accounts.deployer.sendTransaction(deployTx))
+          .to.be.revertedWithCustomError(
+            config.genArt721Core,
+            GENART721_ERROR_NAME
+          )
+          .withArgs(GENART721_ERROR_CODES.OnlyNonZeroAddress);
+      });
+
+      it("reverts when reader address is zero", async function () {
+        const config = await loadFixture(_beforeEach);
+        const bytecodeStorageLibFactory = await ethers.getContractFactory(
+          "contracts/libs/v0.8.x/BytecodeStorageV2.sol:BytecodeStorageReader"
+        );
+        const library = await bytecodeStorageLibFactory
+          .connect(config.accounts.deployer)
+          .deploy(/* no args for library ever */);
+        const v3flexlibFactory = await ethers.getContractFactory(
+          "contracts/libs/v0.8.x/V3FlexLib.sol:V3FlexLib"
+        );
+        const v3flexlib = await v3flexlibFactory
+          .connect(config.accounts.deployer)
+          .deploy(/* no args for library ever */);
+        const curatedFactory = new GenArt721CoreV3_Curated_Flex__factory(
+          {
+            "contracts/libs/v0.8.x/BytecodeStorageV2.sol:BytecodeStorageReader":
+              library.address,
+            "contracts/libs/v0.8.x/V3FlexLib.sol:V3FlexLib": v3flexlib.address,
+          },
+          config.accounts.deployer
+        );
+        const invalidCuratedConfiguration = {
+          tokenName: config.name,
+          tokenSymbol: config.symbol,
+          renderProviderAddress: config.accounts.deployer.address,
+          platformProviderAddress: constants.ZERO_ADDRESS,
+          newSuperAdminAddress: constants.ZERO_ADDRESS,
+          minterFilterAddress: config.minterFilter.address,
+          randomizerContract: config.randomizer.address,
+          splitProviderAddress: config.splitProvider?.address,
+          startingProjectId: 999,
+          autoApproveArtistSplitProposals: false,
+          nullPlatformProvider: true,
+          allowArtistProjectActivation: false,
+        };
+        // deploy curated core
+        const deployTx = curatedFactory.getDeployTransaction(
+          invalidCuratedConfiguration,
+          config.adminACL.address,
+          DEFAULT_BASE_URI,
+          constants.ZERO_ADDRESS // INVALID ZERO ADDRESS
+        );
+        await expect(config.accounts.deployer.sendTransaction(deployTx))
+          .to.be.revertedWithCustomError(
+            config.genArt721Core,
+            GENART721_ERROR_NAME
+          )
+          .withArgs(GENART721_ERROR_CODES.OnlyNonZeroAddress);
+      });
+
+      it("reverts when defaultBaseURIHost is empty", async function () {
+        const config = await loadFixture(_beforeEach);
+        const bytecodeStorageLibFactory = await ethers.getContractFactory(
+          "contracts/libs/v0.8.x/BytecodeStorageV2.sol:BytecodeStorageReader"
+        );
+        const library = await bytecodeStorageLibFactory
+          .connect(config.accounts.deployer)
+          .deploy(/* no args for library ever */);
+        const v3flexlibFactory = await ethers.getContractFactory(
+          "contracts/libs/v0.8.x/V3FlexLib.sol:V3FlexLib"
+        );
+        const v3flexlib = await v3flexlibFactory
+          .connect(config.accounts.deployer)
+          .deploy(/* no args for library ever */);
+        const curatedFactory = new GenArt721CoreV3_Curated_Flex__factory(
+          {
+            "contracts/libs/v0.8.x/BytecodeStorageV2.sol:BytecodeStorageReader":
+              library.address,
+            "contracts/libs/v0.8.x/V3FlexLib.sol:V3FlexLib": v3flexlib.address,
+          },
+          config.accounts.deployer
+        );
+        const invalidCuratedConfiguration = {
+          tokenName: config.name,
+          tokenSymbol: config.symbol,
+          renderProviderAddress: config.accounts.deployer.address,
+          platformProviderAddress: constants.ZERO_ADDRESS,
+          newSuperAdminAddress: constants.ZERO_ADDRESS,
+          minterFilterAddress: config.minterFilter.address,
+          randomizerContract: config.randomizer.address,
+          splitProviderAddress: config.splitProvider?.address,
+          startingProjectId: 999,
+          autoApproveArtistSplitProposals: false,
+          nullPlatformProvider: true,
+          allowArtistProjectActivation: false,
+        };
+        // deploy curated core
+        const deployTx = curatedFactory.getDeployTransaction(
+          invalidCuratedConfiguration,
+          config.adminACL.address,
+          "", // INVALID EMPTY BASE URI
+          config.universalReader.address
+        );
+        await expect(
+          config.accounts.deployer.sendTransaction(deployTx)
+        ).to.be.revertedWith(
+          "GenArt721CoreV3_Curated_Flex: defaultBaseURIHost must be non-empty"
+        );
+      });
+
+      it("reverts when auto approve split proposals is true", async function () {
+        const config = await loadFixture(_beforeEach);
+        const bytecodeStorageLibFactory = await ethers.getContractFactory(
+          "contracts/libs/v0.8.x/BytecodeStorageV2.sol:BytecodeStorageReader"
+        );
+        const library = await bytecodeStorageLibFactory
+          .connect(config.accounts.deployer)
+          .deploy(/* no args for library ever */);
+        const v3flexlibFactory = await ethers.getContractFactory(
+          "contracts/libs/v0.8.x/V3FlexLib.sol:V3FlexLib"
+        );
+        const v3flexlib = await v3flexlibFactory
+          .connect(config.accounts.deployer)
+          .deploy(/* no args for library ever */);
+        const curatedFactory = new GenArt721CoreV3_Curated_Flex__factory(
+          {
+            "contracts/libs/v0.8.x/BytecodeStorageV2.sol:BytecodeStorageReader":
+              library.address,
+            "contracts/libs/v0.8.x/V3FlexLib.sol:V3FlexLib": v3flexlib.address,
+          },
+          config.accounts.deployer
+        );
+        const invalidCuratedConfiguration = {
+          tokenName: config.name,
+          tokenSymbol: config.symbol,
+          renderProviderAddress: config.accounts.deployer.address,
+          platformProviderAddress: constants.ZERO_ADDRESS,
+          newSuperAdminAddress: constants.ZERO_ADDRESS,
+          minterFilterAddress: config.minterFilter.address,
+          randomizerContract: config.randomizer.address,
+          splitProviderAddress: config.splitProvider?.address,
+          startingProjectId: 999,
+          autoApproveArtistSplitProposals: true, // INVALID TRUE
+          nullPlatformProvider: true,
+          allowArtistProjectActivation: false,
+        };
+        // deploy curated core
+        const deployTx = curatedFactory.getDeployTransaction(
+          invalidCuratedConfiguration,
+          config.adminACL.address,
+          "dummybaseurihost",
+          config.universalReader.address
+        );
+        await expect(
+          config.accounts.deployer.sendTransaction(deployTx)
+        ).to.be.revertedWith(
+          "GenArt721CoreV3_Curated_Flex: autoApproveArtistSplitProposals must be false"
+        );
+      });
+
+      it("reverts when platform provider isn't constrained to be null", async function () {
+        const config = await loadFixture(_beforeEach);
+        const bytecodeStorageLibFactory = await ethers.getContractFactory(
+          "contracts/libs/v0.8.x/BytecodeStorageV2.sol:BytecodeStorageReader"
+        );
+        const library = await bytecodeStorageLibFactory
+          .connect(config.accounts.deployer)
+          .deploy(/* no args for library ever */);
+        const v3flexlibFactory = await ethers.getContractFactory(
+          "contracts/libs/v0.8.x/V3FlexLib.sol:V3FlexLib"
+        );
+        const v3flexlib = await v3flexlibFactory
+          .connect(config.accounts.deployer)
+          .deploy(/* no args for library ever */);
+        const curatedFactory = new GenArt721CoreV3_Curated_Flex__factory(
+          {
+            "contracts/libs/v0.8.x/BytecodeStorageV2.sol:BytecodeStorageReader":
+              library.address,
+            "contracts/libs/v0.8.x/V3FlexLib.sol:V3FlexLib": v3flexlib.address,
+          },
+          config.accounts.deployer
+        );
+        const invalidCuratedConfiguration = {
+          tokenName: config.name,
+          tokenSymbol: config.symbol,
+          renderProviderAddress: config.accounts.deployer.address,
+          platformProviderAddress: constants.ZERO_ADDRESS,
+          newSuperAdminAddress: constants.ZERO_ADDRESS,
+          minterFilterAddress: config.minterFilter.address,
+          randomizerContract: config.randomizer.address,
+          splitProviderAddress: config.splitProvider?.address,
+          startingProjectId: 999,
+          autoApproveArtistSplitProposals: false,
+          nullPlatformProvider: false, // INVALID FALSE
+          allowArtistProjectActivation: false,
+        };
+        // deploy curated core
+        const deployTx = curatedFactory.getDeployTransaction(
+          invalidCuratedConfiguration,
+          config.adminACL.address,
+          "dummybaseurihost",
+          config.universalReader.address
+        );
+        await expect(
+          config.accounts.deployer.sendTransaction(deployTx)
+        ).to.be.revertedWith(
+          "GenArt721CoreV3_Curated_Flex: nullPlatformProvider must be true"
+        );
+      });
+
+      it("reverts when allowArtistProjectActivation is true", async function () {
+        const config = await loadFixture(_beforeEach);
+        const bytecodeStorageLibFactory = await ethers.getContractFactory(
+          "contracts/libs/v0.8.x/BytecodeStorageV2.sol:BytecodeStorageReader"
+        );
+        const library = await bytecodeStorageLibFactory
+          .connect(config.accounts.deployer)
+          .deploy(/* no args for library ever */);
+        const v3flexlibFactory = await ethers.getContractFactory(
+          "contracts/libs/v0.8.x/V3FlexLib.sol:V3FlexLib"
+        );
+        const v3flexlib = await v3flexlibFactory
+          .connect(config.accounts.deployer)
+          .deploy(/* no args for library ever */);
+        const curatedFactory = new GenArt721CoreV3_Curated_Flex__factory(
+          {
+            "contracts/libs/v0.8.x/BytecodeStorageV2.sol:BytecodeStorageReader":
+              library.address,
+            "contracts/libs/v0.8.x/V3FlexLib.sol:V3FlexLib": v3flexlib.address,
+          },
+          config.accounts.deployer
+        );
+        const invalidCuratedConfiguration = {
+          tokenName: config.name,
+          tokenSymbol: config.symbol,
+          renderProviderAddress: config.accounts.deployer.address,
+          platformProviderAddress: constants.ZERO_ADDRESS,
+          newSuperAdminAddress: constants.ZERO_ADDRESS,
+          minterFilterAddress: config.minterFilter.address,
+          randomizerContract: config.randomizer.address,
+          splitProviderAddress: config.splitProvider?.address,
+          startingProjectId: 999,
+          autoApproveArtistSplitProposals: false,
+          nullPlatformProvider: true,
+          allowArtistProjectActivation: true, // INVALID TRUE
+        };
+        // deploy curated core
+        const deployTx = curatedFactory.getDeployTransaction(
+          invalidCuratedConfiguration,
+          config.adminACL.address,
+          "dummybaseurihost",
+          config.universalReader.address
+        );
+        await expect(
+          config.accounts.deployer.sendTransaction(deployTx)
+        ).to.be.revertedWith(
+          "GenArt721CoreV3_Curated_Flex: allowArtistProjectActivation must be false"
+        );
+      });
+
+      it("reverts when starting project is zero", async function () {
+        const config = await loadFixture(_beforeEach);
+        const bytecodeStorageLibFactory = await ethers.getContractFactory(
+          "contracts/libs/v0.8.x/BytecodeStorageV2.sol:BytecodeStorageReader"
+        );
+        const library = await bytecodeStorageLibFactory
+          .connect(config.accounts.deployer)
+          .deploy(/* no args for library ever */);
+        const v3flexlibFactory = await ethers.getContractFactory(
+          "contracts/libs/v0.8.x/V3FlexLib.sol:V3FlexLib"
+        );
+        const v3flexlib = await v3flexlibFactory
+          .connect(config.accounts.deployer)
+          .deploy(/* no args for library ever */);
+        const curatedFactory = new GenArt721CoreV3_Curated_Flex__factory(
+          {
+            "contracts/libs/v0.8.x/BytecodeStorageV2.sol:BytecodeStorageReader":
+              library.address,
+            "contracts/libs/v0.8.x/V3FlexLib.sol:V3FlexLib": v3flexlib.address,
+          },
+          config.accounts.deployer
+        );
+        const invalidCuratedConfiguration = {
+          tokenName: config.name,
+          tokenSymbol: config.symbol,
+          renderProviderAddress: config.accounts.deployer.address,
+          platformProviderAddress: constants.ZERO_ADDRESS,
+          newSuperAdminAddress: constants.ZERO_ADDRESS,
+          minterFilterAddress: config.minterFilter.address,
+          randomizerContract: config.randomizer.address,
+          splitProviderAddress: config.splitProvider?.address,
+          startingProjectId: 0, // INVALID ZERO
+          autoApproveArtistSplitProposals: false,
+          nullPlatformProvider: true,
+          allowArtistProjectActivation: false,
+        };
+        // deploy curated core
+        const deployTx = curatedFactory.getDeployTransaction(
+          invalidCuratedConfiguration,
+          config.adminACL.address,
+          "dummybaseurihost",
+          config.universalReader.address
+        );
+        await expect(
+          config.accounts.deployer.sendTransaction(deployTx)
+        ).to.be.revertedWith(
+          "GenArt721CoreV3_Curated_Flex: startingProjectId must be greater than 0"
+        );
+      });
+
+      it("properly initializes default base URI", async function () {
+        const config = await loadFixture(_beforeEach);
+        const expectedTokenURI = "https://token.artblocks.io/";
+        expect(await config.genArt721Core.defaultBaseURI()).to.equal(
+          expectedTokenURI
+        );
+      });
+    });
+
+    describe("initialize", function () {
+      it("reverts on call to initialize (curated is initialized in constructor)", async function () {
+        const config = await loadFixture(_beforeEach);
+        const validCuratedConfiguration = {
+          tokenName: config.name,
+          tokenSymbol: config.symbol,
+          renderProviderAddress: config.accounts.deployer.address,
+          platformProviderAddress: constants.ZERO_ADDRESS,
+          newSuperAdminAddress: constants.ZERO_ADDRESS,
+          minterFilterAddress: config.minterFilter.address,
+          randomizerContract: config.randomizer.address,
+          splitProviderAddress: config.splitProvider?.address,
+          startingProjectId: 999,
+          autoApproveArtistSplitProposals: false,
+          nullPlatformProvider: true,
+          allowArtistProjectActivation: false,
+        };
+        await expect(
+          config.genArt721Core.initialize(
+            validCuratedConfiguration,
+            constants.ZERO_ADDRESS, // dummy,
+            "dummybaseurihost",
+            constants.ZERO_ADDRESS // dummy
+          )
+        ).to.be.revertedWith(
+          "GenArt721CoreV3_Curated_Flex: contract initialized in constructor"
+        );
+      });
+    });
+
+    describe("updateArtblocksCurationRegistryAddress", function () {
+      it("reverts when called by non-admin", async function () {
+        const config = await loadFixture(_beforeEach);
+        const newAddress = config.accounts.deployer.address;
+        await expect(
+          config.genArt721Core
+            .connect(config.accounts.user)
+            .updateArtblocksCurationRegistryAddress(newAddress)
+        )
+          .to.be.revertedWithCustomError(
+            config.genArt721Core,
+            GENART721_ERROR_NAME
+          )
+          .withArgs(GENART721_ERROR_CODES.OnlyAdminACL);
+      });
+
+      it("updates state after calling", async function () {
+        const config = await loadFixture(_beforeEach);
+        const newAddress = config.accounts.deployer.address;
+        await config.genArt721Core.updateArtblocksCurationRegistryAddress(
+          newAddress
+        );
+        expect(
+          await config.genArt721Core.artblocksCurationRegistryAddress()
+        ).to.equal(newAddress);
+      });
+    });
+
+    describe("addProjectExternalAssetDependency", function () {
+      it("reverts when called by non-artist or admin", async function () {
+        const config = await loadFixture(_beforeEach);
+        await expect(
+          config.genArt721Core
+            .connect(config.accounts.user)
+            .addProjectExternalAssetDependency(
+              0,
+              "dummycid",
+              ExternalAssetDependencyType.ONCHAIN
+            )
+        )
+          .to.be.revertedWithCustomError(
+            config.genArt721Core,
+            GENART721_ERROR_NAME
+          )
+          .withArgs(GENART721_ERROR_CODES.OnlyArtistOrAdminACL);
+      });
+
+      it("reverts when dependency type is not ONCHAIN", async function () {
+        const config = await loadFixture(_beforeEach);
+        await expect(
+          config.genArt721Core.addProjectExternalAssetDependency(
+            0,
+            "dummycid",
+            ExternalAssetDependencyType.IPFS
+          )
+        ).to.be.revertedWith(
+          "GenArt721CoreV3_Curated_Flex: Curated dependency type must be ONCHAIN"
+        );
+      });
+
+      it("accepts valid ONCHAIN dependency", async function () {
+        const config = await loadFixture(_beforeEach);
+        await config.genArt721Core.addProjectExternalAssetDependency(
+          0,
+          "dummyonchaindata",
+          ExternalAssetDependencyType.ONCHAIN
+        );
+        expect(
+          (
+            await config.genArt721Core.projectExternalAssetDependencyByIndex(
+              0,
+              0
+            )
+          ).data
+        ).to.equal("dummyonchaindata");
+      });
+    });
+
+    describe("updateProjectExternalAssetDependency", function () {
+      it("reverts when called by non-artist or admin", async function () {
+        const config = await loadFixture(_beforeEach);
+        await expect(
+          config.genArt721Core
+            .connect(config.accounts.user)
+            .updateProjectExternalAssetDependency(
+              0,
+              0,
+              "dummycid",
+              ExternalAssetDependencyType.ONCHAIN
+            )
+        )
+          .to.be.revertedWithCustomError(
+            config.genArt721Core,
+            GENART721_ERROR_NAME
+          )
+          .withArgs(GENART721_ERROR_CODES.OnlyArtistOrAdminACL);
+      });
+
+      it("reverts when dependency type is not ONCHAIN", async function () {
+        const config = await loadFixture(_beforeEach);
+        // add a dependency first
+        await config.genArt721Core.addProjectExternalAssetDependency(
+          0,
+          "dummyonchaindata",
+          ExternalAssetDependencyType.ONCHAIN
+        );
+        // update the dependency
+        await expect(
+          config.genArt721Core.updateProjectExternalAssetDependency(
+            0,
+            0,
+            "dummycid",
+            ExternalAssetDependencyType.IPFS
+          )
+        ).to.be.revertedWith(
+          "GenArt721CoreV3_Curated_Flex: Curated dependency type must be ONCHAIN"
+        );
+      });
+
+      it("updates the dependency", async function () {
+        const config = await loadFixture(_beforeEach);
+        // add a dependency first
+        await config.genArt721Core.addProjectExternalAssetDependency(
+          0,
+          "dummyonchaindata",
+          ExternalAssetDependencyType.ONCHAIN
+        );
+        // update the dependency
+        await config.genArt721Core.updateProjectExternalAssetDependency(
+          0,
+          0,
+          "dummyonchaindata",
+          ExternalAssetDependencyType.ONCHAIN
+        );
+        expect(
+          (
+            await config.genArt721Core.projectExternalAssetDependencyByIndex(
+              0,
+              0
+            )
+          ).data
+        ).to.equal("dummyonchaindata");
+      });
+    });
+  });
+}

--- a/packages/contracts/test/core/V3/GenArt721CoreV3_Curated_Flex/events.test.ts
+++ b/packages/contracts/test/core/V3/GenArt721CoreV3_Curated_Flex/events.test.ts
@@ -1,7 +1,7 @@
 import { constants } from "@openzeppelin/test-helpers";
 import { expect } from "chai";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
-import { GenArt721CoreV3_Curated } from "../../../../scripts/contracts";
+import { GenArt721CoreV3_Curated_Flex } from "../../../../scripts/contracts";
 
 import {
   T_Config,
@@ -11,12 +11,12 @@ import {
 } from "../../../util/common";
 
 interface T_CuratedTestConfig extends T_Config {
-  genArt721Core: GenArt721CoreV3_Curated;
+  genArt721Core: GenArt721CoreV3_Curated_Flex;
 }
 
 // test the following V3 core contract derivatives:
 const coreContractsToTest = [
-  "GenArt721CoreV3_Curated", // V3.2 core Curated contract
+  "GenArt721CoreV3_Curated_Flex", // V3.2 core Curated Flex contract
 ];
 
 /**

--- a/packages/contracts/test/core/V3/GenArt721CoreV3_Curated_Flex/views.test.ts
+++ b/packages/contracts/test/core/V3/GenArt721CoreV3_Curated_Flex/views.test.ts
@@ -1,0 +1,108 @@
+import { constants } from "@openzeppelin/test-helpers";
+import { expect } from "chai";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { GenArt721CoreV3_Curated_Flex } from "../../../../scripts/contracts";
+
+import {
+  T_Config,
+  getAccounts,
+  assignDefaultConstants,
+  deployCoreWithMinterFilter,
+} from "../../../util/common";
+
+interface T_CuratedTestConfig extends T_Config {
+  genArt721Core: GenArt721CoreV3_Curated_Flex;
+}
+
+// test the following V3 core contract derivatives:
+const coreContractsToTest = [
+  "GenArt721CoreV3_Curated_Flex", // V3.2 core Curated Flex contract
+];
+
+const EXPECTED_CORE_VERSION = "v3.2.7";
+
+const EXPECTED_PREVIOUS_ART_BLOCKS_CONTRACTS = [
+  "0x059EDD72Cd353dF5106D2B9cC5ab83a52287aC3a",
+  "0xa7d8d9ef8D8Ce8992Df33D8b8CF4Aebabd5bD270",
+  "0x99a9B7c1116f9ceEB1652de04d5969CcE509B069",
+  "0xAB0000000000aa06f89B268D604a9c1C41524Ac6",
+];
+
+/**
+ * Tests for V3 core dealing with configuring the core contract.
+ */
+for (const coreContractName of coreContractsToTest) {
+  describe(`${coreContractName} Contract Views`, async function () {
+    async function _beforeEach() {
+      let config: T_Config = {
+        accounts: await getAccounts(),
+      };
+      config = await assignDefaultConstants(config);
+
+      // deploy and configure minter filter and minter
+      ({
+        genArt721Core: config.genArt721Core,
+        minterFilter: config.minterFilter,
+        randomizer: config.randomizer,
+        adminACL: config.adminACL,
+      } = await deployCoreWithMinterFilter(
+        config,
+        coreContractName,
+        "MinterFilterV2"
+      ));
+
+      return config as T_CuratedTestConfig;
+    }
+
+    describe("coreVersion", function () {
+      it("returns expected value", async function () {
+        const config = await loadFixture(_beforeEach);
+        expect(await config.genArt721Core.coreVersion()).to.equal(
+          EXPECTED_CORE_VERSION
+        );
+      });
+    });
+
+    describe("PREVIOUS_ART_BLOCKS_CONTRACTS", function () {
+      it("returns expected value", async function () {
+        const config = await loadFixture(_beforeEach);
+        for (
+          let i = 0;
+          i < EXPECTED_PREVIOUS_ART_BLOCKS_CONTRACTS.length;
+          i++
+        ) {
+          expect(
+            await config.genArt721Core.PREVIOUS_ART_BLOCKS_CONTRACTS(i)
+          ).to.equal(EXPECTED_PREVIOUS_ART_BLOCKS_CONTRACTS[i]);
+        }
+      });
+    });
+
+    describe("IS_FLAGSHIP", function () {
+      it("returns expected value", async function () {
+        const config = await loadFixture(_beforeEach);
+        expect(await config.genArt721Core.IS_FLAGSHIP()).to.equal(true);
+      });
+    });
+
+    describe("artblocksCurationRegistryAddress", function () {
+      it("returns null address initially", async function () {
+        const config = await loadFixture(_beforeEach);
+        expect(
+          await config.genArt721Core.artblocksCurationRegistryAddress()
+        ).to.equal(constants.ZERO_ADDRESS);
+      });
+
+      it("returns set address after setting", async function () {
+        const config = await loadFixture(_beforeEach);
+        const newAddress = config.accounts.deployer.address;
+        await config.genArt721Core.updateArtblocksCurationRegistryAddress(
+          newAddress
+        );
+        expect(
+          await config.genArt721Core.artblocksCurationRegistryAddress()
+        ).to.equal(newAddress);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Description of the change

Add new Curated Flex core contract, compatible with on-chain flex dependencies to enable PostParams.

This approach is similar to the previous Curated core contract:
* derived from parent Engine contract (Engine_Flex, in this case)
* offload initialization logic to constructor for one-off deployments

Override guards are added to only allow ONCHAIN flex dependencies, ensuring the high bar of only on-chain dependencies for Art Blocks Curated is maintained.

We will follow a similar strategy of using the owned create2 factory for deployment, in case of any royalties being misdirected to the contract deployer. https://etherscan.io/address/0x000000ab6881dbbbd231db99d69134fea2385bf8#code
