### PR TITLE
Add dev Studio Flex deployment for Privy agent testing

### DIFF
--- a/packages/contracts/deployments/engine/V3/studio/dev/2026-06-23-deployment-config.ts
+++ b/packages/contracts/deployments/engine/V3/studio/dev/2026-06-23-deployment-config.ts
@@ -1,0 +1,35 @@
+// Dev Studio deployment for Privy automated testing.
+// Run: yarn deploy:v3-engine:dev
+// Post: set transactionHash after Safe execution, then run yarn post-deploy:v3-engine:dev
+
+const privyDevTestUserAddress = "0xb91633E1acdbDC9539131b433C7c027113CA1512";
+
+export const deployNetworkConfiguration = {
+  network: "sepolia",
+  environment: "dev",
+  useLedgerSigner: false,
+  useGnosisSafe: true,
+  safeAddress: "0xbaD99DdBa319639e0e9FB2E42935BfE5b2a1B6a8",
+  transactionServiceUrl: "https://safe-transaction-sepolia.safe.global",
+  transactionHash: "",
+};
+
+export const deployConfigDetailsArray = [
+  {
+    productClass: "Studio",
+    engineCoreContractType: 1,
+    tokenName: "Art Blocks Studio Flex | DEV Privy Test",
+    tokenTicker: "ABSTUDIO_DEV_PRIVY_TEST_FLEX",
+    artistName: "Infra",
+    renderProviderAddress: "0x3c6412FEE019f5c50d6F03Aa6F5045d99d9748c4",
+    platformProviderAddress: "0x0000000000000000000000000000000000000000",
+    newSuperAdminAddress: privyDevTestUserAddress,
+    startingProjectId: 0,
+    autoApproveArtistSplitProposals: true,
+    nullPlatformProvider: true,
+    allowArtistProjectActivation: true,
+    adminACLContract: "0x0000000000000000000000000000000000000000",
+    salt: "0x0",
+    defaultVerticalName: "studio",
+  },
+];

--- a/packages/contracts/deployments/engine/V3/studio/dev/DEPLOYMENT_LOGS.md
+++ b/packages/contracts/deployments/engine/V3/studio/dev/DEPLOYMENT_LOGS.md
@@ -1,3 +1,7 @@
       ----------------------------------------
       [INFO] Datetime of deployment: 2024-05-09T15:17:55.487Z
       [INFO] Deployment configuration file: /Users/lindsaygilbert/Documents/Projects/artblocks-contracts/packages/contracts/deployments/engine/V3/studio/dev/deployment-config.dev.ts
+
+      ----------------------------------------
+      [INFO] Datetime of deployment: 2026-06-27T00:19:46.569Z
+      [INFO] Deployment configuration file: /Users/benyo/Development/artblocks-contracts/packages/contracts/deployments/engine/V3/studio/dev/2026-06-23-deployment-config.ts


### PR DESCRIPTION
## Summary
- Adds a Sepolia dev Studio Flex deployment config for automated agent testing.
- Sets the Privy dev test user wallet `0xb91633E1acdbDC9539131b433C7c027113CA1512` as the new super admin for the deployed contract.
- Records the deployment script run in the dev Studio deployment log.

## Context
This is a contract deployment specifically for our Privy dev test user to be admin on, so agent testing can exercise Studio admin flows against a dedicated dev Studio Flex contract.

## Validation
- `yarn prettier --check packages/contracts/deployments/engine/V3/studio/dev/DEPLOYMENT_LOGS.md packages/contracts/deployments/engine/V3/studio/dev/2026-06-23-deployment-config.ts`
- Pre-push hook ran SDK tests: 19 suites passed, 111 tests passed. Existing lint/Babel warnings were emitted.