### PR TITLE
Add openzeppelin mcp server to cursor project context

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "OpenZeppelinSolidityContracts": {
+      "type": "streamable-http",
+      "url": "https://mcp.openzeppelin.com/contracts/solidity/mcp"
+    }
+  }
+}


### PR DESCRIPTION
## Description of the change

Add OpenZeppelin MCP server to cursor project context.

ref: https://blog.openzeppelin.com/introducing-contracts-mcp
