### PR TITLE
fix edge cases in feistel walk lib

### DIFF
--- a/packages/contracts/contracts/libs/v0.8.x/FeistelWalkLib.sol
+++ b/packages/contracts/contracts/libs/v0.8.x/FeistelWalkLib.sol
@@ -12,6 +12,12 @@ pragma solidity ^0.8.20;
  *      - Not cryptographic; optimized for gas efficiency with good mixing
  *  Uses 2 Feistel rounds with 64-bit round keys (k0, k1) derived from the seed.
  *  Additional keys (k2, k3) reserved for potential future use.
+ *
+ *  The Feistel domain is exactly 2^logM = M (the next power of two >= N) for both
+ *  even and odd logM, achieved with an UNBALANCED split in `_feistelOnPow2Domain`
+ *  (`a = logM/2`, `b = logM - a`, `a + b = logM`). This keeps M <= 2N, so the
+ *  cycle-walk in-range probability is >= ~0.5 and a full traversal (k = 0..N-1) is
+ *  a true permutation of [0..N) with no duplicates or drops.
  */
 library FeistelWalkLib {
     uint256 private constant MAX_CYCLE_WALKS = 32;
@@ -110,7 +116,18 @@ library FeistelWalkLib {
     }
 
     /// @dev Feistel permutation over [0..M) where M is a power of two.
-    ///      Split into halves and apply round function twice for good mixing.
+    ///      Split into a low half (a bits) and a high half (b bits) with
+    ///      a + b = logM, and apply the round function twice for good mixing.
+    ///      Using an UNBALANCED split (a = logM/2, b = logM - a) keeps the domain
+    ///      exactly 2^logM = M for both even and odd logM. A balanced split
+    ///      (half = (logM + 1) / 2) would span 2*half = logM + 1 bits for odd logM
+    ///      and therefore permute [0, 2M) instead of [0, M); the wider domain pushes
+    ///      the cycle-walk past its cap for N just above a power of two and triggers
+    ///      the identity `return x` fallback, breaking the bijection (duplicate /
+    ///      missing elements). Each round masks its output to the width of the half
+    ///      it writes, so every round is invertible and the whole map is a bijection
+    ///      over [0, M). For even logM, a == b and this is identical to a balanced
+    ///      split.
     function _feistelOnPow2Domain(
         uint256 x,
         uint256 M,
@@ -128,15 +145,18 @@ library FeistelWalkLib {
         // Full assembly for maximum gas efficiency
         uint256 result;
         assembly {
-            // Balanced Feistel: split into two equal (or nearly equal) halves
-            let half := div(add(logM, 1), 2)
-            let mask := sub(shl(half, 1), 1)
+            // Unbalanced Feistel: low half is `a` bits, high half is `b` bits,
+            // with a + b = logM (so the domain is exactly 2^logM = M).
+            let a := div(logM, 2)
+            let b := sub(logM, a)
+            let maskA := sub(shl(a, 1), 1)
+            let maskB := sub(shl(b, 1), 1)
 
-            // Split into L and R
-            let L := and(x, mask)
-            let R := and(shr(half, x), mask)
+            // Split into L (low, a bits) and R (high, b bits)
+            let L := and(x, maskA)
+            let R := and(shr(a, x), maskB)
 
-            // Round 0: Inline round function
+            // Round 0: R (b bits) -> a-bit register
             let F := and(R, 0xFFFFFFFFFFFFFFFF)
             F := xor(F, k0)
             F := xor(F, shl(13, F))
@@ -144,11 +164,11 @@ library FeistelWalkLib {
             F := xor(F, shl(17, F))
             F := xor(F, shr(5, F))
 
-            let newR := and(xor(L, F), mask)
-            L := R
-            R := newR
+            let newR := and(xor(L, F), maskA) // a bits
+            L := R // b bits
+            R := newR // a bits
 
-            // Round 1: Inline round function
+            // Round 1: R (a bits) -> b-bit register
             F := and(R, 0xFFFFFFFFFFFFFFFF)
             F := xor(F, xor(k1, 1))
             F := xor(F, shl(13, F))
@@ -156,12 +176,12 @@ library FeistelWalkLib {
             F := xor(F, shl(17, F))
             F := xor(F, shr(5, F))
 
-            newR := and(xor(L, F), mask)
-            L := R
-            R := newR
+            newR := and(xor(L, F), maskB) // b bits
+            L := R // a bits
+            R := newR // b bits
 
-            // Recombine
-            result := or(shl(half, R), L)
+            // Recombine: R (b bits) high, L (a bits) low => a + b = logM bits
+            result := or(shl(a, R), L)
         }
         return result;
     }

--- a/packages/contracts/test/libs/FeistelWalkLib.test.ts
+++ b/packages/contracts/test/libs/FeistelWalkLib.test.ts
@@ -554,14 +554,20 @@ describe("FeistelWalkLib", function () {
     // traversal must be a perfect permutation for EVERY seed.
     //
     // Bands (N, logM): (257, 9), (1025, 11), (4097, 13).
-    const bands = [257, 1025, 4097];
-    const SEEDS_PER_BAND = 16;
+    // Seed count scales down as N grows: each fullTraversal is O(N) gas in one
+    // eth_call, and CI runners are much slower than local (coverage worse still).
+    const bands: { N: number; seeds: number }[] = [
+      { N: 257, seeds: 16 },
+      { N: 1025, seeds: 8 },
+      { N: 4097, seeds: 4 },
+    ];
 
-    for (const N of bands) {
-      it(`should be a bijection over [0..${N}) for ${SEEDS_PER_BAND} fixed seeds`, async function () {
+    for (const { N, seeds } of bands) {
+      it(`should be a bijection over [0..${N}) for ${seeds} fixed seeds`, async function () {
+        this.timeout(180_000);
         const { mock } = await loadFixture(deployFixture);
 
-        for (let s = 0; s < SEEDS_PER_BAND; s++) {
+        for (let s = 0; s < seeds; s++) {
           const result = await mock.fullTraversal(fixedSeed(s), N);
           const resultNumbers = result.map((bn) => bn.toNumber());
           expect(

--- a/packages/contracts/test/libs/FeistelWalkLib.test.ts
+++ b/packages/contracts/test/libs/FeistelWalkLib.test.ts
@@ -553,18 +553,21 @@ describe("FeistelWalkLib", function () {
     // drops. The unbalanced split keeps the domain at exactly M, so a full
     // traversal must be a perfect permutation for EVERY seed.
     //
-    // Bands (N, logM): (257, 9), (1025, 11), (4097, 13).
+    // Bands (N, logM): (257, 9), (1025, 11). (4097, 13) is omitted here:
+    // fullTraversal under solidity-coverage is ~50x slower than plain hardhat test,
+    // and one N=4097 call exceeds what coverage-parallel CI can sustain (exit 129).
+    // N=257 and N=1025 are enough to catch the odd-logM balanced-split bug.
+    //
     // Seed count scales down as N grows: each fullTraversal is O(N) gas in one
     // eth_call, and CI runners are much slower than local (coverage worse still).
     const bands: { N: number; seeds: number }[] = [
       { N: 257, seeds: 16 },
-      { N: 1025, seeds: 8 },
-      { N: 4097, seeds: 4 },
+      { N: 1025, seeds: 4 },
     ];
 
     for (const { N, seeds } of bands) {
       it(`should be a bijection over [0..${N}) for ${seeds} fixed seeds`, async function () {
-        this.timeout(180_000);
+        this.timeout(300_000);
         const { mock } = await loadFixture(deployFixture);
 
         for (let s = 0; s < seeds; s++) {

--- a/packages/contracts/test/libs/FeistelWalkLib.test.ts
+++ b/packages/contracts/test/libs/FeistelWalkLib.test.ts
@@ -528,10 +528,47 @@ describe("FeistelWalkLib", function () {
       it(`should handle N=${N} (non-power of 2)`, async function () {
         const { mock } = await loadFixture(deployFixture);
         const seed = randomSeed();
+
         const result = await mock.fullTraversal(seed, N);
 
         const resultNumbers = result.map((bn) => bn.toNumber());
         expect(coversRange(resultNumbers, N)).to.be.true;
+      });
+    }
+  });
+
+  // Deterministic seed so the bijection is asserted against the exact inputs that
+  // used to break the permutation (the random-seed tests above only catch the bug
+  // probabilistically).
+  function fixedSeed(i: number): string {
+    return ethers.utils.keccak256(
+      ethers.utils.defaultAbiCoder.encode(["uint256"], [i])
+    );
+  }
+
+  describe("Bijection regression: odd-logM bands (sizes just above a power of two)", function () {
+    // For these N, M = nextPow2(N) has an ODD log2. A balanced Feistel split
+    // would span logM+1 bits and permute [0, 2M) instead of [0, M), pushing the
+    // cycle-walk past its cap and triggering the identity fallback -> duplicates /
+    // drops. The unbalanced split keeps the domain at exactly M, so a full
+    // traversal must be a perfect permutation for EVERY seed.
+    //
+    // Bands (N, logM): (257, 9), (1025, 11), (4097, 13).
+    const bands = [257, 1025, 4097];
+    const SEEDS_PER_BAND = 16;
+
+    for (const N of bands) {
+      it(`should be a bijection over [0..${N}) for ${SEEDS_PER_BAND} fixed seeds`, async function () {
+        const { mock } = await loadFixture(deployFixture);
+
+        for (let s = 0; s < SEEDS_PER_BAND; s++) {
+          const result = await mock.fullTraversal(fixedSeed(s), N);
+          const resultNumbers = result.map((bn) => bn.toNumber());
+          expect(
+            coversRange(resultNumbers, N),
+            `seed #${s} broke the permutation at N=${N}`
+          ).to.be.true;
+        }
       });
     }
   });


### PR DESCRIPTION
## Description of the change

Feistel walk lib had some minor issues on edge cases that could result in some duplicate results.

This fix prevents those edge cases from ever happening.

It does not meaningfully affect gas costs.

I do not recommend any re-deployment of SRHooks.lib. This fix can be incorporated in any and-on SRHooks updates.
