### PR TITLE
update on chain gen for custom html projects

### DIFF
--- a/packages/contracts/contracts/generator/GenArt721GeneratorV0.sol
+++ b/packages/contracts/contracts/generator/GenArt721GeneratorV0.sol
@@ -65,6 +65,8 @@ contract GenArt721GeneratorV0 is Initializable, IGenArt721GeneratorV0 {
         0x6a73406e61000000000000000000000000000000000000000000000000000000; // "js@na"
     bytes32 constant SVG_AT_NA_BYTES32 =
         0x737667406e610000000000000000000000000000000000000000000000000000; // "svg@na"
+    bytes32 constant CUSTOM_AT_NA_BYTES32 =
+        0x637573746f6d406e610000000000000000000000000000000000000000000000; // "custom@na"
 
     function _onlySupportedCoreContract(address coreContract) internal view {
         require(
@@ -873,6 +875,13 @@ contract GenArt721GeneratorV0 is Initializable, IGenArt721GeneratorV0 {
             .getDependencyNameAndVersionForProject(coreContract, projectId)
             .stringToBytes32();
 
+        // @dev Projects declaring the "custom@na" dependency store a complete HTML
+        // document as their project script rather than a JavaScript program. Such a
+        // document must be injected verbatim - wrapping it in a script tag both breaks
+        // HTML parsing (the document's own "</script>" terminates the wrapper early) and
+        // is semantically wrong, since markup inside a script tag is never rendered.
+        bool isRawHtmlDep = dependencyNameAndVersion == CUSTOM_AT_NA_BYTES32;
+
         // Create head tags
         // pre-fetch data to properly allocate memory for HTML tags
         (
@@ -889,10 +898,14 @@ contract GenArt721GeneratorV0 is Initializable, IGenArt721GeneratorV0 {
         HTMLTag[] memory headTags = new HTMLTag[](
             2 + dependencyRegistryAssetNamesAndVersionsLength
         );
-        headTags[0].tagOpen = "<style>";
-        headTags[0]
-            .tagContent = "html{height:100%}body{min-height:100%;margin:0;padding:0}canvas{padding:0;margin:auto;display:block;position:absolute;top:0;bottom:0;left:0;right:0}";
-        headTags[0].tagClose = "</style>";
+        // @dev The default style reset is omitted for raw HTML documents, which supply
+        // their own document-level styling. This matches Art Blocks' hosted generator.
+        if (!isRawHtmlDep) {
+            headTags[0].tagOpen = "<style>";
+            headTags[0]
+                .tagContent = "html{height:100%}body{min-height:100%;margin:0;padding:0}canvas{padding:0;margin:auto;display:block;position:absolute;top:0;bottom:0;left:0;right:0}";
+            headTags[0].tagClose = "</style>";
+        }
 
         // @dev decode any base64 encoded flex data in the browser while parsing the json
         headTags[1].tagContent = abi.encodePacked(
@@ -947,10 +960,12 @@ contract GenArt721GeneratorV0 is Initializable, IGenArt721GeneratorV0 {
         );
 
         HTMLTag memory projectScriptTag = HTMLTag({
-            tagOpen: isProcessingDep
-                ? bytes("<script type='application/processing'>")
-                : bytes("<script>"),
-            tagClose: bytes("</script>"),
+            tagOpen: isRawHtmlDep
+                ? bytes("")
+                : isProcessingDep
+                    ? bytes("<script type='application/processing'>")
+                    : bytes("<script>"),
+            tagClose: isRawHtmlDep ? bytes("") : bytes("</script>"),
             tagType: HTMLTagType.useTagOpenAndClose,
             name: "",
             contractAddress: address(0),

--- a/packages/contracts/deployments/generator/GenArt721GeneratorV0-custom-na-upgrade.md
+++ b/packages/contracts/deployments/generator/GenArt721GeneratorV0-custom-na-upgrade.md
@@ -1,0 +1,146 @@
+# Upgrade: GenArt721GeneratorV0 — raw HTML injection for `custom@na`
+
+## Problem
+
+`GenArt721GeneratorV0` wrapped every project script in `<script>` … `</script>`. Projects that
+declare the `custom@na` dependency do not store a JavaScript program — they store a **complete HTML
+document**. Wrapping such a document fails in two independent ways:
+
+1. The document's own `</script>` terminates the wrapper early, so everything before it is swallowed
+   as inert script text and everything after it is reparsed as top-level HTML.
+2. Even with the closing tag escaped, markup inside a `<script>` block is never rendered, so the
+   artwork would still be blank.
+
+Because the malformed bytes are assembled on-chain, every consumer of `getTokenHtml` /
+`getTokenHtmlBase64EncodedDataUri` was affected identically. Art Blocks' hosted generator was never
+affected — it already injects `custom@na` scripts raw.
+
+Symptom in a browser: `SyntaxError: Unexpected token '<'`, variables defined in the document's first
+inline `<script>` left undefined, blank render.
+
+## Affected projects
+
+All five `custom@na` projects on mainnet were broken. There are no others — `custom@na` is a perfect
+predictor, and every `custom@na` project stores markup.
+
+| Project | Artist | Contract | Project ID | Invocations |
+|---|---|---|---|---|
+| send/receive | Snowfro | `0xababababab20053426ad1c782de9ea8444358070` | 5 | 8,983 |
+| SpiroFlakes | Alexander Reben | `0xa7d8d9ef8d8ce8992df33d8b8cf4aebabd5bd270` | 136 | 1,024 |
+| Quine | Larva Labs | `0xab00000000002ade39f58f9d8278a31574ffbe77` | 506 | 497 |
+| Overture | Mitchell F. Chan | `0x000000dab303a194b3f55d4702b24740ad5a2f00` | 0 | 178 |
+| Paramecircle | Alexander Reben (artBoffin) | `0xa7d8d9ef8d8ce8992df33d8b8cf4aebabd5bd270` | 195 | 76 |
+
+## Why not simply escape `</script>`
+
+Two live mainnet projects — **PRELUDES** (Trevor Paglen, `0xea698596b6009a622c3ed00dd5a8b5d1cae4fc36-5`)
+and **Crypt** (The Cyclops Group, `0x99a9b7c1116f9ceeb1652de04d5969cce509b069-453`) — are genuine
+JavaScript that *deliberately* emits `</script>` near the end in order to close the generator's
+wrapper and append their own `<style>` and `<body>` markup. They render correctly today **because**
+the wrapped path is unescaped.
+
+Escaping `</script>` would therefore break two working artworks while fixing zero. The wrapped path
+is left byte-for-byte unchanged.
+
+## Change
+
+`contracts/generator/GenArt721GeneratorV0.sol`, confined to `_getTokenHtmlRequest`:
+
+- New constant `CUSTOM_AT_NA_BYTES32` (`"custom@na"`).
+- `isRawHtmlDep` is true when the project's resolved dependency is `custom@na`. When true:
+  - the project script is injected with empty `tagOpen` / `tagClose` (verbatim, no wrapper);
+  - the generator's default `<style>` reset is omitted, matching the hosted generator, since a full
+    HTML document supplies its own document-level styling.
+- Everything else is untouched: `tokenData` is still injected in `<head>` ahead of the document, the
+  gunzip script is still included, and no canvas tag is added (`custom` was never in the canvas list).
+
+**No storage variables were added**, so this upgrade carries no storage-layout risk. There is no
+per-project configuration and therefore **no follow-up admin transaction** — the fix takes effect for
+all five projects the moment the proxy is upgraded.
+
+## Verification performed
+
+Unit tests (`test/generator/GenArt721GeneratorV0.test.ts`) — 31 passing, including the 26 pre-existing
+tests, which assert exact HTML output and would fail on any change to the wrapped path.
+
+Mainnet-fork regression (`test/network-fork/generator/GenArt721GeneratorV0.fork.test.ts`) — 39
+passing. Forks mainnet, upgrades the real proxy via the impersonated ProxyAdmin owner, and asserts
+that each `custom@na` project is injected verbatim while PRELUDES, Crypt, and Gas Wars produce
+**byte-identical** output before and after.
+
+Browser rendering — post-upgrade HTML pulled from the forked chain and loaded in headless Chromium.
+All seven projects render with zero JavaScript errors; Quine's output matches its canonical
+`media-proxy` image.
+
+| Project | Before | After |
+|---|---|---|
+| Quine | `SyntaxError`, blank | 12,447 SVG shapes |
+| send/receive | `SyntaxError`, blank | 3 canvases painting |
+| SpiroFlakes | `SyntaxError`, blank | canvas painting |
+| Paramecircle | `SyntaxError`, blank | canvas painting |
+| Overture | `SyntaxError`, no canvas | Unity WebGL 1400×1400 |
+| PRELUDES | renders | unchanged (byte-identical) |
+| Crypt | renders | unchanged (byte-identical) |
+
+## Deployed addresses
+
+| Network | Proxy | ProxyAdmin | ProxyAdmin owner |
+|---|---|---|---|
+| mainnet | `0x953D288708bB771F969FCfD9BA0819eF506Ac718` | `0x5705023921B577e5BAeFF66f1fC7d52f5ccF1232` | `0x52119BB73Ac8bdbE59aF0EEdFd4E4Ee6887Ed2EA` (Safe) |
+| sepolia staging | `0xdC862938cA0a2D8dcabe5733C23e54ac7aAFFF27` | `0xb71b829185159AB5B26D7F0BB7f991D0E17d5a7a` | — |
+| sepolia dev | `0x705E55FCD5CB00eB727213aa777C914B814817Be` | `0xb71b829185159AB5B26D7F0BB7f991D0E17d5a7a` | deployer |
+
+## Upgrade procedure
+
+### 1. Sepolia dev (rehearsal)
+
+Deploys the implementation and switches the proxy in one step, since the deployer controls that
+ProxyAdmin.
+
+```bash
+cd packages/contracts
+yarn hardhat run --network sepolia scripts/one-off/upgrade-dev-generator.ts
+```
+
+### 2. Sepolia staging
+
+```bash
+yarn hardhat run --network sepolia scripts/on-chain-generator/2_reference_upgrade-sepolia-on-chain-generator.ts
+```
+
+### 3. Mainnet
+
+`prepareUpgrade` only — it deploys and verifies the new implementation but does **not** switch the
+proxy. OpenZeppelin runs storage-layout validation here; it must pass before proceeding.
+
+```bash
+yarn hardhat run --network mainnet scripts/on-chain-generator/2_reference_upgrade-mainnet-on-chain-generator.ts
+```
+
+Then, from the Safe `0x52119BB73Ac8bdbE59aF0EEdFd4E4Ee6887Ed2EA`, call on ProxyAdmin
+`0x5705023921B577e5BAeFF66f1fC7d52f5ccF1232`:
+
+```
+upgrade(
+  proxy:          0x953D288708bB771F969FCfD9BA0819eF506Ac718,
+  implementation: <address printed by the script>
+)
+```
+
+### 4. Post-upgrade verification
+
+For each of the five projects above, confirm `getTokenHtml` no longer contains
+`<script>` + projectScript + `</script>`, and spot-check a token in the on-chain generator viewer.
+Then confirm a control project (e.g. PRELUDES `0xea698596b6009a622c3ed00dd5a8b5d1cae4fc36`, token
+`5000000`) is unchanged.
+
+## Notes
+
+- Running the fork test requires `MAINNET_JSON_RPC_PROVIDER_URL` in `packages/contracts/.env`. It
+  pins a block, so refresh `FORK_BLOCK_NUMBER` if core contracts or project scripts change.
+- The fork test raises the `eth_call` gas limit; send/receive assembles ~700 KB of HTML and exceeds
+  hardhat's default cap. This affects only the test harness, not the contract.
+- Two Arbitrum projects (`0x47a91457a3a1f700097199fd63c039c4784384ab` projects 27 and 39) also store
+  HTML while declaring `three@0.124.0` / `p5@1.0.0`. No generator is deployed on Arbitrum, so they
+  are out of scope. If a generator ships there, they will need a dependency override to `custom@na`
+  (or an explicit per-project mechanism), since script type alone will not identify them.

--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -167,6 +167,7 @@ module.exports = {
       "GenArt721CoreV3_Curated_Flex$",
       "GenArt721CoreV3_Engine$",
       "GenArt721CoreV3_Engine_Flex$",
+      "GenArt721GeneratorV0$",
       "MinterRAM.*",
     ],
   },

--- a/packages/contracts/scripts/one-off/upgrade-dev-generator.ts
+++ b/packages/contracts/scripts/one-off/upgrade-dev-generator.ts
@@ -3,7 +3,7 @@
 
 import hre, { ethers, upgrades } from "hardhat";
 import { GenArt721GeneratorV0 } from "../contracts";
-import { GenArt721GeneratorV0__factory } from "../contracts/factories/generator/GenArt721GeneratorV0__factory";
+import { GenArt721GeneratorV0__factory } from "../contracts/factories/contracts/generator/GenArt721GeneratorV0.sol/GenArt721GeneratorV0__factory";
 import { getNetworkName } from "../util/utils";
 
 const universalBytecodeStorageReaderAddress =

--- a/packages/contracts/test/generator/GenArt721GeneratorV0.test.ts
+++ b/packages/contracts/test/generator/GenArt721GeneratorV0.test.ts
@@ -90,6 +90,9 @@ describe(`GenArt721GeneratorV0`, async function () {
   const jsNameAndVersion = "js@na";
   const jsNameAndVersionBytes =
     ethers.utils.formatBytes32String(jsNameAndVersion);
+  const customNameAndVersion = "custom@na";
+  const customNameAndVersionBytes =
+    ethers.utils.formatBytes32String(customNameAndVersion);
   const mitLicenseType = "MIT";
   const mitLicenseTypeBytes = ethers.utils.formatBytes32String(mitLicenseType);
   const naLicenseType = "NA";
@@ -163,6 +166,15 @@ describe(`GenArt721GeneratorV0`, async function () {
     // Add js to registry
     await config.dependencyRegistry.addDependency(
       jsNameAndVersionBytes,
+      naLicenseTypeBytes,
+      "",
+      "",
+      ""
+    );
+
+    // Add custom to registry
+    await config.dependencyRegistry.addDependency(
+      customNameAndVersionBytes,
       naLicenseTypeBytes,
       "",
       "",
@@ -1002,6 +1014,163 @@ describe(`GenArt721GeneratorV0`, async function () {
         expect(tokenHtml3).to.include(
           '"externalAssetDependencies":[{"dependency_type":"ONCHAIN","cid":"","data":"#web3call#eyJjR0Z5WVcweCI6IlhVaGhibVJzWlNCVWFHbHpJSHRiTENjaVFDTWtRQ01sUUNNa0pTTWxKQ1U9In0="}]'
         );
+      });
+    });
+
+    describe("custom@na raw HTML injection", function () {
+      // @dev mirrors the shape of real custom@na projects (e.g. Quine, send/receive):
+      // a complete HTML document that itself contains "</script>"
+      const rawHtmlProjectScript = [
+        "<!DOCTYPE html>",
+        "<html><head><style>body{background:#000}</style></head><body>",
+        "<script>const early = tokenData.hash;</script>",
+        "<script>console.log(early);</script>",
+        "</body></html>",
+      ].join("\n");
+
+      // Deploys a V3 core with a single project whose script/type are configurable,
+      // mints token 0, and returns the generator's HTML for it.
+      async function setupProjectAndGetHtml(
+        config: GenArt721GeneratorV0TestConfig,
+        projectScript: string,
+        scriptTypeBytes: string
+      ) {
+        const { genArt721Core: genArt721CoreV3, minterFilter } =
+          await deployCoreWithMinterFilter(
+            config,
+            "GenArt721CoreV3",
+            "MinterFilterV1"
+          );
+
+        const minter = (await deployAndGet(config, "MinterSetPriceV2", [
+          genArt721CoreV3.address,
+          minterFilter.address,
+        ])) as MinterSetPriceV2;
+        await minterFilter
+          .connect(config.accounts.deployer)
+          .addApprovedMinter(minter.address);
+
+        const projectId = await genArt721CoreV3.nextProjectId();
+        await genArt721CoreV3
+          .connect(config.accounts.deployer)
+          .addProject("name", config.accounts.artist.address);
+        await genArt721CoreV3
+          .connect(config.accounts.artist)
+          .addProjectScript(projectId, projectScript);
+        await genArt721CoreV3
+          .connect(config.accounts.artist)
+          .updateProjectScriptType(projectId, scriptTypeBytes);
+
+        await minterFilter
+          .connect(config.accounts.artist)
+          .setMinterForProject(projectId, minter.address);
+        await minter
+          .connect(config.accounts.artist)
+          .updatePricePerTokenInWei(projectId, 0);
+        await minter.connect(config.accounts.artist).purchase(projectId);
+
+        const tokenId = projectId.mul(ONE_MILLION);
+        await config.coreRegistry
+          ?.connect(config.accounts.deployer)
+          .registerContract(
+            genArt721CoreV3.address,
+            ethers.utils.formatBytes32String("DUMMY_VERSION"),
+            ethers.utils.formatBytes32String("DUMMY_TYPE")
+          );
+
+        return {
+          tokenHtml: await config.genArt721Generator.getTokenHtml(
+            genArt721CoreV3.address,
+            tokenId
+          ),
+          genArt721CoreV3,
+          tokenId,
+        };
+      }
+
+      it("injects the project script verbatim, without a wrapping script tag", async function () {
+        const config = await loadFixture(_beforeEach);
+        const { tokenHtml } = await setupProjectAndGetHtml(
+          config,
+          rawHtmlProjectScript,
+          customNameAndVersionBytes
+        );
+
+        // the document is present byte-for-byte, and is NOT wrapped in a script tag
+        expect(tokenHtml).to.include(rawHtmlProjectScript);
+        expect(tokenHtml).to.not.include(getScriptTag(rawHtmlProjectScript));
+        // the project's own script tags survive as real, parseable tags
+        expect(tokenHtml).to.include(
+          "<script>const early = tokenData.hash;</script>"
+        );
+        // the document is the final element of the body, immediately before </body>
+        expect(tokenHtml).to.include(`${rawHtmlProjectScript}</body></html>`);
+      });
+
+      it("omits the default style reset for raw HTML documents", async function () {
+        const config = await loadFixture(_beforeEach);
+        const { tokenHtml } = await setupProjectAndGetHtml(
+          config,
+          rawHtmlProjectScript,
+          customNameAndVersionBytes
+        );
+
+        expect(tokenHtml).to.not.include(STYLE_TAG);
+        // the generator contributes no styling of its own; the only <style> in the
+        // output is the one belonging to the project's own document
+        const generatorEmitted = tokenHtml.slice(
+          0,
+          tokenHtml.indexOf(rawHtmlProjectScript)
+        );
+        expect(generatorEmitted).to.not.include("<style>");
+      });
+
+      it("still injects tokenData so the raw document can consume it", async function () {
+        const config = await loadFixture(_beforeEach);
+        const { tokenHtml, genArt721CoreV3, tokenId } =
+          await setupProjectAndGetHtml(
+            config,
+            rawHtmlProjectScript,
+            customNameAndVersionBytes
+          );
+
+        const hash = await genArt721CoreV3.tokenIdToHash(tokenId);
+        expect(tokenHtml).to.include(
+          getScriptTag(
+            `let tokenData = JSON.parse(\`{"tokenId":"${tokenId}","hash":"${hash}"}\`, ${REVIVER_SCRIPT};`
+          )
+        );
+        // tokenData must be defined before the raw document runs
+        expect(tokenHtml.indexOf("let tokenData")).to.be.lessThan(
+          tokenHtml.indexOf(rawHtmlProjectScript)
+        );
+      });
+
+      it("does not add a canvas tag for custom@na", async function () {
+        const config = await loadFixture(_beforeEach);
+        const { tokenHtml } = await setupProjectAndGetHtml(
+          config,
+          rawHtmlProjectScript,
+          customNameAndVersionBytes
+        );
+
+        expect(tokenHtml).to.not.include("<canvas id=");
+      });
+
+      it("leaves non-custom@na dependencies wrapped and unescaped", async function () {
+        const config = await loadFixture(_beforeEach);
+        // @dev some live projects (e.g. PRELUDES, Crypt) deliberately close the
+        // wrapping script tag to append their own markup, and must keep working
+        const breakoutScript =
+          "let a = 1;</script><style>body{margin:0}</style><body><canvas></canvas>";
+        const { tokenHtml } = await setupProjectAndGetHtml(
+          config,
+          breakoutScript,
+          p5NameAndVersionBytes
+        );
+
+        expect(tokenHtml).to.include(getScriptTag(breakoutScript));
+        expect(tokenHtml).to.include(STYLE_TAG);
       });
     });
   });

--- a/packages/contracts/test/network-fork/generator/GenArt721GeneratorV0.fork.test.ts
+++ b/packages/contracts/test/network-fork/generator/GenArt721GeneratorV0.fork.test.ts
@@ -1,0 +1,232 @@
+import helpers = require("@nomicfoundation/hardhat-network-helpers");
+import { expect } from "chai";
+import { ethers, upgrades } from "hardhat";
+
+/**
+ * Fork regression test for the on-chain generator's handling of "custom@na" projects.
+ *
+ * Projects declaring "custom@na" store a complete HTML document as their project
+ * script. The pre-upgrade generator wrapped that document in a <script> tag, which
+ * both broke HTML parsing (the document's own "</script>" closed the wrapper early)
+ * and prevented the markup from rendering at all.
+ *
+ * This suite upgrades the real mainnet proxy on a fork and asserts that:
+ *  - every "custom@na" project is now injected verbatim, and
+ *  - every other project's HTML is byte-identical to what it was before the upgrade.
+ */
+const FORK_URL = process.env.MAINNET_JSON_RPC_PROVIDER_URL;
+// @dev must be after Quine's Oct 2025 launch, and after every core contract under
+// test was registered with the DependencyRegistry
+const FORK_BLOCK_NUMBER = 25691272;
+
+const GENERATOR_PROXY = "0x953D288708bB771F969FCfD9BA0819eF506Ac718";
+const PROXY_ADMIN = "0x5705023921B577e5BAeFF66f1fC7d52f5ccF1232";
+const PROXY_ADMIN_OWNER = "0x52119BB73Ac8bdbE59aF0EEdFd4E4Ee6887Ed2EA";
+
+// Every "custom@na" project on mainnet. Each stores a full HTML document.
+const CUSTOM_NA_PROJECTS = [
+  {
+    name: "Quine",
+    core: "0xab00000000002ade39f58f9d8278a31574ffbe77",
+    projectId: 506,
+    tokenId: 506000239,
+  },
+  {
+    name: "send/receive",
+    core: "0xababababab20053426ad1c782de9ea8444358070",
+    projectId: 5,
+    tokenId: 5000000,
+  },
+  {
+    name: "SpiroFlakes",
+    core: "0xa7d8d9ef8d8ce8992df33d8b8cf4aebabd5bd270",
+    projectId: 136,
+    tokenId: 136000000,
+  },
+  {
+    name: "Paramecircle",
+    core: "0xa7d8d9ef8d8ce8992df33d8b8cf4aebabd5bd270",
+    projectId: 195,
+    tokenId: 195000000,
+  },
+  {
+    name: "Overture",
+    core: "0x000000dab303a194b3f55d4702b24740ad5a2f00",
+    projectId: 0,
+    tokenId: 0,
+  },
+];
+
+// Projects that must be completely unaffected. PRELUDES and Crypt are the important
+// ones: they are JavaScript that deliberately emits "</script>" to close the wrapper
+// and append its own markup, so they depend on the wrapped path staying byte-identical.
+const UNAFFECTED_PROJECTS = [
+  {
+    name: "PRELUDES",
+    core: "0xea698596b6009a622c3ed00dd5a8b5d1cae4fc36",
+    projectId: 5,
+    tokenId: 5000000,
+  },
+  {
+    name: "Crypt",
+    core: "0x99a9b7c1116f9ceeb1652de04d5969cce509b069",
+    projectId: 453,
+    tokenId: 453000000,
+  },
+  {
+    name: "Gas Wars",
+    core: "0xab00000000002ade39f58f9d8278a31574ffbe77",
+    projectId: 505,
+    tokenId: 505000001,
+  },
+];
+
+const STYLE_TAG =
+  "<style>html{height:100%}body{min-height:100%;margin:0;padding:0}canvas{padding:0;margin:auto;display:block;position:absolute;top:0;bottom:0;left:0;right:0}</style>";
+
+// @dev send/receive assembles ~700KB of HTML, which exceeds hardhat's default
+// eth_call gas cap; these are view calls, so the limit is free to raise
+const CALL_OVERRIDES = { gasLimit: 500_000_000 };
+
+describe("GenArt721GeneratorV0 custom@na fork regression", function () {
+  // forking + a full upgrade is slow relative to the default mocha timeout
+  this.timeout(600_000);
+
+  let generator: any;
+  const htmlBefore: Record<string, string> = {};
+  const scripts: Record<string, string> = {};
+
+  before(async function () {
+    await helpers.reset(FORK_URL, FORK_BLOCK_NUMBER);
+    generator = await ethers.getContractAt(
+      "GenArt721GeneratorV0",
+      GENERATOR_PROXY
+    );
+
+    // capture pre-upgrade output for every project under test
+    for (const p of [...CUSTOM_NA_PROJECTS, ...UNAFFECTED_PROJECTS]) {
+      htmlBefore[p.name] = await generator.getTokenHtml(
+        p.core,
+        p.tokenId,
+        CALL_OVERRIDES
+      );
+      scripts[p.name] = await generator.getProjectScript(
+        p.core,
+        p.projectId,
+        CALL_OVERRIDES
+      );
+    }
+
+    // upgrade the real proxy to the new implementation
+    const factory = await ethers.getContractFactory("GenArt721GeneratorV0");
+    const newImplementation = await upgrades.prepareUpgrade(
+      GENERATOR_PROXY,
+      factory
+    );
+    const proxyAdmin = await ethers.getContractAt(
+      ["function upgrade(address proxy, address implementation) external"],
+      PROXY_ADMIN
+    );
+    await helpers.setBalance(PROXY_ADMIN_OWNER, ethers.utils.parseEther("10"));
+    const owner = await ethers.getImpersonatedSigner(PROXY_ADMIN_OWNER);
+    await proxyAdmin
+      .connect(owner)
+      .upgrade(GENERATOR_PROXY, newImplementation as string);
+  });
+
+  after(async function () {
+    await helpers.reset();
+  });
+
+  describe("custom@na projects", function () {
+    for (const p of CUSTOM_NA_PROJECTS) {
+      describe(p.name, function () {
+        it("was broken before the upgrade (script wrapped in a script tag)", async function () {
+          expect(htmlBefore[p.name]).to.include(
+            `<script>${scripts[p.name]}</script>`
+          );
+        });
+
+        it("contains a literal </script> that would break the wrapper", async function () {
+          expect(scripts[p.name]).to.include("</script>");
+        });
+
+        it("stores markup rather than JavaScript", async function () {
+          expect(scripts[p.name].trimStart().startsWith("<")).to.equal(true);
+        });
+
+        it("is injected verbatim after the upgrade", async function () {
+          const html = await generator.getTokenHtml(
+            p.core,
+            p.tokenId,
+            CALL_OVERRIDES
+          );
+          expect(html).to.include(scripts[p.name]);
+          expect(html).to.not.include(`<script>${scripts[p.name]}</script>`);
+          // the document is the last thing in the body
+          expect(html).to.include(`${scripts[p.name]}</body></html>`);
+        });
+
+        it("no longer emits the generator's default style reset", async function () {
+          const html = await generator.getTokenHtml(
+            p.core,
+            p.tokenId,
+            CALL_OVERRIDES
+          );
+          expect(html).to.not.include(STYLE_TAG);
+        });
+
+        it("still injects tokenData before the document", async function () {
+          const html = await generator.getTokenHtml(
+            p.core,
+            p.tokenId,
+            CALL_OVERRIDES
+          );
+          expect(html).to.include("let tokenData = JSON.parse(`");
+          expect(html.indexOf("let tokenData")).to.be.lessThan(
+            html.indexOf(scripts[p.name])
+          );
+        });
+
+        it("keeps the base64 data URI consistent with the raw HTML", async function () {
+          const html = await generator.getTokenHtml(
+            p.core,
+            p.tokenId,
+            CALL_OVERRIDES
+          );
+          const encoded = await generator.getTokenHtmlBase64EncodedDataUri(
+            p.core,
+            p.tokenId,
+            CALL_OVERRIDES
+          );
+          expect(encoded).to.equal(
+            `data:text/html;base64,${Buffer.from(html).toString("base64")}`
+          );
+        });
+      });
+    }
+  });
+
+  describe("unaffected projects", function () {
+    for (const p of UNAFFECTED_PROJECTS) {
+      it(`${p.name} output is byte-identical after the upgrade`, async function () {
+        const html = await generator.getTokenHtml(
+          p.core,
+          p.tokenId,
+          CALL_OVERRIDES
+        );
+        expect(html).to.equal(htmlBefore[p.name]);
+      });
+    }
+
+    it("PRELUDES still closes the wrapper itself (breakout preserved)", async function () {
+      const html = await generator.getTokenHtml(
+        UNAFFECTED_PROJECTS[0].core,
+        UNAFFECTED_PROJECTS[0].tokenId,
+        CALL_OVERRIDES
+      );
+      expect(html).to.include(`<script>${scripts["PRELUDES"]}</script>`);
+      expect(scripts["PRELUDES"]).to.include("</script>");
+    });
+  });
+});

--- a/packages/contracts/test/network-fork/generator/GenArt721GeneratorV0.fork.test.ts
+++ b/packages/contracts/test/network-fork/generator/GenArt721GeneratorV0.fork.test.ts
@@ -88,7 +88,9 @@ const STYLE_TAG =
 // eth_call gas cap; these are view calls, so the limit is free to raise
 const CALL_OVERRIDES = { gasLimit: 500_000_000 };
 
-describe("GenArt721GeneratorV0 custom@na fork regression", function () {
+// @dev skipped under coverage: instrumented bytecode plus send/receive's ~700KB of
+// assembled HTML exhausts the coverage runner's memory (CircleCI exit code 129).
+describe("GenArt721GeneratorV0 custom@na fork regression [ @skip-on-coverage ]", function () {
   // forking + a full upgrade is slow relative to the default mocha timeout
   this.timeout(600_000);
 


### PR DESCRIPTION
## Description of the change

Update on-chain generator for custom html projects.

Updates on-chain generator with proper formatting for custom@na legacy projects.

Includes runbook for deployment and upgrade.

- [x] approve pr
- [x] deploy implementations (all networks)
- [x] upgrade testnet - verify project behaviors
- [x] upgrade mainnet