### PR TITLE
Add updated mint event to abi

### DIFF
--- a/packages/sdk/abis/iGenArt721CoreContractV3BaseAbi.ts
+++ b/packages/sdk/abis/iGenArt721CoreContractV3BaseAbi.ts
@@ -37,6 +37,31 @@ export const iGenArt721CoreContractV3BaseAbi = [
       {
         indexed: true,
         internalType: "address",
+        name: "_to",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "_tokenId",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "bytes32",
+        name: "_tokenHash",
+        type: "bytes32",
+      },
+    ],
+    name: "Mint",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
         name: "_currentMinter",
         type: "address",
       },

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artblocks/sdk",
-  "version": "0.1.30-34",
+  "version": "0.1.30-35",
   "description": "JavaScript SDK for configuring and using Art Blocks minters.",
   "main": "dist/index.js",
   "repository": "git@github.com:ArtBlocks/artblocks-sdk.git",


### PR DESCRIPTION
## Description of the change

The stale abi was causing the purchase tracking machine to fail to parse the mint log which left the website in a broken state. This PR updates the ABI to match the new mint event with token hash
